### PR TITLE
naming: refresh repo + bin tables to post-launch reality

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -13,16 +13,17 @@ entries on top. Each entry: date, change, affected repos, status.
 
 **Affected:**
 
-- `parachute-vault` — currently ships `parachute`; **rename to
-  `parachute-vault`** (pending). Blocks umbrella dispatch.
-- `parachute-scribe` — ships `scribe`; rename to `parachute-scribe`.
-- `parachute-narrate` — ships `narrate`; rename to `parachute-narrate`.
+- `parachute-vault` — renamed `parachute` → `parachute-vault` in
+  [#134](https://github.com/ParachuteComputer/parachute-vault/pull/134) (2026-04-21).
+- `parachute-scribe` — renamed `scribe` → `parachute-scribe` in
+  [#9](https://github.com/ParachuteComputer/parachute-scribe/pull/9) (2026-04-22).
+- `parachute-narrate` — not yet published; will ship as
+  `parachute-narrate` from day one.
 - `parachute-channel` — conformant (`parachute-channel`, `parachute-channel-bridge`).
 - `parachute-agents` — conformant (`parachute-agent`, `parachute-agent-ui`).
 - `tailshare` — exempt; not a Parachute-branded tool.
 
-**Status:** [DRAFT] — renames not yet executed. File per-repo issues to
-track each rename.
+**Status:** complete for shipped modules. Narrate to follow on first publish.
 
 ---
 

--- a/naming/bins.md
+++ b/naming/bins.md
@@ -17,18 +17,19 @@ First match on PATH wins (same as shell lookup). This means `parachute vault
 ...` works as soon as `@openparachute/vault` is installed anywhere on PATH,
 without the umbrella having to know about it at build time.
 
-See: [openparachute-cli/src/cli.ts](https://github.com/ParachuteComputer/openparachute-cli/blob/main/src/cli.ts).
+See: [parachute-cli/src/cli.ts](https://github.com/ParachuteComputer/parachute-cli/blob/main/src/cli.ts).
 
-## Current bins (state of the world, 2026-04-15)
+## Current bins (state of the world, 2026-04-25)
 
 | Package | Bin name | Status |
 |---|---|---|
 | `@openparachute/cli` | `parachute` | umbrella dispatcher |
-| `@openparachute/vault` | `parachute-vault` | **rename in flight** — currently ships `parachute` (collides with umbrella) |
+| `@openparachute/vault` | `parachute-vault` | conformant (renamed in [vault #134](https://github.com/ParachuteComputer/parachute-vault/pull/134)) |
+| `@openparachute/scribe` | `parachute-scribe` | conformant (renamed in [scribe #9](https://github.com/ParachuteComputer/parachute-scribe/pull/9)) |
+| `@openparachute/notes` | *(no bin)* | frontend; served by `parachute-cli`'s `notes-serve` shim, no own bin |
+| `@openparachute/channel` | `parachute-channel`, `parachute-channel-bridge` | conformant |
 | `@openparachute/agent` | `parachute-agent`, `parachute-agent-ui` | conformant |
-| `parachute-channel` | `parachute-channel`, `parachute-channel-bridge` | conformant |
-| `parachute-scribe` | `scribe` | **non-conformant** — should become `parachute-scribe` |
-| `parachute-narrate` | `narrate` | **non-conformant** — should become `parachute-narrate` |
+| `@openparachute/narrate` | `parachute-narrate` | planned; not yet published |
 | `tailshare` | `tailshare` | not a Parachute-branded tool; no rename planned |
 
 ## Why

--- a/naming/repos.md
+++ b/naming/repos.md
@@ -16,20 +16,24 @@ Examples:
 - `ParachuteComputer/parachute-agents` (plural repo, singular package `@openparachute/agent`)
 - `ParachuteComputer/parachute-daily`
 - `ParachuteComputer/parachute-scribe`
+- `ParachuteComputer/parachute-notes`
+- `ParachuteComputer/parachute-channel`
+- `ParachuteComputer/parachute-cli` — the umbrella; ships the `parachute` bin
 - `ParachuteComputer/parachute-patterns` (this repo)
-- `ParachuteComputer/openparachute-cli` — the umbrella, named after the npm scope since the repo is the CLI itself
+- `ParachuteComputer/parachute.computer` — the website (kept literal, matching
+  the domain)
 
 ## Why
 
 - One GitHub org surface for everything that makes up the Parachute Computer.
 - `parachute-` prefix makes the family obvious from a bare repo list.
-- Matching the filesystem layout under `~/UnforcedAGI/Code/ParachuteComputer/`
-  means repo-name == folder-name everywhere.
+- Matching the on-disk layout under `ParachuteComputer/<repo>` means
+  repo-name == folder-name everywhere.
 
 ## Rules
 
 - Repo name must match the folder checked out under
-  `~/UnforcedAGI/Code/ParachuteComputer/<repo>`. (Octopus tentacle spawn
+  `ParachuteComputer/<repo>` on the workstation. (Octopus tentacle spawn
   prompts rely on this.)
 - License: AGPL-3.0 by default, matching the family. If a module needs a
   different license, open an issue here first so we discuss it once rather
@@ -42,3 +46,7 @@ Examples:
 - Are there private or unreleased Parachute repos that should stay outside
   the `ParachuteComputer` org? Currently: UnforcedAGI is private but lives
   under a personal namespace. Decision not urgent.
+- The `ParachuteComputer/openparachute-cli` repo predated the
+  `parachute-` prefix decision; it's no longer the active CLI source
+  (active source is `parachute-cli`). Archive or redirect — tracked but
+  not urgent.


### PR DESCRIPTION
## Summary

Pure correctness repair on the naming docs. They were last touched 2026-04-15; the rename migrations they describe have since shipped.

- **`naming/repos.md`** — drop `openparachute-cli` (the umbrella is `parachute-cli` now); add the missing notes / channel / cli / site repos to the worked-example list; loosen the on-disk-layout rule from a user-specific `~/UnforcedAGI/Code/...` path (tentacles checkout in arbitrary locations).
- **`naming/bins.md`** — refresh the "current bins" table to 2026-04-25 reality: vault renamed (`parachute-vault` #134), scribe renamed (`parachute-scribe` #9), notes is a frontend (no own bin), narrate is planned-not-non-conformant; fix the upstream code link.
- **`adoption/migration-notes.md`** — close out the 2026-04-15 bin-rename entry; reflect that vault + scribe shipped, narrate is a future-not-pending item.

No new conventions. No design calls. No sibling-repo issues to file — the renames already happened.

## Patterns alignment

Per the new governance rule (`patterns/governance.md`, currently on `feat/governance-pattern`):

1. **Patterns touched:** `naming/repos.md`, `naming/bins.md`, `adoption/migration-notes.md`.
2. **Conforms?** Yes — pure stale-text repair to match shipped state.
3. **New patterns?** No.

## Test plan

- [ ] Render the three files on GitHub and confirm the tables read clean.
- [ ] Spot-check the upstream PR links resolve.
- [ ] Verify there's nothing in either file that contradicts the [governance.md](https://github.com/ParachuteComputer/parachute-patterns/blob/feat/governance-pattern/patterns/governance.md) draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)