### PR TITLE
patterns: add hub-as-issuer.md

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,39 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-04-26 — Hub is the OAuth issuer
+
+**Change:** the hub origin is the canonical OAuth issuer for the
+ecosystem. Vault still implements the OAuth endpoints, but advertises
+the hub as `issuer` (and stamps it into token `iss` claims) whenever
+the request reaches it via the hub origin. Falls back to the
+vault-local URL on direct loopback. See
+[`patterns/hub-as-issuer.md`](../patterns/hub-as-issuer.md); pairs
+with [`patterns/oauth-scopes.md`](../patterns/oauth-scopes.md).
+
+**Affected:**
+
+- `parachute-vault` — already implements the contract. Reference:
+  `resolveOAuthCoordinates` in `src/oauth.ts`, landed in
+  [#147](https://github.com/ParachuteComputer/parachute-vault/pull/147)
+  and refined in
+  [#152](https://github.com/ParachuteComputer/parachute-vault/pull/152).
+- `parachute-cli` (renaming to `parachute-hub` —
+  [cli#55](https://github.com/ParachuteComputer/parachute-cli/issues/55))
+  — derives the canonical hub origin in `src/hub-origin.ts` and passes
+  it through as `PARACHUTE_HUB_ORIGIN` on `expose up` / `start`.
+- `parachute-scribe`, `parachute-channel`, future modules — when they
+  begin OAuth enforcement, validate `iss` against the hub origin (not
+  their own URL). No code change needed before they implement OAuth.
+- Phase B2 cutover (hub becomes IdP itself) tracked in
+  [cli#58](https://github.com/ParachuteComputer/parachute-cli/issues/58)
+  and
+  [vault#169](https://github.com/ParachuteComputer/parachute-vault/issues/169).
+
+**Status:** Phase 0+1 complete on 2026-04-23. Phase B2 in design.
+
+---
+
 ## 2026-04-25 — CLI is the port authority at install time
 
 **Change:** `parachute install` now picks each service's port up front and

--- a/patterns/hub-as-issuer.md
+++ b/patterns/hub-as-issuer.md
@@ -1,0 +1,153 @@
+# Hub as OAuth issuer
+
+## Convention
+
+The Parachute ecosystem has **one OAuth issuer**: the hub origin. Every
+auth-capable module advertises the hub as `issuer` and accepts tokens
+that pin trust to the hub URL — not to the module's internal address.
+
+In Phase 0+1 (today), vault is the only module that runs OAuth
+endpoints. It still serves `/oauth/authorize`, `/oauth/token`,
+`/oauth/register`, and the discovery documents — but its `issuer`
+metadata is the hub origin whenever the client reached vault through
+the hub. The user-visible authority is always the hub; vault is the
+implementation behind it.
+
+## The two views
+
+The same vault process serves two legitimate issuer views concurrently:
+
+| Client reached vault via… | `issuer` it sees |
+|---|---|
+| The hub origin (`PARACHUTE_HUB_ORIGIN`, e.g. `https://you.tail-net.ts.net`) | The hub origin |
+| Direct loopback (`http://127.0.0.1:1940/vault/<name>`) | The vault-local URL |
+
+This is RFC 8414 compliant on both sides — the issuer always matches
+the origin the client is actually talking to. Discovery, token `iss`
+claims, and the service catalog returned with the token all stem from
+one resolver, so they can never disagree.
+
+Canonical implementation:
+[`parachute-vault/src/oauth.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/oauth.ts)
+(`resolveOAuthCoordinates`, `resolvePublicOrigin`). The hub origin is
+derived once by the CLI in
+[`parachute-cli/src/hub-origin.ts`](https://github.com/ParachuteComputer/parachute-cli/blob/main/src/hub-origin.ts)
+(`deriveHubOrigin`) and passed through to vault as `PARACHUTE_HUB_ORIGIN`
+on `expose up` / `start` (see
+[`parachute-cli/src/commands/expose.ts`](https://github.com/ParachuteComputer/parachute-cli/blob/main/src/commands/expose.ts)).
+
+## Why
+
+- **The front door owns identity.** Conflating "data service" with
+  "identity provider" couples them in ways that make extraction painful
+  later. Putting the issuer at the hub means vault, scribe, channel,
+  and every future module can stay narrowly scoped.
+- **One issuer for the user.** A user grants consent to "Parachute" at
+  one URL, not separately to vault, scribe, and channel. Tokens carry
+  scopes ([`oauth-scopes.md`](./oauth-scopes.md)) for every service in
+  the ecosystem, signed by the same issuer.
+- **Same shape local and remote.** A loopback dev install and a
+  tailnet-exposed install run the same code; only the hub origin
+  changes. Discovery, token `iss`, and refresh flows all follow.
+- **Clean extraction path.** Today vault's OAuth implementation powers
+  the issuer behind the scenes. When the hub grows its own IdP (Phase
+  B2 below), the user-visible URL doesn't change — clients keep using
+  the same `issuer`, and the implementation moves underneath them.
+
+## Status
+
+**Phase 0+1 (live, 2026-04-23):** vault implements all OAuth endpoints
+and discovery. When `PARACHUTE_HUB_ORIGIN` is set and the request
+arrives via that origin, vault advertises the hub as `issuer` and emits
+the hub URL in the `iss` claim of issued tokens. When unset (or when
+the request arrives via direct loopback), vault advertises itself as
+issuer at `http://127.0.0.1:1940/vault/<name>`. Same vault, two
+origin-consistent views.
+
+**Phase B2 (target, post-launch):** the hub becomes the IdP itself.
+Hub serves `/.well-known/oauth-authorization-server` and `/oauth/*`
+directly; vault becomes a pure resource server that validates
+hub-issued JWTs via JWKS. A small shared scope-guard library lives in
+[`parachute-patterns`](./oauth-scopes.md)'s upstream code home (TBD)
+so every module enforces the same scope semantics. Tracked in
+[`parachute-cli#58`](https://github.com/ParachuteComputer/parachute-cli/issues/58)
+and
+[`parachute-vault#169`](https://github.com/ParachuteComputer/parachute-vault/issues/169).
+
+The user-facing URL — and therefore the token's `iss` claim — does not
+change between Phase 1 and Phase B2. Only the implementation does.
+
+## Rules
+
+- **`issuer` matches the origin.** Whatever URL the client reached you
+  on, that origin is the issuer they see. Don't return a hard-coded
+  issuer from config; resolve it per request.
+- **Hub origin comes from `PARACHUTE_HUB_ORIGIN` (env).** Set by the
+  CLI on hub-fronted processes; absent on standalone runs. Don't
+  re-derive it inside services — read the env var.
+- **Tokens pin trust to the issuer URL.** Downstream services
+  validating a token compare `iss` against the hub origin they were
+  configured with. Never trust a token whose `iss` doesn't match the
+  expected issuer.
+- **Standalone fallback is intentional.** A vault running without a
+  hub advertises itself as issuer. Don't break this — it's how
+  developers without a tailnet still get a coherent OAuth surface.
+- **`authorization_servers` in protected-resource metadata points at
+  the issuer.** RFC 9728: the AS metadata locator is whatever the
+  client should trust as the issuer. Today vault hosts the AS metadata
+  document on its own origin even when the issuer is the hub — the
+  document still reports `issuer = hub`. See
+  [`well-known-discovery-rfc.md`](./well-known-discovery-rfc.md) (when
+  it lands) for the path-component subtleties.
+
+## Naming note
+
+The hub repo is currently named `parachute-cli`. A rename to
+`parachute-hub` is in flight
+([`parachute-cli#55`](https://github.com/ParachuteComputer/parachute-cli/issues/55))
+— "the CLI" is one surface of the hub, not its identity. Throughout
+this doc and going forward, use **hub** / **`parachute-hub`** for the
+role and the eventual repo name. Source links above point at the
+current repo path; they'll redirect after the rename.
+
+## Where this applies
+
+- **`parachute-vault`** — implements the issuer surface; honours
+  `PARACHUTE_HUB_ORIGIN`. Reference `resolveOAuthCoordinates` in
+  `src/oauth.ts`.
+- **`parachute-hub`** (`parachute-cli` today) — derives the canonical
+  hub origin once, passes it through to every service it spawns. See
+  `src/hub-origin.ts` + `src/commands/expose.ts`.
+- **`parachute-scribe`** — scopes declared, OAuth enforcement waiting
+  on Phase B2 (hub-issued JWTs validated via JWKS). No issuer surface
+  of its own.
+- **`parachute-notes` / future frontends** — perform OAuth against the
+  issuer URL (hub origin); never against a vault-local URL.
+
+## Open questions
+
+- **Multi-vault and scope narrowing.** A single hub fronts N vaults
+  today, each at `/vault/<name>`. The issuer is still the hub origin
+  for all of them; per-vault narrowing is a scope concern, not an
+  issuer concern. See `oauth-scopes.md` "Future: per-resource
+  narrowing".
+- **Token format at the Phase B2 cutover.** Today's tokens are opaque
+  `pvt_*` strings looked up by hash on the issuing vault. Phase B2 is
+  expected to switch to signed JWTs; the transition needs a bridge
+  period where both formats validate. Specced in the design doc, not
+  yet implemented.
+- **Refresh and step-up flows across modules.** A token granted
+  `vault:read` requesting `scribe:transcribe` later is conceptually one
+  hub re-prompt, but the dance touches every module. Designed in
+  [`design/2026-04-20-hub-as-portal-oauth-and-service-catalog.md`](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-04-20-hub-as-portal-oauth-and-service-catalog.md);
+  not yet implemented.
+
+## What's out of scope here
+
+- **Scope format and inheritance** — see [`oauth-scopes.md`](./oauth-scopes.md).
+- **Well-known metadata path math (RFC 8414 + RFC 9728)** — see
+  [`well-known-discovery-rfc.md`](./well-known-discovery-rfc.md) when
+  it lands.
+- **Service-to-service auth** (e.g. vault → scribe webhook) — see
+  [`service-to-service-auth.md`](./service-to-service-auth.md) when it
+  lands. That's a separate trust axis from user OAuth.


### PR DESCRIPTION
## Summary

- New pattern doc: the hub origin is the canonical OAuth issuer for the ecosystem.
- Documents the two issuer views (hub-origin → hub issuer; direct loopback → vault-local issuer) and the RFC 8414 grounding.
- Captures Phase 0+1 reality (live since 2026-04-23, vault implements endpoints + advertises hub as issuer) and the Phase B2 target (hub becomes IdP itself, vault becomes pure resource server validating JWTs via JWKS — tracked in [cli#58](https://github.com/ParachuteComputer/parachute-cli/issues/58) + [vault#169](https://github.com/ParachuteComputer/parachute-vault/issues/169)).
- Uses **parachute-hub** for the role/eventual repo name. The rename from `parachute-cli` is in flight ([cli#55](https://github.com/ParachuteComputer/parachute-cli/issues/55)); source links point at current repo paths and will redirect after the rename.
- `adoption/migration-notes.md`: 2026-04-26 entry.

## Why now

Sequence the team-lead asked for: `hub-as-issuer.md` → `well-known-discovery-rfc.md` → `service-to-service-auth.md`. This is the foundation the next two anchor against.

## Pattern alignment

- One pattern per file ✓
- One screen, links to upstream code (vault `src/oauth.ts:resolveOAuthCoordinates`, cli `src/hub-origin.ts`, cli `src/commands/expose.ts`) ✓
- Documents what's real (live), with a clearly-labeled forward-looking Phase B2 section ✓
- Cross-links to existing `oauth-scopes.md` and forward-references the not-yet-landed `well-known-discovery-rfc.md` + `service-to-service-auth.md` ✓

## Test plan

- [ ] Render the file on GitHub and confirm all links resolve (vault PR #147, #152; cli #55, #58; vault #169; design doc).
- [ ] Skim against `oauth-scopes.md` to confirm no contradictions on issuer semantics.
- [ ] Confirm `parachute-hub` naming usage matches `canonical-ports.md` conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)