### PR TITLE
add governance.md — PR review, RC versioning, patterns alignment

### DIFF
--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -11,10 +11,19 @@ summary; the repo owner (currently Aaron) clicks merge.
 
 - All Parachute repos with code or content (`parachute-cli`, `parachute-vault`,
   `parachute-notes`, `parachute-scribe`, `parachute.computer`,
-  `parachute-patterns`) have **branch protection on `main`**: at least 1
-  approving review required, no force-push, no branch deletion.
+  `parachute-patterns`) have **branch protection on `main`**: no force-push,
+  no branch deletion, PR-required for changes.
+- **Required-review count is calibrated to team size**:
+  - **Solo human team (today):** required approvals = `0`. The single human
+    *is* both reviewer and merger; a separate "approve" click before "merge"
+    is ceremony without an additional safeguard. The discipline is on the
+    automated actors (tentacles, team-lead) not to merge without a human.
+  - **Multi-human team (later):** required approvals = `≥1`. Bump back up
+    when a second human contributor with merge authority joins so PRs see a
+    second pair of eyes before main.
 - New Parachute repos turn on the same protection at the moment they hit
-  RC / first publish. Before that, direct push is fine while shape is fluid.
+  RC / first publish, calibrated to whatever team-size rule is active. Before
+  RC, direct push is fine while shape is fluid.
 - Reverts and emergency hotfixes follow the same rule: branch, PR, review,
   human merge. Speed comes from a faster review cycle, not from skipping
   review.
@@ -87,10 +96,7 @@ durable alignment across modules and humans.
 
 ## Open questions
 
-- **Self-approval**: GitHub allows a repo admin to approve their own PR in
-  some configurations. We're not currently using `enforce_admins`, so
-  admins can technically merge without a separate approval. This is
-  intentional for emergency overrides; track abuse.
-- **Multi-tentacle approval workflow**: when the codebase has >1 active
-  human contributor, we add explicit `CODEOWNERS` and require code-owner
-  reviews. Out of scope today.
+- **Multi-human transition**: when a second human contributor joins, bump
+  required approvals from `0` to `≥1` on each repo and add explicit
+  `CODEOWNERS` files for path-scoped review. Out of scope today; not
+  forgotten.

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -1,0 +1,96 @@
+# Governance: PR review, RC versioning, patterns alignment
+
+> One short doc covering how Parachute repos ship code post-launch (v0.x,
+> April 2026 onward). Three rules, one shared shape.
+
+## Rule 1 — No auto-merge
+
+**Every PR is reviewed by a team-lead role and merged by a human.** Tentacles
+open PRs and report status; team-lead reviews and writes a verification
+summary; the repo owner (currently Aaron) clicks merge.
+
+- All Parachute repos with code or content (`parachute-cli`, `parachute-vault`,
+  `parachute-notes`, `parachute-scribe`, `parachute.computer`,
+  `parachute-patterns`) have **branch protection on `main`**: at least 1
+  approving review required, no force-push, no branch deletion.
+- New Parachute repos turn on the same protection at the moment they hit
+  RC / first publish. Before that, direct push is fine while shape is fluid.
+- Reverts and emergency hotfixes follow the same rule: branch, PR, review,
+  human merge. Speed comes from a faster review cycle, not from skipping
+  review.
+
+## Rule 2 — RC versioning before `@latest`
+
+While the ecosystem is pre-1.0, every published change goes to npm's `rc`
+dist-tag first; promotion to `@latest` is a deliberate, separate step.
+
+**Per PR:**
+
+- The PR bumps `package.json` to `0.X.Y-rc.N` (next patch + a fresh rc
+  number). Don't ship a "final" version straight from a feature PR.
+- After the human merge, the publisher runs `npm publish --tag rc` so the
+  build is reachable as `@openparachute/<pkg>@rc` (or
+  `@openparachute/<pkg>@0.X.Y-rc.N` directly) but **not** the default
+  `@latest` install for new users.
+
+**Promotion (a separate, deliberate action):**
+
+- Run `npm dist-tag add @openparachute/<pkg>@0.X.Y-rc.N latest` once the RC
+  has been validated (smoke install, manual demo, real-world feedback).
+- The same RC artifact becomes the `@latest`; no second build, no second
+  version. This keeps git history and npm versions aligned and keeps the
+  cadence fast.
+
+**Doc-only / test-only PRs follow the same convention** for uniformity. Every
+PR that changes the published artifact bumps the version. The cost is one
+line in `package.json`; the benefit is no special-casing.
+
+**At v1.0 and after**, switch to standard SemVer with `alpha` / `beta` / `rc`
+prerelease tags as feature stability warrants, and to a "release PR" pattern
+that promotes `0.X.Y-rc.N` → `0.X.Y` final via a small dedicated PR for a
+cleaner public version history. This pattern doc gets a v1.0 update at that
+time.
+
+## Rule 3 — Patterns check in every review
+
+Every PR review surfaces three questions (in the team-lead's report to the
+repo owner):
+
+1. **Which patterns from `parachute-patterns/` does this PR touch?**
+   Explicit (the PR cites a doc) or implicit (the PR conforms to a pattern
+   without naming it).
+2. **Does it conform?** If not, why? (Sometimes the right call is the
+   non-conforming change; the pattern is wrong or stale.)
+3. **Does it establish a new pattern that should be documented, or change an
+   existing pattern?** If yes, file or update the relevant pattern doc — as
+   a follow-up PR in `parachute-patterns/` or, if small, bundled into the
+   originating PR.
+
+The patterns repo's steward (the `patterns` tentacle) is an active
+participant in this loop — flagged when a new pattern is established,
+involved in updates that affect cross-cutting conventions.
+
+## Why these rules
+
+The first two months of post-launch shipping (April 2026 → ?) are the period
+of most rapid change. In that window:
+
+- Every direct-merge is a chance to ship something the team owner didn't
+  expect.
+- Every untagged `@latest` publish is a chance for new users to install a
+  half-validated artifact.
+- Every undocumented pattern becomes harder to retrofit later.
+
+The cost of these rules is small (one extra click for merge, one extra
+command for promotion, one extra paragraph in review). The benefit is
+durable alignment across modules and humans.
+
+## Open questions
+
+- **Self-approval**: GitHub allows a repo admin to approve their own PR in
+  some configurations. We're not currently using `enforce_admins`, so
+  admins can technically merge without a separate approval. This is
+  intentional for emergency overrides; track abuse.
+- **Multi-tentacle approval workflow**: when the codebase has >1 active
+  human contributor, we add explicit `CODEOWNERS` and require code-owner
+  reviews. Out of scope today.

--- a/patterns/oauth-scopes.md
+++ b/patterns/oauth-scopes.md
@@ -1,0 +1,162 @@
+# OAuth scopes
+
+## Convention
+
+Parachute OAuth tokens carry **whitespace-separated scope strings**
+(OAuth 2.0 §3.3). Every scope follows the same shape:
+
+```
+<service>[:<resource>]*:<action>
+```
+
+- First segment — the service (vault, scribe, channel, hub, or any
+  third-party module's declared name).
+- Last segment — the action (`read`, `write`, `admin`, or a service-specific
+  verb like `transcribe`, `send`).
+- Middle segments (zero or more) — a resource hierarchy that narrows the
+  scope. Today the only narrowing segment in use is `vault:<name>:<verb>`
+  (per-vault), which is **parsed but treated as a synonym** for
+  `vault:<verb>` in Phase 2.
+
+## Launch scopes (Phase 0+1)
+
+| Scope | Grants |
+| --- | --- |
+| `vault:read` | Read any vault via REST + MCP |
+| `vault:write` | Write + read (inheritance) |
+| `vault:admin` | Write + read + `/.parachute/config*` |
+| `scribe:transcribe` | POST audio to scribe's transcription endpoint |
+| `scribe:admin` | Manage scribe config |
+| `hub:admin` | Reserved; not yet enforced |
+| `channel:send` | Post messages via channel |
+
+Third-party modules declare their own namespace (`my-service:read`, etc.)
+and the hub renders consent for those scopes the same way.
+
+## Inheritance
+
+```
+admin ⊇ write ⊇ read       (for vault)
+```
+
+- `vault:admin` satisfies any check for `vault:write` or `vault:read`.
+- `vault:write` satisfies `vault:read`.
+- **Non-vault scopes exact-match only.** `scribe:admin` does **not**
+  currently imply `scribe:transcribe` — each non-inheritance-tree scope
+  stands alone. This is deliberate: we add inheritance per-service
+  when the verb set clearly lines up as read/write/admin.
+
+Canonical implementation:
+[`parachute-vault/src/scopes.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/scopes.ts)
+(`hasScope`, `parseScopes`, `scopeForMethod`). Enforcement landed in
+[PR #97](https://github.com/ParachuteComputer/parachute-vault/pull/97).
+
+## Parser rules
+
+- **Split on whitespace** for the scope string; **split on `:`** for each
+  scope.
+- **`vault:<name>:<verb>` collapses** to `vault:<verb>` during parse
+  (Phase 2 synonym — per-vault narrowing is a Phase 2+ feature).
+- **Empty resource segments are preserved verbatim** (`vault::read` stays
+  `vault::read`, so it can't satisfy a `vault:read` check — a one-line
+  defence against a malformed DB row).
+- **Unknown scopes pass through** the parser untouched. They simply won't
+  match anything, which is the right failure mode for a future-scope that
+  reaches an old server.
+
+## 403 response shape
+
+When a request is authenticated but under-scoped, modules return:
+
+```json
+{
+  "error": "Forbidden",
+  "error_type": "insufficient_scope",
+  "message": "This endpoint requires the 'vault:write' scope.",
+  "required_scope": "vault:write",
+  "granted_scopes": ["vault:read"]
+}
+```
+
+`error_type: "insufficient_scope"` is the machine-readable key clients
+should branch on (so they can present "Reconnect with broader access" UI
+without parsing the human message).
+
+## HTTP ↔ scope mapping
+
+Vault's default, reused verbatim by any API-surface module with the same
+verb set:
+
+| Method | Scope |
+| --- | --- |
+| `GET` / `HEAD` / `OPTIONS` | `<service>:read` |
+| `POST` / `PUT` / `PATCH` / `DELETE` | `<service>:write` |
+| `/.parachute/config*` (regardless of method) | `<service>:admin` |
+
+MCP tools are partitioned by intended effect, not by HTTP verb — see the
+per-tool gate table in vault's PR #97.
+
+## Soft-launch back-compat
+
+v0.2-era tokens carry a legacy `permission` column (`"full"` or `"read"`)
+instead of a scope string. For **one release cycle after enforcement
+lands**, these are mapped on the fly by
+`legacyPermissionToScopes(permission)`:
+
+- `"full"` / `"admin"` / `"write"` → `[vault:read, vault:write, vault:admin]`
+- `"read"` → `[vault:read]`
+
+A one-shot per-process-per-token warning is logged on first use so
+operators can see which tokens need rotation. The mapper is marked
+`@deprecated`; remove it one release after v0.4.
+
+The OAuth `token_endpoint_auth_methods_supported`/`scopes_supported`
+metadata similarly keeps `full` + `read` alongside the `vault:*` scopes
+for one release cycle so legacy clients don't hard-break on discovery.
+
+## Rules
+
+- **Declare scopes up front** in your module's `.parachute/module.json`
+  under `scopes.defines`. The hub renders consent prompts from this list.
+- **Use OAuth-standard whitespace serialization**, not comma-separated.
+  Parsers MUST accept any whitespace run including `\t` + `\n`.
+- **Don't invent synonyms.** A module adding a new verb should add the
+  verb, not alias an existing scope. New scopes are additive and cheap.
+- **Respect the `admin ⊇ write ⊇ read` contract** when your module has
+  exactly that verb set. If your verbs are `send` / `admin`, don't force
+  them into the read/write/admin tree — they're separate axes.
+- **`vault:admin` (or any `:admin`) gates `/.parachute/config*`** on that
+  module. This is the cross-cutting rule every module should honour.
+
+## Future: per-resource narrowing (Phase 2+)
+
+`vault:<name>:<verb>` is parsed today but collapsed to `vault:<verb>`.
+The real shape, once enforced:
+
+- `vault:work:read` — read the `work` vault only.
+- `vault:work:notes/inbox/:read` — read one path prefix inside one vault
+  (notional; not yet designed).
+- `scribe:groq:transcribe` — use only the `groq` provider on scribe.
+
+The parser already knows to split on `:`; the matcher is what gains the
+"most-specific-grant-wins" logic when we flip this on.
+
+## Where this applies
+
+- `parachute-vault` — reference implementation + enforcement (PR #97).
+- `parachute-scribe` — scopes declared under `x-scopes` in the config
+  schema; enforcement follows once hub starts issuing JWTs. See scribe's
+  CLAUDE.md ("Scopes declared, not yet enforced").
+- `parachute-channel` — `channel:send` defined; enforcement tracking the
+  same JWT cutover.
+- `parachute-notes` — requests `vault:read vault:write scribe:transcribe`
+  on first-run OAuth consent.
+
+## Open questions
+
+- When does `scribe:admin ⊃ scribe:transcribe` land? Not today, by the
+  "exact-match for non-vault" rule. Likely when scribe grows a second
+  non-admin verb and the tree clearly forms.
+- Rotation / step-up story: a token granted `vault:read` requests
+  `vault:write` later via refresh flow, hub re-prompts. Specced in the
+  module-architecture design doc, not yet implemented.


### PR DESCRIPTION
Captures the three governance rules Aaron established at the start of post-launch operations on 2026-04-25:

1. No auto-merge (branch protection on 6 repos enforces this)
2. RC versioning before @latest (Option A — same RC artifact promoted via dist-tag)
3. Patterns check in every review

Companion to the propagation work happening in parallel across each repo's CLAUDE.md.