### PR TITLE
patterns: add module-protocol.md

### DIFF
--- a/patterns/module-protocol.md
+++ b/patterns/module-protocol.md
@@ -1,0 +1,130 @@
+# Module protocol
+
+## Convention
+
+Every Parachute module plugs into the ecosystem by implementing the same
+small set of contracts. The hub (and any other consumer) can discover,
+identify, configure, and route to any module — first-party or third-party —
+without hub-side code changes. "Module" is the primary noun; the hub is a
+module that happens to also orchestrate.
+
+The protocol has three layers:
+
+### 1. Storage — `~/.parachute/services.json`
+
+The installed-module registry. One entry per module, written at install
+time by `parachute install`. Canonical source of truth for which modules
+exist on this machine and how to reach them.
+
+```json
+{
+  "name": "parachute-vault",
+  "port": 1940,
+  "paths": ["/vault/default"],
+  "health": "/vault/default/health",
+  "version": "0.3.0",
+  "displayName": "Vault",
+  "tagline": "Agent-native knowledge graph …",
+  "kind": "api"
+}
+```
+
+Canonical shape: [`parachute-cli/src/services-manifest.ts`](https://github.com/ParachuteComputer/parachute-cli/blob/main/src/services-manifest.ts).
+
+### 2. Runtime — `/.parachute/*` endpoints
+
+Every module serves these under its own mount path. No auth for `info` /
+`icon.svg` / `config/schema`; reads/writes to `config` are scope-gated once
+Phase 2+ lands.
+
+| Path | Purpose | Auth |
+| --- | --- | --- |
+| `GET /.parachute/info` | identity + version + `kind` + capabilities | none (CORS `*`) |
+| `GET /.parachute/icon.svg` | small inline SVG, `image/svg+xml` + `nosniff` | none |
+| `GET /.parachute/config/schema` | JSON Schema for configuration | none |
+| `GET /.parachute/config` | current config values | `<module>:admin` (Phase 2) |
+| `PUT /.parachute/config` | write config, validated against schema | `<module>:admin` (Phase 3) |
+
+`kind` is one of `"api" | "frontend" | "tool"`. Reference implementation
+dispatches these in
+[`parachute-vault/src/routing.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/routing.ts)
+(`/.parachute/info`, `/.parachute/icon.svg`, `/.parachute/config/schema`,
+`/.parachute/config`).
+
+### 3. Discovery — `/.well-known/parachute.json`
+
+The hub aggregates every installed service's storage entry into a single
+document at `/.well-known/parachute.json` on the ecosystem origin. Clients
+(the hub page, third-party integrations, future agents) fetch this once and
+iterate, then fan out to each service's `/.parachute/info` for live
+metadata.
+
+Shape (see
+[`parachute-cli/src/well-known.ts`](https://github.com/ParachuteComputer/parachute-cli/blob/main/src/well-known.ts)):
+
+```json
+{
+  "vaults":   [{ "name": "default", "url": "…", "version": "…" }],
+  "services": [{ "name": "…", "url": "…", "path": "…", "version": "…", "infoUrl": "…/.parachute/info" }],
+  "<shortName>": { "url": "…", "version": "…" }   // back-compat, one per service
+}
+```
+
+Served by
+[`parachute-cli/src/hub-server.ts`](https://github.com/ParachuteComputer/parachute-cli/blob/main/src/hub-server.ts);
+the hub page fetch lives in
+[`parachute-cli/src/hub.ts`](https://github.com/ParachuteComputer/parachute-cli/blob/main/src/hub.ts).
+
+## Why
+
+- **Open by construction.** The protocol is the standard, not the package
+  names. A module called `my-cool-thing` that ships the four required
+  contracts is a first-class Parachute module — no `@openparachute/` scope
+  or `parachute-*` prefix required. See
+  [`module-json-extensibility.md`](./module-json-extensibility.md) when
+  that pattern lands.
+- **Hub stays thin.** `services.json` + `/.well-known/parachute.json` +
+  `/.parachute/info` on each module is everything the hub needs. No
+  per-module special-casing in hub code.
+- **Same shape local and remote.** A loopback vault on port 1940 and a
+  cloud-hosted vault at `vault.example.com` speak the same protocol. Cloud
+  is a hosting option, not a separate product.
+- **Additive evolution.** New keys in the well-known doc and new
+  `/.parachute/*` endpoints are optional. Old clients keep working; the
+  `services[]` array was added alongside the original flat-shortName keys
+  for exactly this reason.
+
+## Rules
+
+- **Mount at `/.parachute/*` literally.** Not `/api/parachute/*`, not
+  `/v1/.parachute/*`. Keeps cross-module URL construction uniform.
+- **`info` + `icon.svg` are unauthenticated and CORS-open.** The hub page
+  loads them from the browser with `credentials: 'omit'`.
+- **`kind` is required.** Hubs decide how to render the card (link vs.
+  iframe vs. tool launcher) from this field.
+- **Every service gets one `services.json` entry.** Multi-tenant modules
+  (e.g. multiple vaults) write one entry per instance with distinct `name`
+  + `paths`.
+- **Pick a port in the reserved range when you can.** See
+  [`canonical-ports.md`](./canonical-ports.md). Third parties should stay
+  out of 1939–1949.
+
+## What's out of scope here
+
+- OAuth issuer location and scope format — see
+  [`hub-as-issuer.md`](./hub-as-issuer.md) and
+  [`oauth-scopes.md`](./oauth-scopes.md).
+- Third-party module manifest (`.parachute/module.json`) shape — see
+  [`module-json-extensibility.md`](./module-json-extensibility.md).
+- Well-known metadata for OAuth (RFC 8414 / RFC 9728) — see
+  [`well-known-discovery-rfc.md`](./well-known-discovery-rfc.md).
+
+## Status
+
+Live. Phase 0 (launch, 2026-04-23) ships `services.json`,
+`/.parachute/info`, `/.parachute/icon.svg`, `/.well-known/parachute.json`
+across vault + notes + scribe + channel + hub. Phase 2 adds
+`/.parachute/config/schema` + `GET /.parachute/config`; Phase 3 adds
+`PUT /.parachute/config` and the auto-wiring story. Track the full phasing
+in
+[`parachute.computer/design/2026-04-20-module-architecture.md`](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-04-20-module-architecture.md).


### PR DESCRIPTION
## Summary

Adds `patterns/module-protocol.md` — the foundational write-up of the three-layer contract every Parachute module implements:

- **Storage**: `~/.parachute/services.json` (the install-time registry)
- **Runtime**: `/.parachute/{info,icon.svg,config,config/schema}` (per-module endpoints)
- **Discovery**: `/.well-known/parachute.json` (hub-aggregated catalog)

This is the anchor file. Subsequent patterns (`oauth-scopes`, `hub-as-issuer`, `canonical-ports`, `module-json-extensibility`, `well-known-discovery-rfc`) will link back to it.

## Why now

The pattern was established across vault, notes, scribe, channel, and hub during launch prep (2026-04-23) but wasn't written down cross-cuttingly anywhere a third-party integrator or future contributor could point at. Launch beta users will look at this file first.

## Sources cited (linked, not duplicated)

- `parachute-vault/src/routing.ts` — runtime dispatch of the four `.parachute/*` endpoints
- `parachute-cli/src/services-manifest.ts` — canonical `ServiceEntry` shape
- `parachute-cli/src/well-known.ts` + `hub-server.ts` + `hub.ts` — aggregation + serving + client fetch
- `parachute.computer/design/2026-04-20-module-architecture.md` — canonical design doc

## Scope calls

- One screen, matches existing pattern file shape (TL;DR, why, rules, open/out-of-scope).
- Doesn't invent — all seven endpoints + the well-known doc shape + `services.json` shape map 1:1 to shipped code on `main`.
- Forward links (`oauth-scopes.md`, `canonical-ports.md`, etc.) point at files that don't exist yet. They'll land in follow-up PRs this week. Reviewers can treat the dangling links as intentional placeholders.

## Test plan
- [x] File renders as one screen in GitHub's markdown view
- [x] Every code/file reference points at something that exists on `main` in the cited repo
- [x] Follows the shape of existing `patterns/*.md` files (token-auth, mcp-transport, report-contract)
- [ ] Reviewer confirms scope boundaries vs. `oauth-scopes.md` and `module-json-extensibility.md` (still to be drafted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)