### PR TITLE
Initial parachute-patterns seed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# CLAUDE.md — parachute-patterns
+
+This repo is **documentation**, not code. When you work here you are curating
+conventions that every other Parachute repo points at.
+
+## Rules
+
+- **No code.** No `package.json`, no build step, no lint config beyond
+  markdown. If you feel the urge to add tooling, stop and ask.
+- **One pattern per file.** If a file starts growing two ideas, split it.
+- **Short beats complete.** One screen per file. Link to upstream source
+  rather than duplicating it. An out-of-date duplicate is worse than a link.
+- **Document what's real.** Don't invent conventions we haven't established.
+  For anything uncertain, mark `[DRAFT]` at the top and note the open
+  question. Remove the marker once the first two modules conform.
+- **When a pattern changes**, update the file *and* file an issue against any
+  Parachute repo that needs to follow, *and* add an entry to
+  `adoption/migration-notes.md` with the date, the change, and the affected
+  repos.
+
+## Shape of a good pattern file
+
+1. One-line summary at the top.
+2. The convention itself (TL;DR).
+3. Why — the constraint or lesson that produced it.
+4. Examples — link to specific files in upstream repos.
+5. Open questions / drafts at the bottom if any.
+
+## Scope
+
+- **In scope:** naming, modularity principle, brand tokens, shared schemas,
+  cross-cutting patterns (auth, transport, report contract, loader shapes),
+  adoption guidance.
+- **Out of scope:** per-module architecture, runtime code, anything that
+  belongs inside a single repo's own docs.
+
+## Working conventions
+
+- Feature branches. PR to `main`. No direct commits to `main`.
+- Every PR that changes an established pattern should reference the sibling
+  repo(s) that will need to follow.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# parachute-patterns
+
+Shared conventions across the Parachute ecosystem — the single source of truth
+for how Parachute modules align with their siblings.
+
+Parachute is intentionally a set of small pieces, loosely joined: Vault, Daily,
+Scribe, Narrate, Channel, Agents, Cloud, Octopus, the `parachute` CLI. Every
+module stands alone; composition is opt-in. That modularity only holds together
+if the surfaces they share — naming, brand, schemas, auth, reporting shapes —
+stay coherent. This repo is where those surfaces are written down.
+
+## Who this is for
+
+- **Humans** starting a new Parachute module, or adopting a pattern into an
+  existing one.
+- **Tentacles** (Uni facets, see [UnforcedAGI](https://github.com/ParachuteComputer/UnforcedAGI))
+  working inside a Parachute repo.
+- **Future Parachute modules** — when we invent the fifth, sixth, tenth thing,
+  it should feel like a Parachute thing.
+
+## For tentacles working in a Parachute repo
+
+Before you ship code that crosses a naming, brand, schema, or pattern
+boundary, check the relevant file here. If the convention is wrong, propose a
+change in this repo first. Every Parachute module should be able to point at a
+single source of truth for how it aligns with its siblings.
+
+## Layout
+
+```
+naming/       package names, bin names, repo names
+modularity/   the standalone-first principle, with worked examples
+brand/        palette, typography, motifs, canonical tokens.css
+schemas/      agent markdown, vault note metadata, lint rules
+patterns/     loadX sources, report contract, token auth, MCP transport, dev-auto-user
+adoption/     checklist for new modules, migration notes log
+```
+
+Each file is short on purpose — one screen, one pattern. When examples are
+needed, link to the upstream repo rather than duplicating code here.
+
+## Contributing
+
+- Open a PR with the change. If the pattern is new (not documented before),
+  include a one-paragraph rationale. If the pattern is changing, log the
+  change in `adoption/migration-notes.md` with the date and the repos that
+  need to follow.
+- `[DRAFT]` means the pattern is proposed but not yet adopted across the
+  ecosystem. Remove the marker once the first two modules conform.
+- Keep tone warm, precise, not precious.
+
+## Where this sits in the stack
+
+parachute-patterns is documentation only — no code, no build, no runtime
+dependency. Every other Parachute repo may reference it, but none import from
+it. The repo is the contract, not the implementation.
+
+License: AGPL-3.0 (matching the family).

--- a/adoption/checklist.md
+++ b/adoption/checklist.md
@@ -1,0 +1,62 @@
+# Adoption checklist — new Parachute module
+
+When you create a new module in the Parachute family, run through this
+list. Every item points at the canonical pattern file.
+
+## Naming
+
+- [ ] Repo lives under `ParachuteComputer/parachute-<module>` (`naming/repos.md`).
+- [ ] npm package is `@openparachute/<module>` (`naming/packages.md`).
+- [ ] Primary bin is `parachute-<module>` (`naming/bins.md`).
+- [ ] Extra bins, if any, are `parachute-<module>-<role>`.
+- [ ] `package.json` `bin` field declared up front, even if unpublished.
+
+## License + meta
+
+- [ ] AGPL-3.0 LICENSE in repo root.
+- [ ] README links back to `parachute-patterns` at the top:
+  > Parachute conventions live in [parachute-patterns](https://github.com/ParachuteComputer/parachute-patterns).
+- [ ] `CLAUDE.md` if the repo will be worked on by tentacles — point at
+  upstream conventions, keep repo-specific rules short.
+
+## Modularity
+
+- [ ] The module works standalone — no sibling Parachute module is *required*
+  to boot.
+- [ ] Each opt-in integration with a sibling is a config flag or plugin,
+  not a build-time import (`modularity/principle.md`).
+- [ ] Missing optional integrations degrade gracefully (log, don't crash).
+
+## Brand (if the module has UI)
+
+- [ ] Uses the Parachute palette — either import `brand/tokens.css` (web) or
+  port from Daily's `design_tokens.dart` (mobile/desktop).
+- [ ] Soft radii, warm shadows, settling motion (`brand/motifs.md`).
+- [ ] Uses the Parachute font families where customizable.
+
+## Schemas
+
+- [ ] If the module authors agent markdown, it parses against the canonical
+  schema (`schemas/agent-markdown.md`).
+- [ ] Notes written to the vault carry `metadata.summary` and use full-path
+  wikilinks (`schemas/vault-note.md`).
+
+## Patterns (apply if relevant)
+
+- [ ] Lists loaded from multiple sources use the `loadX` tagged-union shape
+  (`patterns/loadAgents.md`).
+- [ ] Reports/handoffs back to a parent agent follow the report contract
+  (`patterns/report-contract.md`).
+- [ ] Issued tokens use the `pvt_` prefix, sha256 storage, scope, cookie
+  reveal (`patterns/token-auth.md`).
+- [ ] MCP transport is Streamable HTTP at `/mcp`, bearer or OAuth client
+  credentials (`patterns/mcp-transport.md`).
+- [ ] Dev-mode auth shortcut (if any) gated on `PARACHUTE_DEV_AUTO_USER`
+  (`patterns/dev-auto-user.md`).
+
+## After
+
+- [ ] If your module introduces a pattern the ecosystem should follow, PR it
+  into this repo **before** rolling it out to siblings.
+- [ ] Log any deviation from a canonical pattern in
+  `adoption/migration-notes.md` with the reason.

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -1,0 +1,53 @@
+# Migration notes
+
+Running log of pattern changes and the repos that need to follow. Newest
+entries on top. Each entry: date, change, affected repos, status.
+
+---
+
+## 2026-04-15 — `parachute-*` bin naming
+
+**Change:** all Parachute executables adopt the `parachute-<module>` prefix
+(see `naming/bins.md`). The umbrella `parachute` bin is reserved for
+`@openparachute/cli`.
+
+**Affected:**
+
+- `parachute-vault` — currently ships `parachute`; **rename to
+  `parachute-vault`** (pending). Blocks umbrella dispatch.
+- `parachute-scribe` — ships `scribe`; rename to `parachute-scribe`.
+- `parachute-narrate` — ships `narrate`; rename to `parachute-narrate`.
+- `parachute-channel` — conformant (`parachute-channel`, `parachute-channel-bridge`).
+- `parachute-agents` — conformant (`parachute-agent`, `parachute-agent-ui`).
+- `tailshare` — exempt; not a Parachute-branded tool.
+
+**Status:** [DRAFT] — renames not yet executed. File per-repo issues to
+track each rename.
+
+---
+
+## 2026-04-15 — parachute-patterns repo created
+
+**Change:** this repo exists. Conventions that were implicit across the
+ecosystem (naming, brand palette, agent schema, modularity principle, etc.)
+are now written down.
+
+**Affected:** every Parachute repo eventually needs a README link back to
+this repo (`adoption/checklist.md`). Non-urgent — add as repos get touched.
+
+**Status:** in progress.
+
+---
+
+## Template
+
+```
+## YYYY-MM-DD — <one-line change>
+
+**Change:** what changed and why. Link to the pattern file.
+
+**Affected:** which repos need to follow and what specifically each needs
+to do.
+
+**Status:** DRAFT | in progress | complete.
+```

--- a/brand/motifs.md
+++ b/brand/motifs.md
@@ -1,0 +1,38 @@
+# Motifs
+
+## [DRAFT]
+
+Parachute's visual vocabulary beyond color. What a "Parachute thing" looks
+and feels like, regardless of medium.
+
+## Principles
+
+- **Settling, not snapping.** Motion feels like a deep breath. Standard
+  transitions are 250ms with `easeOutCubic`; ambient animations can run 4s
+  with `easeInOut` ("breathing"). Source:
+  [design_tokens.dart `Motion`](https://github.com/ParachuteComputer/parachute-daily/blob/main/lib/core/theme/design_tokens.dart).
+- **Pebbles, leaves, water ripples.** Corners are soft. Default card radius
+  is 16px; buttons 12px; badges 8px; pills full. No hard right-angle card
+  chrome.
+- **Subtle depth.** Shadows are warm-tinted (charcoal at 4–10% alpha, small
+  blur, small offset). No harsh elevation.
+- **Breathing room.** Spacing leans generous. Default page padding 16px,
+  section dividers 24–32px.
+
+## Known motifs in flight
+
+- **Silk-drift** — the ambient animation used on parachute.computer hero
+  treatments. Canonical implementation lives in the
+  [parachute.computer](https://github.com/ParachuteComputer/parachute.computer)
+  repo. No pattern file yet — pin the component once we use it twice.
+- **Octopus glyph** — used by UnforcedAGI / Octopus. Source-of-truth asset
+  path TBD.
+- **Card treatments** — cream surface, subtle warm shadow, generous interior
+  padding (16px), soft radius. Used in Daily, octopus-ui.
+
+## Open questions
+
+- Publish the silk-drift component (React + CSS, or web-component) so other
+  web properties can reuse it without copy-paste.
+- Canonical SVG assets folder — where do Parachute glyphs live? Probably a
+  branded `brand/assets/` directory here, once we have them committed.

--- a/brand/palette.md
+++ b/brand/palette.md
@@ -1,0 +1,69 @@
+# Brand palette
+
+Canonical source:
+[parachute-daily/lib/core/theme/design_tokens.dart](https://github.com/ParachuteComputer/parachute-daily/blob/main/lib/core/theme/design_tokens.dart).
+That's the Dart/Flutter authority. `brand/tokens.css` in this repo is the
+ported CSS custom-property version for web apps. Keep them in sync — any
+palette change lands in Daily first, then gets ported here.
+
+## Keywords
+
+Smoothness, balance, growth, connected, in tune with nature. "Think
+naturally" — technology that gives you space rather than demands attention.
+
+## Primary — Forest Green (grounded, natural, trustworthy)
+
+| Token | Hex | Use |
+|---|---|---|
+| `forest` | `#40695B` | primary actions, brand presence |
+| `forestLight` | `#5A8577` | backgrounds, containers |
+| `forestMist` | `#D4E5DF` | subtle backgrounds |
+| `forestDeep` | `#2D4A40` | emphasis |
+
+## Secondary — Turquoise (flow, clarity, breath)
+
+| Token | Hex | Use |
+|---|---|---|
+| `turquoise` | `#5EA8A7` | secondary actions, links, accents |
+| `turquoiseLight` | `#7FBFBE` | lighter variant |
+| `turquoiseMist` | `#D5ECEB` | backgrounds |
+| `turquoiseDeep` | `#3D8584` | emphasis |
+
+## Neutrals — warm, soft tones
+
+| Token | Hex | Use |
+|---|---|---|
+| `cream` | `#FAF9F7` | page backgrounds (not clinical white) |
+| `softWhite` | `#FFFEFC` | surfaces with warmth |
+| `stone` | `#E8E6E3` | light warm gray |
+| `driftwood` | `#9B9590` | secondary text |
+| `charcoal` | `#3D3A37` | primary text |
+| `ink` | `#1F1D1B` | high-contrast text |
+
+## Semantic — gentle, not alarming
+
+| Token | Hex | Use |
+|---|---|---|
+| `success` / `successLight` | `#6B9B7A` / `#E3F0E7` | soft sage, not harsh |
+| `warning` / `warningLight` | `#D4A056` / `#FFF3E0` | warm amber, inviting |
+| `error` / `errorLight` | `#B86B5A` / `#FBEAE6` | soft terracotta — serious, not aggressive |
+| `info` / `infoLight` | `#6B8BA8` / `#E6EEF4` | muted blue-gray |
+
+## Dark mode
+
+| Token | Hex | Use |
+|---|---|---|
+| `nightSurface` | `#1A1917` | base surface (deep warm dark, not pure black) |
+| `nightSurfaceElevated` | `#262523` | elevated surface |
+| `nightForest` | `#7AB09D` | primary (lighter for visibility) |
+| `nightTurquoise` | `#8CCFCE` | secondary |
+| `nightText` | `#E8E5E1` | primary text |
+| `nightTextSecondary` | `#A09B95` | secondary text |
+
+## Rules
+
+- Never use pure `#FFFFFF` or `#000000`. We use warm cream and warm ink.
+- Semantic colors are gentle on purpose — alarming red has no place in a
+  "think naturally" product.
+- If you need a hue we don't have, propose a new token in a PR against Daily
+  first, then port here.

--- a/brand/tokens.css
+++ b/brand/tokens.css
@@ -1,0 +1,139 @@
+/*
+ * Parachute brand tokens — canonical CSS custom properties.
+ *
+ * Ported from parachute-daily/lib/core/theme/design_tokens.dart. The Dart
+ * file is the source of truth; when you change palette values, update Daily
+ * first and then port the changes here.
+ *
+ * Usage: import this file (or copy into your app's global stylesheet) and
+ * reference vars as `var(--forest)`, `var(--radius-lg)`, etc. Dark mode is
+ * opt-in via `.dark` on a container or `[data-theme="dark"]`.
+ */
+
+:root {
+  /* ── Forest (primary) ─────────────────────────────────────────── */
+  --forest:         #40695B;
+  --forest-light:   #5A8577;
+  --forest-mist:    #D4E5DF;
+  --forest-deep:    #2D4A40;
+
+  /* ── Turquoise (secondary) ────────────────────────────────────── */
+  --turquoise:         #5EA8A7;
+  --turquoise-light:   #7FBFBE;
+  --turquoise-mist:    #D5ECEB;
+  --turquoise-deep:    #3D8584;
+
+  /* ── Neutrals (warm) ──────────────────────────────────────────── */
+  --cream:      #FAF9F7;
+  --soft-white: #FFFEFC;
+  --stone:      #E8E6E3;
+  --driftwood:  #9B9590;
+  --charcoal:   #3D3A37;
+  --ink:        #1F1D1B;
+
+  /* ── Semantic (gentle) ────────────────────────────────────────── */
+  --success:       #6B9B7A;
+  --success-light: #E3F0E7;
+  --warning:       #D4A056;
+  --warning-light: #FFF3E0;
+  --error:         #B86B5A;
+  --error-light:   #FBEAE6;
+  --info:          #6B8BA8;
+  --info-light:    #E6EEF4;
+
+  /* ── Surfaces ─────────────────────────────────────────────────── */
+  --surface:          var(--cream);
+  --surface-elevated: var(--soft-white);
+  --text-primary:     var(--charcoal);
+  --text-secondary:   var(--driftwood);
+  --text-strong:      var(--ink);
+
+  /* ── Spacing ──────────────────────────────────────────────────── */
+  --space-xxs:  2px;
+  --space-xs:   4px;
+  --space-sm:   8px;
+  --space-md:   12px;
+  --space-lg:   16px;
+  --space-xl:   24px;
+  --space-xxl:  32px;
+  --space-xxxl: 48px;
+
+  /* ── Radii (soft, pebble-like) ────────────────────────────────── */
+  --radius-sm:   8px;
+  --radius-md:   12px;
+  --radius-lg:   16px;
+  --radius-xl:   20px;
+  --radius-full: 999px;
+
+  /* ── Shadows (warm-tinted) ────────────────────────────────────── */
+  --shadow-card:
+    0 1px 4px rgba(61, 58, 55, 0.04),
+    0 2px 8px rgba(61, 58, 55, 0.06);
+  --shadow-elevated:
+    0 2px 6px rgba(61, 58, 55, 0.05),
+    0 4px 16px rgba(61, 58, 55, 0.10);
+
+  /* ── Motion (settling, not snapping) ──────────────────────────── */
+  --motion-quick:     150ms;
+  --motion-standard:  250ms;
+  --motion-gentle:    350ms;
+  --motion-slow:      500ms;
+  --motion-breathing: 4000ms;
+  --ease-settling: cubic-bezier(0.215, 0.61, 0.355, 1);   /* easeOutCubic */
+  --ease-lift:     cubic-bezier(0.165, 0.84, 0.44, 1);    /* easeOutQuart */
+  --ease-breathe:  cubic-bezier(0.42, 0, 0.58, 1);        /* easeInOut */
+
+  /* ── Typography (sizes in px) ─────────────────────────────────── */
+  --font-sans:  "Inter", system-ui, -apple-system, sans-serif;
+  --font-serif: "Fraunces", Georgia, serif;
+  --font-mono:  "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --text-display-lg: 48px;
+  --text-display-md: 36px;
+  --text-display-sm: 28px;
+  --text-headline-lg: 24px;
+  --text-headline-md: 20px;
+  --text-headline-sm: 18px;
+  --text-body-lg: 16px;
+  --text-body-md: 14px;
+  --text-body-sm: 13px;
+  --text-label-lg: 14px;
+  --text-label-md: 12px;
+  --text-label-sm: 11px;
+
+  --leading-tight:   1.2;
+  --leading-normal:  1.5;
+  --leading-relaxed: 1.7;
+}
+
+/* ── Dark mode ──────────────────────────────────────────────────── */
+.dark,
+[data-theme="dark"] {
+  --surface:          #1A1917;   /* nightSurface */
+  --surface-elevated: #262523;   /* nightSurfaceElevated */
+  --text-primary:     #E8E5E1;   /* nightText */
+  --text-secondary:   #A09B95;   /* nightTextSecondary */
+  --text-strong:      #FFFFFF;
+
+  --forest:    #7AB09D;          /* nightForest */
+  --turquoise: #8CCFCE;          /* nightTurquoise */
+
+  --shadow-card:
+    0 1px 4px rgba(0, 0, 0, 0.30),
+    0 2px 8px rgba(0, 0, 0, 0.24);
+  --shadow-elevated:
+    0 2px 6px rgba(0, 0, 0, 0.28),
+    0 4px 16px rgba(0, 0, 0, 0.40);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --surface:          #1A1917;
+    --surface-elevated: #262523;
+    --text-primary:     #E8E5E1;
+    --text-secondary:   #A09B95;
+    --text-strong:      #FFFFFF;
+    --forest:    #7AB09D;
+    --turquoise: #8CCFCE;
+  }
+}

--- a/brand/typography.md
+++ b/brand/typography.md
@@ -1,0 +1,55 @@
+# Typography
+
+## [DRAFT]
+
+The mobile app canonicalized sizes and weights in
+[design_tokens.dart](https://github.com/ParachuteComputer/parachute-daily/blob/main/lib/core/theme/design_tokens.dart).
+The web-side font family choices (Inter / Fraunces / JetBrains Mono) are
+used in practice across `octopus-ui` and `parachute.computer`, but haven't
+been pinned as a canonical stack here yet.
+
+## Sizes (from Daily)
+
+| Token | px |
+|---|---|
+| displayLarge | 48 |
+| displayMedium | 36 |
+| displaySmall | 28 |
+| headlineLarge | 24 |
+| headlineMedium | 20 |
+| headlineSmall | 18 |
+| titleLarge | 18 |
+| titleMedium | 16 |
+| titleSmall | 14 |
+| bodyLarge | 16 |
+| bodyMedium | 14 |
+| bodySmall | 13 |
+| labelLarge | 14 |
+| labelMedium | 12 |
+| labelSmall | 11 |
+
+## Line heights
+
+- `tight`: 1.2 (display, headlines)
+- `normal`: 1.5 (body default)
+- `relaxed`: 1.7 (long-form reading)
+
+## Letter spacing
+
+- `tight`: -0.5 (display)
+- `normal`: 0
+- `wide`: 0.5 (labels, uppercase)
+
+## Font families — proposed (not yet canonical)
+
+- **Sans / UI:** Inter
+- **Serif / long-form:** Fraunces
+- **Mono / code:** JetBrains Mono
+
+## Open questions
+
+- Lock the web font stack. Needs someone to audit existing web properties
+  (`octopus-ui`, `parachute.computer`, the parachute-cloud dashboard) and
+  reconcile.
+- Variable-font vs static cutoffs, fallback stacks, self-host vs CDN — all
+  unresolved. File an issue against this repo when the audit happens.

--- a/modularity/examples.md
+++ b/modularity/examples.md
@@ -1,0 +1,56 @@
+# Modularity in practice
+
+Three worked examples of sibling modules composing without coupling.
+
+## Scribe → Vault (proper nouns)
+
+**Standalone:** `parachute-scribe` takes audio or raw text and returns clean
+text. Works fully offline of the vault.
+
+**Opt-in composition:** when a vault is configured, Scribe pulls a
+proper-noun list from notes tagged `scribe/proper-noun` and biases the
+cleanup pass. Without a vault, the cleanup pass still runs — just without
+the custom vocabulary.
+
+**What makes this modular:** Scribe has a `ProperNounSource` interface with
+implementations for `file`, `inline`, and `vault`. The vault impl is one of
+three; none is privileged.
+
+## Agents → Vault (agent definitions)
+
+**Standalone:** `@openparachute/agent` loads agent markdown from a directory
+(`loadAgentsFromDir`). Deploy-time bundled or filesystem-watched.
+
+**Opt-in composition:** set `config.agents` to the result of
+`loadAgentsFromVault({ vault, tag: "agent-definition" })` and the same runner
+reads agents from vault notes instead. The parsed shape is identical — the
+source just differs.
+
+**What makes this modular:** the runner consumes a `Record<string, string>`
+map of `path → markdown`. Where that map came from is the caller's problem.
+See `patterns/loadAgents.md` for the shared source-tagged-union convention.
+
+## Octopus → Vault (future: team roster)
+
+**Standalone:** `octopus-ui` reads the live team from
+`~/.claude/teams/octopus/config.json`. No network. No vault.
+
+**Opt-in composition (planned):** with `OCTOPUS_CONFIG_SOURCE=vault`, the UI
+server reads the roster from a vault note tagged `octopus-config`. Enables
+driving octopus-ui from a tablet against a hosted vault.
+
+**What makes this modular:** the config source is an env-selected strategy.
+The default stays filesystem-local. Nothing in the UI assumes a vault exists.
+
+## What these share
+
+Each integration:
+
+1. Has a **standalone default** that works without the sibling.
+2. Exposes a **named strategy** (env var, config field, or plugin) that swaps
+   in the composed implementation.
+3. Uses a **stable data shape** at the boundary (a proper-noun list; an
+   agent-markdown map; a team roster) so either side can evolve the
+   internals without the other noticing.
+
+When you propose a new cross-module integration, check against those three.

--- a/modularity/principle.md
+++ b/modularity/principle.md
@@ -1,0 +1,55 @@
+# Modularity is the product
+
+## Convention
+
+**Every Parachute module stands alone. Composition is opt-in. No hidden
+coupling.**
+
+Concretely: a module must be useful installed by itself, with no other
+Parachute module present. If it *can* compose with a sibling, that
+composition is a config flag or plugin — never a build-time dependency,
+never a runtime requirement.
+
+## Why
+
+- Adoption path: a user or developer picks up one piece (say, the vault) and
+  gets real value without signing up for a platform.
+- Each module stays small and focused. The pressure to grow features lives
+  inside that module, not in a shared core.
+- The failure mode we're avoiding is "Parachute Suite" — a coupled monorepo
+  where every module imports the others, nothing can be adopted in isolation,
+  and a breaking change anywhere propagates everywhere. (See Emacs:
+  indispensable for some, unadoptable for most.)
+- The magic is cumulative: each added module makes the others more powerful
+  without any of them *requiring* the others.
+
+## Rules
+
+- **No `@openparachute/*` package may import from another at build time
+  unless it's genuinely a library layer** (e.g. a future `@openparachute/core`
+  providing vault types). Runtime integrations go through configured clients
+  or MCP.
+- **Every integration is a flag.** `config.agentSource = "dir" | "vault"`.
+  `config.backend = "vercel-ai" | "claude"`. `config.vault = { url, token }`
+  (absent → no vault features). Defaults must exercise the standalone path.
+- **Graceful absence.** When an optional integration is missing, the module
+  falls back to its standalone behavior and logs (not errors). Example:
+  `loadAgentsFromVault` returns `{}` with a warning when the vault is
+  unreachable so the runner still boots (see
+  [parachute-agents/src/agent-sources.ts](https://github.com/ParachuteComputer/parachute-agents/blob/main/src/agent-sources.ts)).
+- **Document the opt-in.** Each composable integration gets an entry in the
+  module's README *and* a `patterns/` entry here if the shape is reusable
+  across modules.
+
+## What this looks like in practice
+
+See `modularity/examples.md` for Scribe + vault, Agents + vault, Octopus +
+vault composed without coupling.
+
+## Open questions
+
+- A shared `@openparachute/vault-client` package would reduce duplication
+  across Agents, Daily, Prism. It would be a library (importable), not a
+  runtime dependency, so it doesn't violate the principle — but the
+  threshold for "this is worth extracting" isn't codified yet. Tracked in
+  parachute-vault issue #102.

--- a/naming/bins.md
+++ b/naming/bins.md
@@ -1,0 +1,58 @@
+# Bin names
+
+## Convention
+
+Every executable shipped by a Parachute package is named
+`parachute-<subcommand>` on PATH.
+
+The umbrella `parachute` command (from `@openparachute/cli`) discovers those
+bins by PATH scan and dispatches to them:
+
+```
+parachute <sub> [args...]   →  execs `parachute-<sub>` with the remaining args
+parachute                    →  lists discovered subcommands + descriptions
+```
+
+First match on PATH wins (same as shell lookup). This means `parachute vault
+...` works as soon as `@openparachute/vault` is installed anywhere on PATH,
+without the umbrella having to know about it at build time.
+
+See: [openparachute-cli/src/cli.ts](https://github.com/ParachuteComputer/openparachute-cli/blob/main/src/cli.ts).
+
+## Current bins (state of the world, 2026-04-15)
+
+| Package | Bin name | Status |
+|---|---|---|
+| `@openparachute/cli` | `parachute` | umbrella dispatcher |
+| `@openparachute/vault` | `parachute-vault` | **rename in flight** — currently ships `parachute` (collides with umbrella) |
+| `@openparachute/agent` | `parachute-agent`, `parachute-agent-ui` | conformant |
+| `parachute-channel` | `parachute-channel`, `parachute-channel-bridge` | conformant |
+| `parachute-scribe` | `scribe` | **non-conformant** — should become `parachute-scribe` |
+| `parachute-narrate` | `narrate` | **non-conformant** — should become `parachute-narrate` |
+| `tailshare` | `tailshare` | not a Parachute-branded tool; no rename planned |
+
+## Why
+
+- **PATH discovery is the composition point.** The umbrella never hard-codes
+  its subcommand list — install a new `parachute-<x>` bin anywhere on PATH
+  and it appears. That only works if everyone shares the prefix.
+- **Avoids collisions.** Short names like `scribe` and `narrate` collide with
+  common system or third-party binaries. The prefix is boring and safe.
+- **Discoverability.** Tab-completion on `parachute-` in any shell lists
+  every Parachute bin installed locally.
+
+## Rules
+
+- Primary bin: `parachute-<module>`.
+- Secondary bins (if a package ships more than one, e.g. a server + a UI):
+  `parachute-<module>-<role>`. Example: `parachute-agent-ui`.
+- No bare-word bins. A package that currently ships one is on the migration
+  list (see `adoption/migration-notes.md`).
+- The umbrella `parachute` bin is reserved for `@openparachute/cli`. Nothing
+  else may claim it. The vault rename unblocks this.
+
+## Open questions
+
+- Do we want a `parachute doctor` subcommand (shipped in the umbrella) that
+  lints PATH for bare-name or duplicate bins? Tracked informally until
+  someone hits a real collision.

--- a/naming/packages.md
+++ b/naming/packages.md
@@ -1,0 +1,39 @@
+# Package names
+
+## Convention
+
+All publishable Parachute packages live under the `@openparachute` npm scope.
+
+```
+@openparachute/<module>
+```
+
+Examples:
+
+- `@openparachute/vault` — parachute-vault
+- `@openparachute/agent` — parachute-agents (singular on the package side)
+- `@openparachute/cli` — the umbrella dispatcher
+- `@openparachute/scribe`, `@openparachute/narrate` — when/if published
+
+## Why
+
+- One scope means one audit surface and one set of owners on npm.
+- `openparachute` (not `parachute`) avoids collision with unrelated packages
+  that were already squatting on bare `parachute-*` names, while keeping
+  `parachute` available as a display word across the ecosystem.
+- Singular package names (`agent`, not `agents`) match the import shape
+  (`import { ... } from "@openparachute/agent"`). The repo can stay plural
+  where that reads better — see `naming/repos.md`.
+
+## Rules
+
+- Package name: **singular**, lowercase, no hyphens inside the module slug.
+- Scope: always `@openparachute`, never `@parachute`.
+- Bin names exposed by a package follow `naming/bins.md`, not the package
+  name. They are separate surfaces.
+- A package that isn't yet published still picks its name up front and
+  records it in `package.json` so cross-repo references don't churn.
+
+## Open questions
+
+- None currently.

--- a/naming/repos.md
+++ b/naming/repos.md
@@ -1,0 +1,44 @@
+# Repo names
+
+## Convention
+
+Public Parachute repos live under the `ParachuteComputer` GitHub org, and are
+named `parachute-<module>` (plural is fine where it reads better than
+singular — the npm package stays singular; see `packages.md`).
+
+```
+ParachuteComputer/parachute-<module>
+```
+
+Examples:
+
+- `ParachuteComputer/parachute-vault`
+- `ParachuteComputer/parachute-agents` (plural repo, singular package `@openparachute/agent`)
+- `ParachuteComputer/parachute-daily`
+- `ParachuteComputer/parachute-scribe`
+- `ParachuteComputer/parachute-patterns` (this repo)
+- `ParachuteComputer/openparachute-cli` — the umbrella, named after the npm scope since the repo is the CLI itself
+
+## Why
+
+- One GitHub org surface for everything that makes up the Parachute Computer.
+- `parachute-` prefix makes the family obvious from a bare repo list.
+- Matching the filesystem layout under `~/UnforcedAGI/Code/ParachuteComputer/`
+  means repo-name == folder-name everywhere.
+
+## Rules
+
+- Repo name must match the folder checked out under
+  `~/UnforcedAGI/Code/ParachuteComputer/<repo>`. (Octopus tentacle spawn
+  prompts rely on this.)
+- License: AGPL-3.0 by default, matching the family. If a module needs a
+  different license, open an issue here first so we discuss it once rather
+  than per-repo.
+- README must point back to this repo from its top section: "Parachute
+  conventions live in [parachute-patterns](...)".
+
+## Open questions
+
+- Are there private or unreleased Parachute repos that should stay outside
+  the `ParachuteComputer` org? Currently: UnforcedAGI is private but lives
+  under a personal namespace. Decision not urgent.

--- a/patterns/dev-auto-user.md
+++ b/patterns/dev-auto-user.md
@@ -1,0 +1,54 @@
+# Dev-auto-user convenience
+
+## [DRAFT] — convention is real, the naming isn't locked
+
+## Convention
+
+In local development, a Parachute service may auto-authenticate as a
+synthetic "dev user" when (and only when):
+
+1. The process detects it is running in a **local development** context, AND
+2. An explicit environment variable opts in.
+
+```
+PARACHUTE_DEV_AUTO_USER=1
+```
+
+Without that env, the service refuses dev-auto-user even if other signals
+(hostname, NODE_ENV) suggest dev. This is the gate.
+
+## Why
+
+- Removes friction when hacking on a vault / cloud / agent runner locally —
+  no need to create a token on every fresh checkout.
+- Gating on a *single explicit env var* (not `NODE_ENV=development`, not
+  "localhost only") prevents the class of mistake where a misconfigured
+  staging deploy silently disables auth.
+
+## Rules
+
+- **Env variable name: `PARACHUTE_DEV_AUTO_USER`.** Same name across every
+  module. Never a per-module variant.
+- **Off by default.** The default state of a fresh checkout must still
+  require real auth. Opt in is a deliberate act.
+- **Log loudly on boot.** When dev-auto-user is enabled, the server logs a
+  visible banner: `⚠ PARACHUTE_DEV_AUTO_USER is enabled — do not use in
+  production`.
+- **Never bundle in production builds.** The code path should be reachable
+  from the dev env only; prefer a guard + a unit test that asserts the
+  banner appears in dev and does not appear in prod.
+- **Synthetic user gets a fixed id.** `dev-user` or similar — so vault
+  notes / logs produced during dev are easy to find and clear.
+
+## Where this applies
+
+- `parachute-vault` (single-tenant local dev)
+- `parachute-cloud` (multi-tenant; dev-auto-user maps to a fixed dev tenant)
+- Any future server that would otherwise require real auth to exercise
+  locally.
+
+## Open questions
+
+- Do we want `PARACHUTE_DEV_AUTO_USER=<id>` (picks the synthetic user/tenant
+  id) vs a boolean? Probably boolean + a separate `PARACHUTE_DEV_USER_ID`
+  override. Not blocking.

--- a/patterns/loadAgents.md
+++ b/patterns/loadAgents.md
@@ -1,0 +1,58 @@
+# `loadX` source-tagged-union convention
+
+## Convention
+
+Any Parachute module that loads "a list of configurable things" from one of
+several possible sources exposes the same shape: a tagged union on `type`,
+with interchangeable implementations that return a common data form.
+
+```ts
+type Source<T> =
+  | { type: "dir"; path: string }
+  | { type: "vault"; tag: string; vault: VaultClient }
+  | { type: "inline"; items: T };
+
+async function loadX(source: Source<T>): Promise<T>;
+```
+
+## Why
+
+- **Modularity stays opt-in.** A module works standalone (`dir` or `inline`)
+  and gains vault powers by swapping the source value. No runtime imports
+  change; no build-time dependency is added.
+- **One handshake for every module.** Scribe's proper nouns, Agents'
+  definitions, Daily's templates, Narrate's voice configs — all have the
+  same decision ("where's this list coming from?") and same shape.
+- **Composability with config.** The source is a plain data value, so it's
+  trivially passed from CLI flags, env vars, or a runtime `config` object.
+
+## Where this applies
+
+| Module | `T` | Tag for vault source |
+|---|---|---|
+| `@openparachute/agent` | agent markdown map (`Record<path, md>`) | `agent-definition` |
+| parachute-scribe | proper-noun list | `scribe/proper-noun` |
+| parachute-narrate | voice configs | TBD |
+| parachute-daily | capture templates | TBD |
+
+Today the most complete implementation is in parachute-agents:
+[`src/agent-sources.ts`](https://github.com/ParachuteComputer/parachute-agents/blob/main/src/agent-sources.ts).
+Other modules should port that shape as they add vault integration.
+
+## Rules
+
+- **Common data shape.** Every source branch returns the same `Promise<T>`.
+  The caller never knows which branch produced it.
+- **Graceful degradation.** The `vault` branch must not hard-fail a boot —
+  it logs and returns an empty-ish default so the module still starts.
+  Hard failures belong to the caller that chose the vault source.
+- **Default to standalone.** When no source is explicitly configured, pick
+  the local one (`dir` or `inline`). No surprise network calls.
+- **Type discriminant is `type`.** Don't invent `kind`, `source`, `from`.
+  `type` matches every other tagged union in the codebase.
+
+## Open questions
+
+- Do we want a shared `@openparachute/sources` package that provides the
+  tagged-union helpers? Tempting, but currently the duplication across 2–3
+  modules is a few lines each. Revisit when it's 5+ modules.

--- a/patterns/mcp-transport.md
+++ b/patterns/mcp-transport.md
@@ -1,0 +1,73 @@
+# MCP transport
+
+## Convention
+
+Parachute-hosted MCP servers speak **Streamable HTTP** at `<base>/mcp` and
+authenticate via bearer tokens over `Authorization: Bearer <pvt_...>`.
+
+- Canonical example: `parachute-vault` serves its MCP at `<vault-url>/mcp`.
+- Clients: agents in `@openparachute/agent` connect via
+  `@modelcontextprotocol/sdk` + the Streamable HTTP transport. Source:
+  [parachute-agents/src/vault.ts](https://github.com/ParachuteComputer/parachute-agents/blob/main/src/vault.ts).
+
+## Why Streamable HTTP (not SSE)
+
+- Supports bidirectional streaming over a single HTTP connection.
+- Works behind most load balancers and serverless runtimes (Cloudflare
+  Workers, fly machines) without special long-lived-connection handling.
+- SSE is the legacy transport. Prefer Streamable HTTP for any new server.
+
+## Auth shape
+
+Two schemes supported by `@openparachute/agent`'s MCP tool entry. See
+`schemas/agent-markdown.md` for the frontmatter spec.
+
+### Bearer (static token)
+
+```yaml
+mcp:
+  name: my-service
+  url: https://svc.example.com/mcp
+  auth:
+    type: bearer
+    token_env: MY_SERVICE_TOKEN     # or `token: <literal>` (discouraged)
+```
+
+### OAuth (client credentials)
+
+```yaml
+mcp:
+  name: my-service
+  url: https://svc.example.com/mcp
+  auth:
+    type: oauth
+    client_id_env: MY_SERVICE_CLIENT_ID
+    client_secret_env: MY_SERVICE_CLIENT_SECRET
+    token_url: https://svc.example.com/oauth/token
+    scope: "read write"
+```
+
+Runs the RFC 6749 `client_credentials` grant and caches the access token
+per-server. PKCE, authorization_code, and refresh_token flows are out of
+scope until an agent actually needs one.
+
+## Rules
+
+- **URLs must be http(s).** Non-http schemes (`file://`, etc.) are rejected
+  at schema-parse time — an agent markdown file can't smuggle a bad
+  transport into the client. See
+  [parachute-agents/src/agents.ts](https://github.com/ParachuteComputer/parachute-agents/blob/main/src/agents.ts).
+- **Never inline a token in the markdown** when the file is checked into a
+  repo or stored in vault. Use `token_env` and supply the secret via the
+  runner's environment.
+- **Scope the token.** Follow `patterns/token-auth.md` — every Parachute
+  token has a declared scope; MCP tokens typically have something like
+  `vault:read` or `agent:invoke`.
+- **Path convention.** Servers should mount MCP at `/mcp` (not `/api/mcp`,
+  not `/v1/mcp`). Keeps client URLs uniform.
+
+## Open questions
+
+- Do we want an OAuth `authorization_code` + PKCE flow for user-scoped
+  tokens (as opposed to service-scoped client_credentials)? Likely yes when
+  a first end-user app on top of an agent lands. Not urgent.

--- a/patterns/report-contract.md
+++ b/patterns/report-contract.md
@@ -1,0 +1,78 @@
+# Report contract
+
+## [DRAFT] — `/report` slash command is in flight (octopus-polish)
+
+## Convention
+
+When a tentacle (or any agent) finishes a unit of work, it reports back in
+a structured shape — not narrative. The shape is the same whether the
+consumer is Uni's central source, the Octopus UI, or the vault.
+
+```
+## TL;DR
+<1–2 sentences: what changed>
+
+## Details
+- <bullets of concrete outcomes, with file paths or PR links>
+
+## Decisions / open questions
+- <anything that needs a human to steer>
+
+## Follow-ups
+- <work that's queued but not done>
+```
+
+## `/report` slash command
+
+The intended ergonomic surface: a tentacle types `/report` and is prompted
+(by the harness) to fill in the above sections. The harness then:
+
+1. Sends the structured block back to the team-lead via `SendMessage`.
+2. Optionally persists to vault as `uni/handoff` (path
+   `Uni/Handoffs/<YYYY-MM-DD>-<slug>`), controlled by the spawn brief.
+3. Optionally forwards a TL;DR to Telegram, controlled by the spawn brief.
+
+"Controlled by the spawn brief" means the tentacle's spawn prompt includes
+a `Report contract:` section with `persistToVault: yes|no` and
+`telegram: yes|no` so the tentacle knows its report discipline without
+asking each time.
+
+Implementation tracked in the octopus-polish work. Until it lands, tentacles
+produce the same structured shape manually in their SendMessage response.
+
+## Why
+
+- **Synthesis stays cheap.** A parent agent ingesting structured markdown
+  can skim it in one pass. Narrative responses force re-reading.
+- **Vault-friendly.** The same block drops into a handoff note with zero
+  reformatting.
+- **Stops drift.** Without a contract, each tentacle invents its own shape
+  and the team-lead's context fragments.
+
+## Rules
+
+- Reports are **structured, not narrative.** If you catch yourself writing
+  more than a paragraph in prose, you're missing the sections.
+- **TL;DR first, always.** The team-lead and Aaron may read nothing else.
+- **Link, don't paste.** Reference PR URLs, commit SHAs, file paths. Don't
+  quote diffs into the report.
+- **No emoji or decoration** unless the audience explicitly wants it
+  (rarely). Match Parachute's tone: precise, not precious.
+
+## Spawn-brief section
+
+The block that goes into every tentacle spawn prompt, inherited from
+UnforcedAGI conventions:
+
+```markdown
+## Report contract
+- When done (or blocked), SendMessage team-lead with a structured report.
+- Persist to vault: yes | no  (path: Uni/Handoffs/<date>-<slug>, tag: uni/handoff)
+- Telegram: yes | no  (TL;DR only)
+```
+
+## Open questions
+
+- Push vs pull: should the team-lead explicitly request a report, or should
+  the tentacle send one unprompted at each work-block boundary? Current
+  practice is the latter. Keep until it causes noise.

--- a/patterns/token-auth.md
+++ b/patterns/token-auth.md
@@ -1,0 +1,64 @@
+# Token auth — `pvt_` tokens
+
+## [DRAFT] — canonicalizing the shape across modules
+
+## Convention
+
+Parachute-issued bearer tokens use a `pvt_` prefix ("parachute token"), are
+stored as sha256 hashes (never in clear), are scoped to a vault / tenant /
+agent, and are revealed to the user exactly once via the issuing surface —
+typically a cookie-gated modal after creation.
+
+## Shape
+
+```
+pvt_<base64url random 32 bytes>
+```
+
+Stored as:
+
+```
+sha256(pvt_...) hex → (tenant_id, scope, created_at, last_used_at, label)
+```
+
+## Rules
+
+- **Prefix is `pvt_`.** Makes tokens instantly grep-able in logs and in
+  leaked credentials scanners. No module should use a different prefix.
+- **Store only the hash.** The server never has a plaintext token after
+  issuance. Comparing: hash the incoming bearer, look up by hash.
+- **Scope is required.** Every token has a named scope
+  (`vault:read`, `vault:write`, `agent:invoke`, etc.). A token without
+  scope is a bug.
+- **Reveal once.** The UI that issues a token shows the full `pvt_...`
+  exactly one time, gated by the user's active session cookie. After modal
+  close, the UI shows only a last-4 suffix + label. The caller is
+  responsible for copying it then.
+- **Last-used tracking.** Record `last_used_at` on each successful auth so
+  stale tokens can be surfaced in an admin view.
+- **Revocation is by hash.** Deleting the hash row revokes instantly.
+
+## Why
+
+- Prefix + scope + hash is the pattern GitHub / Anthropic / most modern
+  token issuers use. Nothing exotic.
+- The cookie-reveal pattern prevents a leaked clipboard or ps-listing from
+  burning a token post-issuance — the plaintext exists only in the user's
+  browser for one modal's lifetime.
+- One sha256 hash per row gives O(1) lookup without a KV rotation concern.
+
+## Where this applies
+
+- `parachute-vault` — vault tokens for REST / MCP auth.
+- `parachute-cloud` — tenant-scoped vault access tokens.
+- `@openparachute/agent` — inbound webhook tokens for trigger auth (when the
+  runner exposes a webhook endpoint).
+
+## Open questions
+
+- Rotation story: today we revoke + re-issue. Should we add
+  per-token-rotation (old token works for 24h after rotation)? Not needed
+  until an automated client can't tolerate a flip.
+- Per-scope TTL defaults: unset today. Reasonable future: `agent:invoke`
+  tokens default to 90d, `vault:*` tokens default to no expiry (revoke
+  explicitly).

--- a/schemas/agent-markdown.md
+++ b/schemas/agent-markdown.md
@@ -1,0 +1,97 @@
+# Agent markdown schema
+
+## Convention
+
+One markdown file = one agent. YAML frontmatter describes how it fires and
+what it can do; the body is the system prompt.
+
+Canonical Zod schema:
+[parachute-agents/src/agents.ts](https://github.com/ParachuteComputer/parachute-agents/blob/main/src/agents.ts).
+That file is the authority — this doc summarizes it for reference and for
+modules adopting the same schema (e.g. Prism's `skill-builder`).
+
+## Shape
+
+```yaml
+---
+name: <unique slug>
+description: <human readable; used when exposing the agent via MCP>
+trigger:
+  type: webhook | cron | vault | manual
+  # per-type fields below
+model: <provider>/<model>        # e.g. anthropic/claude-sonnet-4-6
+backend: vercel-ai | claude      # optional; overrides runner default
+tools: [<built-in> | { mcp: {...} }, ...]
+on_save:
+  tags: [<string>, ...]
+  path: <template>
+---
+
+System prompt body in markdown.
+```
+
+## Triggers
+
+- **webhook** — `source: discord | slack | telegram | http | any`,
+  `match: always | contains_url | regex:<pattern>`.
+- **cron** — `schedule: "<cron expression>"`.
+- **vault** — `on_event: created | updated`, optional
+  `filter: { tags: [...], not_tags: [...] }`, `poll_seconds: >=10` (default 60;
+  push-based firing is future work).
+- **manual** — fires only via explicit invocation.
+
+## Tools
+
+Two forms in the same array:
+
+```yaml
+tools:
+  - fetch_url             # string: built-in tool
+  - vault                 # string: built-in tool
+  - mcp:                  # object: attach an external MCP server
+      name: some-service
+      url: https://example.com/mcp
+      auth:
+        type: bearer
+        token_env: SOME_SERVICE_TOKEN
+```
+
+MCP auth supports `bearer` (`token` or `token_env`) and `oauth`
+(client-credentials grant via `client_id_env` / `client_secret_env` /
+`token_url`). Non-http(s) URLs are rejected at parse time. See
+`patterns/mcp-transport.md` for wire-level details.
+
+## Backend
+
+`vercel-ai` (default) routes through Vercel AI SDK + the runner's configured
+provider. `claude` routes through `@anthropic-ai/sdk` Messages API, picking
+up auth from `ParachuteAgentConfig.claudeAuth`. The markdown is identical in
+both cases — only the inference path changes.
+
+## Source options
+
+Agent markdown maps (`path → string`) can come from:
+
+- `loadAgentsFromDir(dir)` — filesystem
+- `loadAgentsFromVault({ vault, tag })` — vault notes tagged
+  `agent-definition` (default)
+- `loadAgentsInline(map)` — hand-authored map
+
+See `patterns/loadAgents.md` for the shared source convention.
+
+## Rules
+
+- Frontmatter must parse against `agentFrontmatterSchema` — no extra fields
+  at the top level (zod will pass-through unknown keys, but new keys should
+  be added to the schema first).
+- Agent `name` must be unique within a runner. `loadAgents` throws on
+  duplicates.
+- `description` is required for any agent that will be exposed via MCP —
+  it's what the caller sees when listing available agents.
+
+## Adoption
+
+Prism's `skill-builder` (Benjamin's project) covers similar ground. When
+Prism adopts `@openparachute/agent` as its runner, this schema is the
+handshake. Log schema extensions in `adoption/migration-notes.md` so we keep
+both sides in sync.

--- a/schemas/frontmatter-lint.md
+++ b/schemas/frontmatter-lint.md
@@ -1,0 +1,38 @@
+# Frontmatter lint rules
+
+## [DRAFT]
+
+Shared linting for markdown files with YAML frontmatter. Applies to agent
+markdown (`@openparachute/agent`), memory files (`~/.claude/projects/.../memory/*.md`),
+and any future markdown-with-frontmatter surface.
+
+## Rules (apply to any frontmatter we author)
+
+1. **Opening `---` and closing `---` on their own lines.** No content on the
+   same line as the fence.
+2. **2-space indent, no tabs.** YAML parsers differ on tabs; avoid the class
+   entirely.
+3. **Strings containing `:` must be quoted.** Example:
+   `description: "Runs at 9:00 daily"`.
+4. **Dates are ISO-8601** (`2026-04-15` or `2026-04-15T12:00:00Z`).
+5. **Arrays prefer block form** when more than 2 items; inline `[a, b]` is
+   fine for short lists.
+6. **Unknown top-level keys are warnings, not errors.** The canonical schemas
+   (agent markdown, memory entries) should grow deliberately; a warning
+   flags drift without blocking.
+
+## Schemas that live elsewhere
+
+- Agent markdown: `schemas/agent-markdown.md` → Zod in
+  [parachute-agents/src/agents.ts](https://github.com/ParachuteComputer/parachute-agents/blob/main/src/agents.ts).
+- Memory files (user / feedback / project / reference): Uni's auto-memory
+  convention in the UnforcedAGI global CLAUDE.md.
+
+## Open questions
+
+- No shared lint tool has been built. `gray-matter` + a schema is the
+  obvious path. If/when we ship one, it lives in `@openparachute/cli` as
+  `parachute lint` and points at the schemas above.
+- Should memory files have a shared Zod schema too, matching the
+  `name/description/type/...` frontmatter Uni writes? Probably yes — file
+  an issue when someone hits an inconsistency.

--- a/schemas/vault-note.md
+++ b/schemas/vault-note.md
@@ -1,0 +1,64 @@
+# Vault note conventions
+
+Canonical vault description lives in the live vault itself — call
+`vault-info` via the `parachute-vault` MCP for the full tag taxonomy and
+any updates. This file captures the conventions that cross module
+boundaries.
+
+## metadata.summary — always
+
+Every note should carry a 1–2 sentence `metadata.summary`.
+
+```
+metadata:
+  summary: <one to two sentences>
+```
+
+**Why:** lightweight scanning. `query-notes` can return summaries without
+content, which keeps context budgets cheap when something is walking many
+notes. Without a summary, you pay full content cost to decide relevance.
+
+## Tags define what a note IS
+
+Tags describe identity. A note about a decision has tag `uni/decision`; an
+agent-run log has `agent-run`; a handoff has `uni/handoff`. Tags are
+hierarchical via `/` (e.g. `uni/decision`, `uni/handoff`, `uni/state`).
+
+## Links define how notes CONNECT
+
+Relationships (mentions, related-to, derived-from, etc.) go through
+outgoing links. Wikilinks in content (`[[Projects/Parachute]]`) auto-resolve
+and count as `mentions`.
+
+## Wikilinks use full paths
+
+Always: `[[Projects/Parachute Vault]]`. Never: `[[Parachute Vault]]`.
+
+**Why:** path prefixes are namespaces — `People/`, `Projects/`,
+`Uni/Decisions/` — and shortening loses the folder signal. Full paths
+survive renames better (the vault's wikilink resolver keys on the path).
+
+## Standard note types shared across the ecosystem
+
+| Tag | Path convention | Written by | Purpose |
+|---|---|---|---|
+| `uni/decision` | `Uni/Decisions/<YYYY-MM-DD>-<slug>` | central source (Uni) | architectural/directional choice + rationale |
+| `uni/handoff` | `Uni/Handoffs/<YYYY-MM-DD>-<slug>` | tentacles | what was done / learned / unresolved, at the end of a work block |
+| `uni/state` | `Uni/State/<YYYY-MM-DD>-<slug>` | central source | "resume from here" snapshot before compaction or quiet period |
+| `agent-definition` | (module-specific) | humans / agents | agent markdown consumed by `@openparachute/agent` |
+| `agent-run` | (auto) | agent runner | opt-in mirror of high-signal run logs |
+| `agent-skill` | (TBD) | humans | reusable composable prompt — future, when skills layer lands |
+| `octopus-config` | `Uni/Octopus/config` | central source | opt-in team roster when `OCTOPUS_CONFIG_SOURCE=vault` |
+
+## Dates
+
+Convert relative dates to absolute when saving (user says "Thursday" →
+store `2026-03-05`). Memories and notes decay fast otherwise.
+
+## Rules
+
+- `metadata.summary` is load-bearing — don't skip it.
+- Use existing tags where possible. Introduce a new tag via
+  `vault-info --description` and document it here if it's cross-module.
+- Paths are stable identity. Renaming a note is expensive (wikilinks need
+  rewriting). Pick the path once, carefully.


### PR DESCRIPTION
## Summary

First pass at the shared-conventions repo. Every Parachute module will point here as the single source of truth for how it aligns with its siblings.

**Structure**

- `naming/` — `@openparachute/*` packages, `parachute-*` bins, `ParachuteComputer/parachute-*` repos, umbrella dispatch.
- `modularity/` — standalone-first principle + worked examples (Scribe, Agents, Octopus composing with vault without coupling).
- `brand/` — palette + typography + motifs (ported from `parachute-daily/lib/core/theme/design_tokens.dart`) + canonical `tokens.css`.
- `schemas/` — agent markdown (links to the Zod in parachute-agents), vault note conventions, frontmatter lint rules.
- `patterns/` — `loadX` source tagged-union, report contract, `pvt_` token auth, MCP Streamable-HTTP transport, `PARACHUTE_DEV_AUTO_USER` convenience.
- `adoption/` — checklist for new modules + migration-notes log.
- `README.md`, `CLAUDE.md` (docs-only repo), `LICENSE` (AGPL-3.0).

**Drafts**

Marked `[DRAFT]`: bin renames (vault/scribe/narrate), typography font stack, motif publication, frontmatter-lint tooling, some token-auth details, dev-auto-user shape.

**Open questions**

- `@openparachute/vault-client` extraction threshold.
- `parachute doctor` / `parachute lint` subcommands.
- User-scoped OAuth (auth_code + PKCE) for MCP.
- Whether octopus-config-in-vault belongs as a first-class pattern.

## Test plan

- [ ] Review layout — each file one screen, one pattern, links upstream.
- [ ] Confirm brand hex values match Daily's `design_tokens.dart`.
- [ ] Confirm bin-naming claims match current `package.json` state.
- [ ] Check drafts are clearly marked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
