### PR TITLE
patterns: bundle remaining patterns (9 docs)

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -71,6 +71,39 @@ not yet OAuth-enforcing.
 
 ---
 
+## 2026-04-26 — Module JSON extensibility (target convention)
+
+**Change:** new pattern doc
+[`patterns/module-json-extensibility.md`](../patterns/module-json-extensibility.md)
+— third-party modules declare themselves via a `.parachute/module.json`
+file shipped in the npm package; `name` / `manifestName` /
+`displayName` / `tagline` / `kind` / `port` / `paths` / `health` /
+`startCmd` / `scopes` / `dependencies`. **No `@openparachute/` scope or
+`parachute-*` prefix required** — the contract is what makes a module
+a Parachute module, not its name. **Status: target, not yet
+implemented in `parachute install`.** Today the CLI uses a hardcoded
+`SERVICE_SPECS` fallback — a first-party shortcut, not an
+architectural limit.
+
+**Affected:**
+
+- `parachute-cli` — needs the `module.json` reader / validator /
+  installer step before this is real. Tracked as Phase 3 work in the
+  design doc. Hardcoded `SERVICE_SPECS` retires (or shrinks to a
+  transitional fallback) when `module.json` lands.
+- `parachute-vault`, `parachute-notes`, `parachute-scribe`,
+  `parachute-channel` — when the convention lands, ship
+  `.parachute/module.json` matching what each currently asserts
+  through `SERVICE_SPECS`. No runtime change.
+- Third-party authors — the canonical shape, today, is in
+  [`parachute.computer/design/2026-04-20-module-architecture.md`](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-04-20-module-architecture.md)
+  (extensibility section). The pattern doc is the durable reference.
+
+**Status:** convention documented; CLI implementation deferred to
+Phase 3.
+
+---
+
 ## 2026-04-26 — Mount-path convention documented
 
 **Change:** new pattern doc

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -71,6 +71,32 @@ not yet OAuth-enforcing.
 
 ---
 
+## 2026-04-26 — Reviewer-agent convention documented
+
+**Change:** new pattern doc
+[`patterns/reviewer-agent.md`](../patterns/reviewer-agent.md). For PRs
+touching auth / scope / schema / public API / module-protocol /
+inter-service contracts, the team-lead runs a fresh-spawn `reviewer`
+agent against the diff before recommending merge. Convention, not
+enforcement; pairs with [`governance.md`](../patterns/governance.md)
+Rule 1 (every PR reviewed by a team-lead role and merged by a human).
+The reviewer agent's value is the fresh-context pass — both steward
+and team-lead are anchored to what they meant the change to do; a
+fresh agent reads the diff cold against named patterns / RFCs /
+surrounding code and surfaces the gap.
+
+**Affected:**
+
+- Team-lead / patterns steward — adopt the convention going forward;
+  cite reviewer findings in the verification summary.
+- Future PRs in the listed change-classes — should expect a reviewer
+  pass.
+
+**Status:** convention documented on 2026-04-26. Already in informal
+use during launch-week shipping; this writes it down.
+
+---
+
 ## 2026-04-26 — Module JSON extensibility (target convention)
 
 **Change:** new pattern doc

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -231,6 +231,35 @@ pair. Phase B2 in design.
 
 ---
 
+## 2026-04-26 — Writes require `if_updated_at` (or explicit `force: true`)
+
+**Change:** Parachute write APIs require an `if_updated_at`
+precondition by default; `force: true` is the explicit opt-out.
+Conflicts return a structured 409 (`error_type: "conflict"` +
+`current_updated_at` / `your_updated_at` / `path` / `note_id`);
+missing precondition returns a structured 428 (RFC 6585,
+`error_type: "precondition_required"`). Single-resource reads
+always include `updated_at` so the next write has a token. See
+[`patterns/optimistic-concurrency.md`](../patterns/optimistic-concurrency.md).
+
+**Affected:**
+
+- `parachute-vault` — reference implementation.
+  [#153](https://github.com/ParachuteComputer/parachute-vault/pull/153)
+  landed required `if_updated_at` + the structured conflict shape.
+  Both HTTP (`src/routes.ts`) and MCP (`src/mcp-http.ts`) tool
+  surfaces enforce identically.
+- `parachute-notes` — must forward `if_updated_at` from PWA edits to
+  vault writes; don't strip it. PWA's local store should hold the
+  last-seen `updated_at` per note.
+- Future API-surface modules — adopt the same shape on every mutating
+  endpoint over a database-backed resource. Pattern doc has the rules.
+
+**Status:** complete for vault on 2026-04-23 (PR #153). Notes adoption
+ongoing — confirm on next touch.
+
+---
+
 ## 2026-04-25 — CLI is the port authority at install time
 
 **Change:** `parachute install` now picks each service's port up front and

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -71,6 +71,34 @@ not yet OAuth-enforcing.
 
 ---
 
+## 2026-04-26 — Parallel cross-repo PRs documented
+
+**Change:** new pattern doc
+[`patterns/parallel-cross-repo-PRs.md`](../patterns/parallel-cross-repo-PRs.md).
+When a single conceptual change spans multiple Parachute repos, the
+team-lead briefs each steward in parallel and each steward opens its
+own PR independently. No master PR, no orchestration branch, no
+"merge X first" instructions. The composition is parallel-safe by
+design — additive contracts, backwards-compatible shape changes, or
+symmetric contracts that exist on both sides. Captures the shipping
+shape already used for OAuth Phase 0 (4 simultaneous PRs) and
+stateless-scribe.
+
+**Affected:**
+
+- Team-lead / patterns steward — adopt the convention going forward;
+  use it to scope multi-repo changes before briefing the stewards.
+- Tentacle stewards — each PR's description references the shared
+  design doc / brief note; no cross-PR coordination mid-flight.
+- Future ecosystem-wide changes — design parallel-safe scope first,
+  brief stewards in parallel second.
+
+**Status:** convention documented on 2026-04-26. Already in active
+use during launch-week shipping (OAuth Phase 0, stateless scribe);
+this writes it down.
+
+---
+
 ## 2026-04-26 — Reviewer-agent convention documented
 
 **Change:** new pattern doc

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -71,6 +71,44 @@ not yet OAuth-enforcing.
 
 ---
 
+## 2026-04-26 — Mount-path convention documented
+
+**Change:** new pattern doc
+[`patterns/mount-path-convention.md`](../patterns/mount-path-convention.md).
+Frontend modules are served at a subpath under the ecosystem origin
+(today: `/notes/`), declared once via Vite `base` and read by everyone
+through `import.meta.env.BASE_URL`. Three coordinated downstream
+consumers — Vite asset URLs, React Router `basename`, PWA manifest
+`scope` / `start_url` / `id`. Internal routes are mount-relative
+(`/n/:id`, not `/notes/n/:id`); the router's basename does the
+prefixing. OAuth redirect URIs read `BASE_URL` so the callback resolves
+under the deployed mount. Override knob: `VITE_BASE_PATH`.
+
+**Affected:**
+
+- `parachute-notes` — reference implementation, already conformant.
+  Refactor sequence: PR
+  [#49](https://github.com/ParachuteComputer/parachute-notes/pull/49)
+  (move `base` to `/notes`) → PR
+  [#50](https://github.com/ParachuteComputer/parachute-notes/pull/50)
+  (drop `/notes/` from internal routes) → PR
+  [#54](https://github.com/ParachuteComputer/parachute-notes/pull/54)
+  (deep-link shim for pre-refactor bookmarks). Architecture writeup at
+  the top of `parachute-notes/CLAUDE.md` already forward-references
+  this doc.
+- Future Parachute frontends (PWAs / SPAs) — adopt the same shape: pick
+  a stable slug, set Vite `base`, write mount-relative routes, mirror
+  the manifest. Hub catalog (`/.well-known/parachute.json`) auto-renders
+  any frontend module that publishes a `services.json` entry with
+  `kind: "frontend"`.
+- Third-party frontends — same contract. Standard SPA-under-subpath
+  hygiene; nothing Parachute-specific.
+
+**Status:** complete on 2026-04-26 for `parachute-notes`. Pattern doc
+captures live behavior; no service-side changes required.
+
+---
+
 ## 2026-04-25 — CLI is the port authority at install time
 
 **Change:** `parachute install` now picks each service's port up front and

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -260,6 +260,37 @@ ongoing — confirm on next touch.
 
 ---
 
+## 2026-04-26 — Context-in-payload pattern documented
+
+**Change:** new pattern doc
+[`patterns/context-in-payload.md`](../patterns/context-in-payload.md). The
+provider pre-fetches narrowly-scoped context (a few dozen names) and ships
+it inline in the trigger payload — multipart `context` part for attachment
+sends, top-level `context: {...}` field for JSON sends. The consumer is
+stateless: parses tolerantly and never calls back into the provider. Empty
+payload → no part attached. Reference pair: `parachute-vault` →
+`parachute-scribe` for transcription proper-noun correction (vault
+[#156](https://github.com/ParachuteComputer/parachute-vault/pull/156)).
+
+**Affected:**
+
+- `parachute-vault` — already conformant. `src/context.ts`
+  (`fetchContextEntries`, `appendContextPart`) implements the provider
+  side; trigger config exposes `include_context` (predicate list with
+  `tag` / `exclude_tag` / `include_metadata`).
+- `parachute-scribe` — already conformant. `src/context.ts`
+  (`parseContextPayload`, `buildProperNounsBlockFromEntries`) implements
+  the tolerant consumer side.
+- Future modules taking context-relevant free-text (cleanup, summarization,
+  classification) — adopt the same `entries[]` shape on receive. Future
+  context-providing modules — emit the exact same shape, do not fork into a
+  per-provider schema.
+
+**Status:** complete on 2026-04-26. Pattern doc captures live behavior; no
+service-side changes required.
+
+---
+
 ## 2026-04-25 — CLI is the port authority at install time
 
 **Change:** `parachute install` now picks each service's port up front and

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -196,6 +196,41 @@ captures live behavior; no service-side changes required.
 
 ---
 
+## 2026-04-26 — Service-to-service auth is a single-validator seam
+
+**Change:** inter-service calls (vault → scribe today; future pairs
+later) authenticate via a bearer token validated by a single
+function on the callee — `validateToken(token) → {valid, scopes}`.
+The CLI mints the secret on install and writes it to both ends. The
+upgrade path to hub-issued JWTs in Phase B2 is a body-swap of that
+one function; callers and callees don't change. See
+[`patterns/service-to-service-auth.md`](../patterns/service-to-service-auth.md);
+pairs with [`patterns/hub-as-issuer.md`](../patterns/hub-as-issuer.md)
+and [`patterns/oauth-scopes.md`](../patterns/oauth-scopes.md).
+
+**Affected:**
+
+- `parachute-cli` — already implements the trust broker in
+  `src/auto-wire.ts` (mints `SCRIBE_AUTH_TOKEN`, writes to vault `.env`
+  and scribe `config.json`, idempotent, restarts vault). No code
+  change needed; pattern documents what's there.
+- `parachute-scribe` — already implements the validator seam in
+  `src/auth.ts`. Returns scopes-on-success even on the shared-secret
+  path so the JWT swap is callable-compatible.
+- `parachute-vault` — caller-side resolver in `src/scribe-env.ts`
+  handles canonical `SCRIBE_AUTH_TOKEN` + deprecated `SCRIBE_TOKEN`
+  with a one-shot warning.
+- Phase B2 cutover (`validateToken` body becomes JWT verify; shared
+  scope-guard library) tracked in
+  [cli#59](https://github.com/ParachuteComputer/parachute-cli/issues/59).
+- Future inter-service pairs — declare the env var name in
+  `.parachute/module.json` and `auto-wire` provisions on install.
+
+**Status:** Phase 0+1 complete on 2026-04-23 for the vault↔scribe
+pair. Phase B2 in design.
+
+---
+
 ## 2026-04-25 — CLI is the port authority at install time
 
 **Change:** `parachute install` now picks each service's port up front and

--- a/patterns/context-in-payload.md
+++ b/patterns/context-in-payload.md
@@ -1,0 +1,181 @@
+# Context in payload
+
+## Convention
+
+When one Parachute service triggers another and the receiving service
+needs *contextual* knowledge (e.g. "who are the people the speaker
+typically talks about?"), the **provider** pre-fetches that context
+and ships it **inline in the payload**. The **consumer** is stateless
+with respect to it — the consumer never calls back into the provider
+to look anything up.
+
+The reference example: vault → scribe transcription. Vault knows the
+speaker's people / projects / aliases. Vault attaches a `context.json`
+part to the audio upload. Scribe uses it as-is for proper-noun
+correction in cleanup, then forgets about it.
+
+## Why
+
+- **No backchannel.** A consumer that calls back into the provider
+  during request handling creates an inverted dependency, an extra
+  round-trip per request, and a credential-management problem on
+  the consumer side. Sending context inline collapses all three.
+- **Stateless consumers.** Scribe doesn't know what a "vault" is.
+  Future consumers (transcription from a microphone app, from a phone
+  recording, from a browser extension) ship the same shape from
+  whatever source they have. The receiver doesn't care where the
+  entries came from.
+- **Provider owns the predicate.** The provider (which has the data)
+  decides what's relevant — by tag, by metadata whitelist, by recency
+  if it grows that knob — and never exposes its query language to the
+  consumer.
+- **Caller-agnostic shape.** The shape is dumb on purpose:
+  `{entries: [{name, ...whitelisted_fields}]}`. A receiver written
+  for vault works for any future provider that emits the same shape.
+
+## Shape
+
+### What the provider sends
+
+```json
+{
+  "entries": [
+    { "name": "Margaret",         "summary": "Close friend",   "aliases": ["Marg"] },
+    { "name": "Learn Vibe Build", "summary": "6-week cohort",  "aliases": ["LVB", "Learn by Build"] }
+  ]
+}
+```
+
+- `name` (required) — canonical display form, typically the source's
+  basename (a note path's filename without extension, in vault's case).
+- Other fields — whitelisted metadata carried through unchanged. The
+  consumer treats these as opaque strings/values; only `name` has
+  cross-service semantic meaning.
+
+### How the provider attaches it
+
+Multipart: a `context` part with `content-type: application/json`.
+
+```ts
+form.append(
+  "context",
+  new Blob([JSON.stringify(payload)], { type: "application/json" }),
+  "context.json",
+);
+```
+
+JSON-bodied requests inline `context: {...}` as a top-level field.
+Trigger config in vault selects either shape via
+`send: "attachment" | "json"`.
+
+Empty payload → **no part attached**. Don't send a zero-entries part
+the receiver would have to special-case.
+
+Reference:
+[`parachute-vault/src/context.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/context.ts)
+(`fetchContextEntries`, `appendContextPart`).
+
+### Provider predicate config
+
+The provider's user-facing config picks what to include. Vault's
+shape (in `vault.yaml` / trigger `action.include_context`):
+
+```yaml
+include_context:
+  - tag: person
+    exclude_tag: archived
+    include_metadata: [summary, aliases]
+  - tag: project
+    include_metadata: [summary, aliases]
+```
+
+Each predicate is a query (scoped by `tag`, optionally excluding
+`exclude_tag`) plus a metadata-key whitelist. Fields not in
+`include_metadata` are dropped before send.
+
+### How the consumer parses it
+
+Tolerant parser. Malformed payload → log + fall through to "no
+context", **not** 400 the whole request.
+
+```ts
+// parachute-scribe/src/context.ts
+export function parseContextPayload(raw: unknown): ContextPayload | null {
+  // Accepts string OR pre-parsed object; null on malformed.
+  // Filters entries that lack a non-empty `name`.
+}
+```
+
+Reference:
+[`parachute-scribe/src/context.ts`](https://github.com/ParachuteComputer/parachute-scribe/blob/main/src/context.ts)
+(`parseContextPayload`, `buildProperNounsBlockFromEntries`).
+
+The consumer's job once parsed is shape-driven, not provider-aware.
+Scribe renders entries into a "Known names in this context" prompt
+block; a different consumer would render them differently. The
+provider doesn't try to format for the consumer.
+
+## Rules
+
+- **Provider pre-fetches; consumer never calls back.** This is the
+  core invariant. A consumer that reaches into the provider is
+  outside the pattern — refactor or document why.
+- **Empty payload → no part / no field.** Don't send `{entries: []}`.
+  Don't send a multipart part with `null`. Absence is the empty case.
+- **`name` is required, everything else is whitelisted opaque.**
+  Adding a new field is allowed (consumers ignore unknown keys);
+  removing or renaming `name` is a breaking change.
+- **Provider config controls what's sent.** Don't bake "always send
+  people + projects" into provider code. The trigger / worker config
+  declares predicates explicitly so the operator can see it.
+- **Consumer parser is tolerant.** Malformed entries are dropped; a
+  malformed payload as a whole produces "no context" rather than a
+  request failure. Transcription should not fail because some unrelated
+  metadata key contained bad UTF-8.
+- **Same shape across providers.** Whatever ships next as a
+  context-providing service must ship the *exact* same JSON shape.
+  Don't fork "vault context" into a vault-specific schema; the
+  shape is the contract.
+
+## Where this applies
+
+- **`parachute-vault` → `parachute-scribe`** — reference pair. Vault
+  PR
+  [#156](https://github.com/ParachuteComputer/parachute-vault/pull/156)
+  ("feat(scribe): vault is now the context provider for
+  transcription"). Trigger config supports `include_context`; the
+  transcription worker reads `transcription.context` from `vault.yaml`
+  and includes the same payload.
+- **`parachute-scribe`** — implements the consumer side. Knows
+  nothing about vault. Any future module sending audio with a
+  `context` part gets the same proper-noun-correction behavior.
+- **Future modules** — any service that takes context-relevant
+  free-text (cleanup, summarization, classification, retrieval) is a
+  candidate consumer. Adopt the same `entries[]` shape; let any
+  context-providing module front it.
+
+## What this isn't
+
+- **A general-purpose retrieval API.** This pattern carries
+  pre-selected, narrowly-scoped entries (a few dozen names, not a
+  whole vault). For arbitrary retrieval, use MCP — the consumer
+  becomes an MCP client and pulls what it needs, with auth.
+- **An auth or trust mechanism.** The context payload is in the
+  request body, alongside the actual workload. It piggybacks on
+  whatever inter-service auth (`service-to-service-auth.md`)
+  already protects the request.
+
+## Open questions
+
+- **Versioning.** Today there's no `version` field on the payload —
+  shape is "v1 forever." If/when a v2 lands (e.g. typed entries,
+  embedding vectors), we'll need a discriminator. Defer until the
+  second shape is real.
+- **Size limits.** No explicit cap today. A 500-entry vault is fine
+  on loopback; 50,000-entry would be a problem. Provider-side
+  predicates are the throttle for now (operators choose narrow tags).
+  A future hard cap with truncation order may be needed.
+- **Ordering / ranking.** Today predicates run in declaration order;
+  duplicates dedupe by first match. No relevance scoring. If consumers
+  start to care (most-recent-first, query-similarity-first), the
+  predicate shape grows.

--- a/patterns/mcp-transport.md
+++ b/patterns/mcp-transport.md
@@ -2,13 +2,21 @@
 
 ## Convention
 
-Parachute-hosted MCP servers speak **Streamable HTTP** at `<base>/mcp` and
-authenticate via bearer tokens over `Authorization: Bearer <pvt_...>`.
+Parachute-hosted MCP servers speak **Streamable HTTP** at `<base>/mcp`
+and authenticate via OAuth bearer tokens (or `pvt_*` PATs) over
+`Authorization: Bearer <token>`. The OAuth bearer path is the
+agent-and-service default; `pvt_*` is the user-facing PAT — see
+[`token-auth.md`](./token-auth.md).
 
 - Canonical example: `parachute-vault` serves its MCP at `<vault-url>/mcp`.
 - Clients: agents in `@openparachute/agent` connect via
   `@modelcontextprotocol/sdk` + the Streamable HTTP transport. Source:
   [parachute-agents/src/vault.ts](https://github.com/ParachuteComputer/parachute-agents/blob/main/src/vault.ts).
+- OAuth-aware clients discover the token endpoint via RFC 8414
+  metadata at `<origin>/.well-known/oauth-authorization-server[/<path>]`
+  — see [`well-known-discovery-rfc.md`](./well-known-discovery-rfc.md)
+  for the path-insertion shape and [`hub-as-issuer.md`](./hub-as-issuer.md)
+  for which origin the `iss` claim points to.
 
 ## Why Streamable HTTP (not SSE)
 
@@ -47,9 +55,17 @@ mcp:
     scope: "read write"
 ```
 
-Runs the RFC 6749 `client_credentials` grant and caches the access token
-per-server. PKCE, authorization_code, and refresh_token flows are out of
-scope until an agent actually needs one.
+Runs the RFC 6749 `client_credentials` grant and caches the access
+token per-server. PKCE, authorization_code, and refresh_token flows
+are out of scope until an agent actually needs one.
+
+`token_url` may be omitted — clients that implement RFC 8414 discovery
+will GET `<origin>/.well-known/oauth-authorization-server[/<issuer-
+path>]` against the MCP `url`'s origin, read the advertised
+`token_endpoint`, and proceed. See
+[`well-known-discovery-rfc.md`](./well-known-discovery-rfc.md). Static
+`token_url` remains the explicit override when an author wants to pin
+the endpoint or skip discovery.
 
 ## Rules
 

--- a/patterns/module-json-extensibility.md
+++ b/patterns/module-json-extensibility.md
@@ -1,0 +1,171 @@
+# Module JSON extensibility
+
+> **Status: target convention, partial implementation.** The shape is
+> declared in
+> [`parachute.computer/design/2026-04-20-module-architecture.md`](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-04-20-module-architecture.md#extensibility-path)
+> and committed to as the third-party path. The CLI's
+> `parachute install` does not yet read `.parachute/module.json` —
+> today it falls back to a hardcoded `SERVICE_SPECS` table in
+> [`parachute-cli/src/service-spec.ts`](https://github.com/ParachuteComputer/parachute-cli/blob/main/src/service-spec.ts).
+> That hardcoding is a **first-party shortcut, not an architectural
+> limit**. This pattern doc nails the contract so third-party authors
+> and the eventual CLI implementation agree on the shape.
+
+## Convention
+
+A Parachute module is identified by its **contracts**, not by its
+package name. A third-party module declares itself by shipping a
+`.parachute/module.json` file in the published npm package; the CLI
+reads it on `parachute install <package>` and treats the package as
+first-class. **No `@openparachute/` scope, no `parachute-*` prefix
+required.**
+
+The `module.json` is the canonical, machine-readable self-description.
+Everything the CLI needs to install and run the module — and
+everything the hub needs to render and route to it — lives in this
+one file the author controls.
+
+## Shape
+
+```json
+{
+  "name": "my-service",
+  "manifestName": "my-service",
+  "displayName": "My Service",
+  "tagline": "What the service does",
+  "kind": "api",
+  "port": 7001,
+  "paths": ["/my-service"],
+  "health": "/health",
+  "startCmd": ["bin/my-service", "serve"],
+  "scopes": { "defines": ["my-service:read", "my-service:write"] },
+  "dependencies": {
+    "vault": { "optional": true, "scopes": ["vault:read"] }
+  }
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `name` | Stable, unique identifier across the ecosystem. Becomes the `services.json` key, the scope namespace, the `parachute start <name>` token. Must match `[a-z][a-z0-9-]*`. |
+| `manifestName` | The name used in user-facing manifests (PWA / OAuth client name). Often equals `name`. |
+| `displayName` | Human label rendered on the hub card. |
+| `tagline` | One-line description rendered under `displayName`. |
+| `kind` | One of `"api" \| "frontend" \| "tool"`. Hub picks card vs. iframe vs. launcher. |
+| `port` | Default loopback port. Pick outside the reserved Parachute range (`1939–1949`) — see [`canonical-ports.md`](./canonical-ports.md). The CLI warns on collision but does not block. |
+| `paths` | URL paths the module serves under the hub origin. |
+| `health` | Path for liveness probes. |
+| `startCmd` | Argv the CLI invokes for `parachute start <name>`. Resolved relative to the installed package. |
+| `scopes.defines` | OAuth scopes the module owns. Namespaced by `name` so collisions don't happen — see [`oauth-scopes.md`](./oauth-scopes.md). |
+| `dependencies` | Other modules this one wants to talk to. Each entry has `optional` and `scopes` fields; CLI uses these to auto-wire on install (env-var injection) — see [`service-to-service-auth.md`](./service-to-service-auth.md). |
+
+## Why this shape
+
+- **Author-controlled.** The package author declares everything in one
+  file in their published artifact. No central registry, no PR against
+  Parachute repos, no naming approval.
+- **Caller-agnostic to the CLI.** First-party and third-party modules
+  go through the same `module.json` path. The first-party
+  `SERVICE_SPECS` table is a transitional shortcut.
+- **Hub doesn't inspect names.** A `services.json` entry written from
+  any `module.json` renders identically to first-party entries. The
+  hub already treats any conformant entry as first-class — see
+  [`module-protocol.md`](./module-protocol.md).
+- **Scope namespace = module name.** No central registry of scope
+  names. A `my-service` module owns `my-service:*`. Names are unique
+  across the ecosystem because `services.json` keys are unique.
+- **Composable with auto-wiring.** The `dependencies` block is what
+  makes `parachute install <module>` able to mint a token (today: a
+  shared secret; Phase B2: a JWT) and inject it into both ends —
+  callee gets the validator material, caller gets the credential —
+  without the user manually copying anything.
+
+## How the CLI consumes it (target)
+
+`parachute install <package>` will run:
+
+1. `bun add -g <package>` — standard npm install. No naming constraint.
+2. Read `<package>/.parachute/module.json` from the installed artifact.
+3. Validate against the module-manifest schema. Reject malformed
+   modules early.
+4. Write a `services.json` entry using the declared `name`, `port`,
+   `paths`, `health`, `displayName`, `tagline`, `kind`.
+5. Register `startCmd` so `parachute start <name>` knows what to spawn.
+6. For each `dependencies` entry, run `auto-wire` (mints credential,
+   writes both ends, idempotent) — same machinery the vault↔scribe
+   pair already uses. See
+   [`service-to-service-auth.md`](./service-to-service-auth.md).
+
+The first-party `SERVICE_SPECS` record stays as a fallback for
+packages that pre-date the convention, then retires.
+
+## Rules
+
+- **`name` is the unique identifier.** Reuse of `name` across packages
+  is a conflict — `services.json` keys must be unique. CLI fails the
+  install if `name` collides with an existing entry.
+- **`name` is the scope namespace.** A module declaring
+  `defines: ["foo:read"]` must have `name: "foo"`. Otherwise a third
+  party could squat scopes the user already trusts for a different
+  module.
+- **Port outside the reserved range when you can.** The Parachute
+  range `1939–1949` is for first-party modules. Third-parties pick
+  outside; the CLI warns but does not block.
+- **`startCmd` must be argv, not a shell string.** Avoids
+  shell-injection weirdness when users have spaces in package paths.
+- **`module.json` is shipped in the npm artifact.** Not in
+  `.gitignore`, not generated at install time. The CLI reads it
+  post-install from the installed package directory.
+- **Don't mutate the caller's `module.json` at install time.** If the
+  CLI needs install-time state (assigned port, generated secret), it
+  goes in `~/.parachute/<name>/.env` (see
+  [`cli-as-port-authority.md`](./cli-as-port-authority.md)), not in
+  the package's source.
+
+## What this isn't
+
+- **A package-naming convention.** First-party packages happen to use
+  `parachute-*` (see [`naming/bins.md`](../naming/bins.md)) but the
+  ecosystem doesn't require it. `module.json` is what makes a package
+  a Parachute module.
+- **A registry.** There is no central index of installed third-party
+  modules. Discovery is per-machine via `~/.parachute/services.json`,
+  exactly like first-party modules.
+- **A trust mechanism.** `module.json` makes a package
+  *Parachute-compatible*; it doesn't make it trusted. Users still
+  decide what to install. The hub-as-OAuth-issuer architecture is
+  what gates capability grants; see
+  [`hub-as-issuer.md`](./hub-as-issuer.md).
+
+## Where this applies
+
+- **Today:** first-party modules (vault, notes, scribe, channel) are
+  hardcoded in `parachute-cli/src/service-spec.ts`. The shape lives in
+  `PORT_RESERVATIONS` + `SERVICE_SPECS` and is functionally a
+  pre-`module.json` ancestor.
+- **Tomorrow (target):** every module — first-party and third-party —
+  ships its own `module.json`. The CLI reads it; the hardcoded
+  `SERVICE_SPECS` table goes away or shrinks to a transitional
+  fallback.
+- **Reference for authors:** the design doc at
+  [`parachute.computer/design/2026-04-20-module-architecture.md`](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-04-20-module-architecture.md)
+  is the live shape until this pattern doc and the CLI implementation
+  catch up.
+
+## Open questions
+
+- **Schema location.** Do we publish a JSON Schema for `module.json`
+  (e.g. `https://parachute.computer/schemas/module.json/v1`)?
+  Defer until the validator is being written — premature otherwise.
+- **Versioning.** Today there's no `version` field on `module.json`
+  itself (separate from the package's `version`). If/when the shape
+  evolves breakingly, we'll need a `manifestVersion: 1` discriminator.
+  Defer until a v2 shape is real.
+- **Capabilities.** The richer `manifest` shape in the design doc has
+  `capabilities`, `iconUrl`, `endpoints` etc. Today most of those
+  duplicate what `/.parachute/info` already exposes at runtime.
+  `module.json` is install-time; runtime metadata stays at
+  `/.parachute/info` (see [`module-protocol.md`](./module-protocol.md)).
+  The boundary is "what the CLI needs to install and route" lives in
+  `module.json`; "what the hub fetches every render" stays at
+  `/.parachute/info`.

--- a/patterns/mount-path-convention.md
+++ b/patterns/mount-path-convention.md
@@ -1,0 +1,207 @@
+# Mount-path convention
+
+## Convention
+
+Every Parachute frontend module is served at a **subpath** under the
+ecosystem origin (today: `/notes/`). The mount path is set in **one
+place** — Vite's `base` — and every consumer of it reads through
+`import.meta.env.BASE_URL`. Internal routes are written as if the app
+sat at the origin root; the framework strips the prefix on read and
+prepends it on write.
+
+This is what lets the hub at `1939` proxy multiple frontends side-by-side
+under one origin, lets `parachute expose` produce one public URL, and
+lets a frontend move to a different mount with a one-line change.
+
+## Single source, three downstream consumers
+
+The mount path is declared in `vite.config.ts` (`base: basePath`,
+overrideable via `VITE_BASE_PATH`). Vite injects it into the bundle as
+`import.meta.env.BASE_URL`. Three things read it:
+
+1. **Vite `base`** — asset URLs, service-worker scope, anything Vite
+   itself emits. Build-time concern.
+2. **`BrowserRouter` basename** — strips the prefix from the URL before
+   matching, prepends it on `<Link>` writes. Runtime concern.
+3. **PWA manifest `id` / `scope` / `start_url`** — installed PWA must
+   launch under the deployed mount, not at `/`.
+
+```ts
+// parachute-notes/vite.config.ts
+const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/notes");
+
+export default defineConfig({
+  base: basePath,                      // (1)
+  plugins: [
+    VitePWA({ manifest: buildPwaManifest(basePath), ... }),  // (3)
+  ],
+});
+
+// parachute-notes/src/app/App.tsx
+<BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, "") || undefined}>
+  <Routes>
+    <Route path="/" element={<NotesIndex />} />
+    <Route path="/n/:id" element={<NoteView />} />
+    {/* ...mount-relative paths only — no `/notes/` prefix */}
+  </Routes>
+</BrowserRouter>
+```
+
+## Internal routes are mount-relative
+
+This is the load-bearing simplification, established in
+[`parachute-notes#50`](https://github.com/ParachuteComputer/parachute-notes/pull/50).
+Routes inside the app drop the mount prefix:
+
+```ts
+<Route path="/n/:id" element={<NoteView />} />          // not "/notes/n/:id"
+<Route path="/oauth/callback" element={<OAuthCallback />} />
+```
+
+Reasoning: `BrowserRouter`'s `basename` already strips and prepends the
+prefix at the URL boundary. Putting `/notes/` inside the `path` props
+double-stacks the prefix and forces a route-by-route search-and-replace
+every time the mount moves. With mount-relative routes, **moving from
+`/notes/` to `/foo/` is a single env-var change.**
+
+The base-path test in `parachute-notes/src/base-url.test.ts` pins the
+production default to catch unintentional drift.
+
+## OAuth callback paths use `BASE_URL`
+
+OAuth redirect URIs are constructed against the deployed mount, not the
+origin root. The auth server registers `${origin}/notes/oauth/callback`
+and bounces the browser back to that exact URL.
+
+```ts
+// parachute-notes/src/lib/vault/oauth.ts
+function basePathPrefix(): string {
+  const b = import.meta.env.BASE_URL ?? "/";
+  return b.replace(/\/$/, "");
+}
+
+export function redirectUriForOrigin(origin = window.location.origin): string {
+  return `${origin.replace(/\/$/, "")}${basePathPrefix()}/oauth/callback`;
+}
+```
+
+If the redirect URI hardcoded `/oauth/callback`, a moved-or-aliased
+mount would 404 the OAuth bounce. Reading `BASE_URL` keeps the redirect
+URI in lockstep with the mount.
+
+## PWA manifest mirrors the mount
+
+```ts
+// parachute-notes/src/pwa-manifest.ts
+export function buildPwaManifest(base = "/"): Partial<ManifestOptions> {
+  const normalized = base.endsWith("/") ? base : `${base}/`;
+  return {
+    id: normalized,
+    start_url: normalized,
+    scope: normalized,
+    icons: [{ src: "pwa-192x192.png", ... }],  // bare (no leading "/")
+    ...
+  };
+}
+```
+
+Two non-obvious calls baked in:
+
+- **`scope` and `start_url` must end in `/`.** A scope of `/notes`
+  (no trailing slash) does not match `/notes/`, breaking installed-PWA
+  launch.
+- **Manifest icon `src` values are bare** (`pwa-192x192.png`, not
+  `/pwa-192x192.png`). They resolve relative to the manifest URL, which
+  itself sits under the mount. Adding a leading slash strands them at
+  the origin root and 404s the icon.
+
+## The override knob
+
+`VITE_BASE_PATH` env var, defaulting to the canonical mount path. Two
+real uses:
+
+- **`VITE_BASE_PATH=/`** — legacy stand-alone shape (dev-server case
+  where you want the app at the origin root, not under a hub mount).
+- **Multi-instance deployments** — a fork serving Notes at `/foo/`
+  alongside the canonical `/notes/`.
+
+Defaulting in `vite.config.ts` means dev / build / `parachute start
+notes` all agree without explicit env-var setting.
+
+## Deep-link shim for pre-refactor bookmarks
+
+When Notes moved from `/<id>` (origin-root era) to `/notes/n/<id>`
+(mount-aware era), pre-refactor bookmarks would land at internal `/<id>`
+after the prefix-strip and bounce to `/`. The fix: a shim route that
+redirects internal `/:id` → canonical `/n/:id`. See
+[`parachute-notes#54`](https://github.com/ParachuteComputer/parachute-notes/pull/54)
+and the `NoteIdRedirect` component in `App.tsx`.
+
+This is mount-specific scaffolding — only relevant when you change the
+internal route shape after users already have bookmarks.
+
+## Rules
+
+- **Declare the mount once.** `vite.config.ts`'s `base` is the single
+  source. Don't hardcode `/notes/` anywhere else; read
+  `import.meta.env.BASE_URL`.
+- **Internal routes are mount-relative.** `path="/foo"`, never
+  `path="/notes/foo"`. The router's `basename` does the prefixing.
+- **`scope` / `start_url` end in `/`.** Manifest icons stay bare. The
+  test in `pwa-manifest.test.ts` covers this.
+- **OAuth redirect URIs read `BASE_URL`.** Never hardcode the callback
+  path.
+- **The mount path is the route slug, not the package name.** `Notes`
+  is `parachute-notes` the package, mounted at `/notes/`. Future
+  modules: pick a short, stable slug; the package-name boundary is
+  separate.
+- **Pin the production default in a test.** `parachute-notes/src/base-url.test.ts`
+  asserts `BASE_URL === "/notes/"` so accidental drift in
+  `vite.config.ts` or `vitest.config.ts` fails CI.
+
+## Where this applies
+
+- **`parachute-notes`** — reference implementation. Mount: `/notes/`.
+  Refactor that established the pattern: PR
+  [#49](https://github.com/ParachuteComputer/parachute-notes/pull/49)
+  (move base to `/notes`) → PR
+  [#50](https://github.com/ParachuteComputer/parachute-notes/pull/50)
+  (drop `/notes/` from internal routes) → PR
+  [#54](https://github.com/ParachuteComputer/parachute-notes/pull/54)
+  (deep-link shim for legacy bookmarks). The full architecture writeup
+  lives in
+  [`parachute-notes/CLAUDE.md`](https://github.com/ParachuteComputer/parachute-notes/blob/main/CLAUDE.md)
+  ("Mount-path architecture").
+- **Future Parachute frontends (PWAs and SPAs)** — same shape. Pick a
+  slug, set `base`, write mount-relative routes, mirror the manifest.
+  The hub catalog (`/.well-known/parachute.json`, see
+  [`module-protocol.md`](./module-protocol.md)) auto-renders any
+  frontend module that publishes a `services.json` entry with
+  `kind: "frontend"`.
+- **Third-party frontends** — same contract. There's nothing
+  Parachute-specific in the convention; it's standard SPA-under-subpath
+  hygiene that Parachute's hub-as-front-door composition pins.
+
+## What this isn't
+
+- **A backend mount convention.** API services already get a mount via
+  the multi-tenant path shape (`/vault/<name>/`); that's a different
+  pattern (see [`module-protocol.md`](./module-protocol.md)). This file
+  is specifically about frontend bundles and the three Vite + Router +
+  PWA places that have to agree.
+- **A routing-library opinion.** The convention is "internal routes are
+  mount-relative"; whether you use React Router, TanStack Router, or
+  vanilla `URL` math is up to the module. The Notes reference happens to
+  use React Router v7.
+
+## Open questions
+
+- **Server-rendered frontends.** Today every Parachute frontend is a
+  client-rendered SPA with a single Vite bundle. If a future module
+  ships SSR (Next, Remix, Astro), the "Vite `base` is the single source"
+  shape needs a parallel: SSR frameworks have their own `basePath` /
+  `app.basePath` knob that has to read the same env var.
+- **Cross-frontend deep links.** Today each frontend handles its own
+  routes; there's no convention for `notes-app` linking to a path inside
+  `lens-app` other than full-URL construction. If/when that becomes a
+  pattern, this doc grows a section.

--- a/patterns/optimistic-concurrency.md
+++ b/patterns/optimistic-concurrency.md
@@ -1,0 +1,154 @@
+# Optimistic concurrency
+
+## Convention
+
+Every Parachute write API requires the caller to present the
+**last-seen `updated_at` timestamp** of the resource it's modifying.
+The server compares it against the live row and refuses the write if
+they differ. The caller can opt out explicitly with `force: true` —
+the only way to clobber, never the default.
+
+This protects against the lost-update race that's the default failure
+mode when N agents (or N tabs, or one agent + a sync worker) write to
+the same note concurrently.
+
+## Shape
+
+### Request
+
+```jsonc
+{
+  "content": "...",
+  "if_updated_at": "2026-04-21T17:33:08.412Z",  // required by default
+  "force": true                                   // explicit opt-out (overrides if_updated_at)
+}
+```
+
+### Responses
+
+**409 Conflict** — caller's `if_updated_at` doesn't match the live row.
+
+```jsonc
+{
+  "error_type": "conflict",
+  "current_updated_at": "2026-04-21T17:35:11.207Z",
+  "your_updated_at":    "2026-04-21T17:33:08.412Z",
+  "path":   "projects/launch.md",
+  "note_id": "01J9Z2K3...",
+  "message": "..."
+}
+```
+
+**428 Precondition Required** (RFC 6585) — caller sent neither
+`if_updated_at` nor `force: true`.
+
+```jsonc
+{
+  "error_type": "precondition_required",
+  "note_id": "01J9Z2K3...",
+  "path":   "projects/launch.md",
+  "message": "update requires `if_updated_at` (the note's last-seen updated_at) or `force: true`."
+}
+```
+
+The two status codes are deliberately differentiated — `428` is
+"you didn't try", `409` is "you tried and lost the race". An agent
+should react differently to each.
+
+### Reads always return `updated_at`
+
+Every single-resource response includes `updated_at`, falling back to
+`created_at` if the resource has never been updated. `create-note`
+returns `updated_at` on the freshly-created note so the next write
+already has a token. There is no path through the API where a caller
+could end up holding a resource without a precondition value.
+
+Canonical implementation:
+[`parachute-vault/src/routes.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/routes.ts)
+(write handlers, lines ~418–525) +
+[`parachute-vault/src/mcp-http.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/mcp-http.ts)
+(MCP tool surface — identical structured-error shape). Landed in
+[`parachute-vault#153`](https://github.com/ParachuteComputer/parachute-vault/pull/153).
+
+## Why
+
+- **Agents are concurrent by default.** Two agents reading the same
+  note, both updating, both succeeding silently is the most common
+  silent-data-loss bug in agent stacks. Optimistic concurrency makes
+  the conflict visible at the API boundary.
+- **428 ≠ 409.** Distinguishing "no precondition supplied" from
+  "precondition supplied but stale" lets clients/agents differentiate
+  *bug-in-my-code* from *raced-with-someone-else*. A blanket 400
+  collapses signal that the caller needs to recover.
+- **Same shape on HTTP and MCP.** Whether an agent calls
+  `update-note` over MCP or `PUT /api/notes/:id` over HTTP, the error
+  body keys are identical (`error_type`, `current_updated_at`,
+  `your_updated_at`, `path`, `note_id`). One recovery path.
+- **`force: true` is loud.** Making the override an explicit boolean
+  rather than absence of a header means clobbers show up in audit
+  logs as deliberate decisions, not accidents.
+
+## Rules
+
+- **Default is required, not optional.** Writes without
+  `if_updated_at` AND without `force: true` get a 428. Don't soft-fail
+  to a write.
+- **`force: true` overrides any `if_updated_at`.** Don't try to honour
+  both — the explicit clobber wins. Documenting one rule keeps client
+  logic simple.
+- **Atomic check + write.** The precondition check must run inside the
+  same transaction as the update, not as a separate `SELECT` →
+  application-layer compare → `UPDATE`. Otherwise the race window
+  reopens.
+- **Never auto-resolve.** The server doesn't merge, doesn't pick a
+  side, doesn't retry. The 409 is a signal back to the caller; the
+  caller decides whether to re-fetch + re-apply or `force: true`.
+- **Conflict body uses the structured field names.** `current_updated_at`,
+  `your_updated_at`, `path`, `note_id`, `error_type: "conflict"`.
+  Don't invent module-specific aliases. Legacy fields
+  (`expected_updated_at`) may exist for back-compat shims; keep them
+  alongside the new shape, drop on the next major.
+- **Single-resource reads always include `updated_at`.** If the
+  resource has never been updated, fall back to `created_at`. A read
+  that doesn't return a precondition token is a bug.
+- **Apply to *every* write.** Update, partial-update, link mutations,
+  tag mutations on a note — anything that changes a resource's
+  `updated_at`. Bulk operations either all-or-nothing the precondition
+  per-resource, or document a different (`force: true`-equivalent)
+  contract on the bulk endpoint.
+
+## Where this applies
+
+- **`parachute-vault`** — reference implementation. HTTP write handlers
+  (`routes.ts`) and MCP `update-note` tool (`mcp-http.ts`) both
+  enforce. PR #153.
+- **`parachute-notes`** — relies on this contract for collaborative
+  edits (browser tab + agent edits to the same note). Must not strip
+  the precondition before forwarding writes from the PWA.
+- **Future API-surface modules** — when a module exposes mutating
+  HTTP/MCP endpoints over a database-backed resource, follow the same
+  shape. Cheap to implement, prevents an entire class of silent
+  corruption.
+
+## Non-applicability
+
+- **Append-only / event-log surfaces.** Anything where the operation
+  is "add a row" rather than "modify a row" doesn't need the
+  precondition — there's no row to clobber. Conflict semantics may
+  still apply at the *uniqueness* level (e.g. a duplicate-path
+  rejection on create), but that's a different shape (typically 409
+  with `error_type: "duplicate"`).
+- **Idempotent overwrites under a caller-supplied key.** Patterns like
+  `PUT /by-key/:idempotency-key { value }` where the caller's key
+  *is* the precondition.
+
+## Open questions
+
+- **Bulk operation semantics.** A bulk update across N notes today
+  would require N preconditions. Reasonable, but verbose. A future
+  bulk endpoint may want a single `if_unchanged_since: <ISO>` against
+  the whole working set; not yet designed.
+- **Cross-resource transactions.** Updating a note + a tag + a link in
+  one call (today: separate operations, separate preconditions). If
+  this becomes common, a transactional wrapper that takes a vector of
+  preconditions could land. Premature today.

--- a/patterns/parallel-cross-repo-PRs.md
+++ b/patterns/parallel-cross-repo-PRs.md
@@ -1,0 +1,186 @@
+# Parallel cross-repo PRs
+
+## Convention
+
+When a single conceptual change spans multiple Parachute repos
+(OAuth Phase 0 was 4 simultaneous PRs across vault / cli / notes /
+scribe; stateless-scribe was a similar fan-out), the team-lead
+**briefs each steward in parallel** and each steward opens its own
+PR independently. The change composes when the PRs land in any
+order. There is no master PR, no orchestration branch, and no
+"please merge mine first."
+
+This is the dominant shipping shape for ecosystem-wide changes. It
+trades a bit of upfront thinking (designing the change to be
+landing-order-independent) for a lot of parallelism (each steward
+moves at full speed without blocking on the others).
+
+## Why parallel
+
+- **Ordering dependencies are a coordination tax.** A "merge X
+  before Y" rule means someone — the team-lead or the human merger
+  — has to remember the order, hold one PR while reviewing the
+  other, and re-verify after the first lands. That tax compounds
+  across 3–4 PRs and breaks down entirely when one PR needs a
+  revision.
+- **Stewards are repo-scoped, not task-scoped.** Each tentacle is
+  the long-lasting steward of one repo. A multi-repo change
+  naturally fans out one PR per steward; coordinating them as
+  separate independent PRs respects the steward boundary. See
+  [`octopus`](https://github.com/ParachuteComputer/parachute-octopus)
+  and the per-repo CLAUDE.md spawning convention.
+- **The human merger is the serializer.** The single human (Aaron
+  today) reviews and merges in whatever order they reach the queue.
+  If the changes are designed parallel-safe, that order doesn't
+  matter.
+- **Failures isolate.** A PR that needs a revision doesn't block
+  the others. The author iterates in their own repo; the rest of
+  the change still ships.
+
+## How to design parallel-safe scope
+
+Before briefing the stewards, the team-lead asks: **does each
+repo's change make sense at every state of the others?**
+
+- ✅ **Additive contracts** — adding a new endpoint, a new optional
+  field, a new env var with a fallback. The new thing exists
+  whether or not the consumer has shipped yet. The consumer-side
+  PR can land before, after, or interleaved with the producer side.
+- ✅ **Backwards-compatible shape changes** — accepting both old and
+  new shapes on the receiving side, then later dropping the old.
+  Shape co-existence is the bridge.
+- ✅ **Symmetric contracts that already exist on both sides** —
+  e.g. RFC 8414 path-insertion adopted by vault, with hub picking
+  it up later when hub becomes the IdP. Both sides eventually meet;
+  neither needs the other to ship today.
+- ❌ **Breaking renames** — renaming a field from `foo` to `bar`
+  across producer and consumer. If the producer ships first,
+  consumers break; if consumers ship first, they get nothing.
+  Either bridge with both-shapes-accepted (and split into a deprecate-
+  then-remove sequence) or accept that this is **not** a parallel
+  change and serialize it.
+- ❌ **Tightly-coupled code moves** — moving a function from one
+  repo to another. The old location can't disappear before the new
+  location is ready, and vice versa. Stage the move: PR 1 adds the
+  new location, PR 2 (after merge) removes the old.
+
+When in doubt, ask whether you'd be comfortable with each PR
+landing alone. If "no," redesign the change.
+
+## Shape
+
+A typical parallel cross-repo brief looks like:
+
+1. **Team-lead writes the design once** — the cross-cutting context,
+   the conformance criteria, the test plan. This goes once into a
+   shared place (the design doc, a `Current/Parachute` note in the
+   vault, or the team-lead's working scratchpad).
+2. **Team-lead briefs each steward** with a self-contained scope:
+   "your repo's part is X; here are the file references; here's
+   how to verify; here's how to know you're done." Each steward
+   gets a brief that does **not** require talking to the other
+   stewards mid-flight.
+3. **Stewards work in parallel.** Each opens its own PR with its
+   own description. They cite the design doc / shared brief.
+4. **Team-lead reviews each PR independently** with the standard
+   verification summary (see [`governance.md`](./governance.md)
+   Rule 1).
+5. **Human merges in whatever order they reach.** Stewards don't
+   coordinate merge order.
+
+## Rules
+
+- **One PR per repo per change.** Don't try to bundle changes from
+  multiple repos into a "monorepo-style" megaPR — Parachute is
+  multi-repo on purpose.
+- **No `merge X first, then Y` instructions.** If the change has a
+  required order, redesign the scope until it doesn't, or split
+  into a sequence of parallel-safe waves.
+- **Each PR description references the shared design.** Reviewers
+  shouldn't have to reconstruct the cross-cutting picture from a
+  single repo's diff. Link to the design doc, the team-lead's
+  brief note, or a sibling PR.
+- **Conformance is per-repo.** If repo A's PR ships and repo B's
+  doesn't, repo A is still in a working state — that's what
+  parallel-safe scope means. The full-system behavior may not yet
+  be live, but no single repo is broken.
+- **Migration notes carry the cross-cutting story.** When the
+  pattern doc lands in `parachute-patterns/`, the
+  [`adoption/migration-notes.md`](../adoption/migration-notes.md)
+  entry is the place that names *all* affected repos. Each
+  individual PR's description is repo-scoped; the cross-cutting
+  index lives here.
+
+## Examples
+
+### OAuth Phase 0 (2026-04-23)
+
+Four parallel PRs:
+
+- `parachute-vault` — implement `/oauth/authorize`, `/oauth/token`,
+  `resolveOAuthCoordinates`, advertise hub as `iss`. PR
+  [#147](https://github.com/ParachuteComputer/parachute-vault/pull/147).
+- `parachute-cli` — derive hub origin in `src/hub-origin.ts`, pass
+  `PARACHUTE_HUB_ORIGIN` to vault on `expose up` / `start`.
+- `parachute-notes` — register OAuth client, request consent, store
+  PKCE state. PR
+  [#49](https://github.com/ParachuteComputer/parachute-notes/pull/49)
+  and follow-ups.
+- `parachute.computer` — design doc, blog post material, scope
+  vocabulary documentation.
+
+Each PR landed independently. Hub-origin awareness landed on the CLI
+side before vault advertised hub-as-issuer; vault's discovery
+endpoint worked correctly in both worlds (with and without the env
+var). Notes' OAuth flow worked against vault-as-issuer first, hub-as-
+issuer after. Parallel-safe by construction.
+
+### Stateless scribe (2026-04 launch week)
+
+Similar fan-out:
+
+- `parachute-vault` — pre-fetch context, attach as multipart part,
+  send to scribe with `transcribe: true`. Vault PR
+  [#156](https://github.com/ParachuteComputer/parachute-vault/pull/156).
+- `parachute-scribe` — drop the `vault:` config block; accept inline
+  `context` part; tolerant parser falls through to "no context" on
+  malformed payload.
+- `parachute-cli` — `auto-wire` mints `SCRIBE_AUTH_TOKEN` and
+  installs it on both ends.
+- `parachute-patterns` — write down `context-in-payload.md`,
+  `service-to-service-auth.md`.
+
+The scribe-side change shipped without immediately requiring the
+vault-side payload to land — old `vault:` config was simply removed,
+and scribe defaulted to "no context" until vault started sending one.
+Parallel-safe.
+
+## What this isn't
+
+- **A monorepo argument.** Parachute is multi-repo because each
+  module is independently deployable and independently authored.
+  Parallel cross-repo PRs are how you coordinate multi-repo without
+  losing parallelism.
+- **A scheduling tool.** This pattern is about *shape* (parallel-
+  safe scope) and *brief* (self-contained per-steward), not about
+  who works when. Stewards are spawned and run on their own
+  cadence.
+- **A workaround for "real" coordination.** Sometimes a change
+  *does* need ordering — a breaking rename across two repos. In
+  that case, design the bridge (accept both shapes, deprecate, then
+  remove) so the bridge-half is parallel-safe, and the removal-half
+  is also parallel-safe. The serial moment shrinks to "the
+  deprecation window," not "the merge sequence."
+
+## Open questions
+
+- **Multi-human team.** Today the human merger is a single person
+  (Aaron). When a second human contributor with merge authority
+  joins, parallel cross-repo merges may interleave with their work.
+  The pattern still holds; the team-lead's brief just goes through
+  the human merger's queue with whatever priority the work needs.
+- **Cross-repo CI.** No cross-repo CI today — each repo's CI runs
+  in isolation. If/when an integration test needs `vault@N +
+  scribe@M` to be valid together, the parallel-safe rule may need
+  to extend to "and CI passes against any sibling-repo HEAD." Out
+  of scope for now.

--- a/patterns/reviewer-agent.md
+++ b/patterns/reviewer-agent.md
@@ -1,0 +1,173 @@
+# Reviewer agent
+
+## Convention
+
+For PRs that touch **auth, scope, schema, or public API**, the team-lead
+runs a `reviewer` agent against the diff before recommending merge.
+This is an additional pass on top of the steward's self-tests and the
+team-lead's own verification — the agent reads the diff with no prior
+context from the conversation, which catches things the author and
+the steward who watched the PR get drafted both miss.
+
+This is a **convention, not enforcement.** No CI gate fires it; no
+merge block. The team-lead invokes it when the change-class warrants
+it. Other PR classes (UI tweaks, doc edits, test-only changes,
+internal refactors with no surface change) skip the reviewer agent.
+
+This pattern pairs with [`governance.md`](./governance.md) Rule 1 —
+"every PR is reviewed by a team-lead role and merged by a human." The
+reviewer agent is a tool the team-lead uses inside that review, not a
+replacement for the human merge step.
+
+## Why a fresh-context reviewer
+
+Tentacles draft PRs in the context of a conversation with the team-lead.
+That conversation gives them the *intent* of the change — which is
+load-bearing for productivity but creates a blind spot: the steward
+won't notice when the diff drifts from the intent, because they're
+seeing it through the lens of what they meant to do. The team-lead has
+the same issue from the other direction (knew the brief, saw the
+draft, anchored on the design).
+
+A fresh agent has neither anchor. It reads the diff cold against
+whatever standards the prompt names — patterns, RFCs, the existing
+codebase — and surfaces the gap between what the diff *says* and what
+the surrounding code expects. The class of bug it catches is the
+class where the steward and team-lead both nodded along with the same
+mistake.
+
+This is why the reviewer is **fresh-spawn each time, not a long-lived
+agent.** Memory of prior reviews would re-introduce the anchoring the
+fresh-spawn was meant to break.
+
+## When to invoke
+
+Run the reviewer agent on PRs that touch:
+
+- **Auth** — token issuance, validation, refresh, OAuth flows, scope
+  checks, JWKS, anything in `parachute-vault/src/oauth.ts` or
+  comparable callee surfaces.
+- **Scope vocabulary** — adding/removing/renaming a scope, changing
+  scope inheritance, splitting `vault:write` semantics, etc. See
+  [`oauth-scopes.md`](./oauth-scopes.md).
+- **Public API surface** — request shapes, response shapes, error
+  envelopes, optional-vs-required fields, status-code semantics. The
+  thing that stings here is a quietly-breaking change to a field
+  third-party clients depend on.
+- **Schemas** — JSON Schema files, well-known metadata shapes,
+  database migrations on shared resources.
+- **`/.parachute/*` endpoints** — the module protocol surface (see
+  [`module-protocol.md`](./module-protocol.md)).
+- **Inter-service contracts** — anything that crosses the
+  vault↔scribe / hub↔service boundaries (see
+  [`service-to-service-auth.md`](./service-to-service-auth.md),
+  [`context-in-payload.md`](./context-in-payload.md)).
+
+Skip the reviewer agent on:
+
+- Pure-content edits (markdown, docs, README, blog posts).
+- Test-only changes.
+- Internal refactors where no caller-visible surface moves.
+- UI-only frontend tweaks that don't change the data the backend
+  emits.
+
+When in doubt, run it. The cost is small; the catch is asymmetric.
+
+## What the reviewer prompt should contain
+
+A good reviewer-agent prompt is **specific and disposable** — it
+describes the change at hand and the exact standards to check, then
+exits.
+
+Useful elements:
+
+- **The diff or PR URL.** The agent should read the actual diff, not
+  a summary.
+- **Patterns the diff touches.** Name them by file (e.g.
+  "compare against `parachute-patterns/patterns/oauth-scopes.md` and
+  `hub-as-issuer.md`"). Don't trust the agent to guess.
+- **The relevant RFC or external spec, if any.** Quoting the exact
+  section saves the agent a search trip and pins the bar of review.
+- **What was claimed in the PR description.** Reviewer should verify
+  the claim against the diff, not just verify the diff in isolation.
+- **What you specifically want eyes on.** "Is the conflict shape
+  symmetric between HTTP and MCP?" is a better prompt than "review
+  this diff."
+
+A bad reviewer-agent prompt is a generic "review this PR" — no
+standards, no reference points, no claim to verify. The agent's
+output is correspondingly generic and doesn't catch the things the
+steward already covered.
+
+## What the reviewer agent reports back
+
+A useful reviewer report is **specific and falsifiable**. The
+team-lead reads it and either accepts or rejects each finding; vague
+findings get rejected by default.
+
+Good shape (use as a template — adapt as needed):
+
+- **Verified**: claims in the PR that the agent checked and
+  confirmed against the diff (e.g. "the new validator returns
+  `{valid, scopes}` on the success path of the shared-secret branch
+  — confirmed at line X").
+- **Discrepancies**: where the diff diverges from the claimed
+  patterns / RFCs / linked docs. Include line numbers.
+- **Risks not addressed**: edge cases or invariants the diff doesn't
+  cover. Don't speculate — only flag risks the agent can point at
+  concretely.
+- **Out of scope but adjacent**: nearby code the diff didn't touch
+  that *probably* should have moved together. Flag, don't demand.
+
+The team-lead's verification summary to the human merger should
+quote (or distill) the reviewer's findings — the human gets the
+benefit of the fresh-context pass without having to spawn another
+agent themselves.
+
+## Rules
+
+- **Reviewer is fresh-spawn each PR.** No long-lived reviewer agent;
+  no memory across PRs. Anchoring is what we're avoiding.
+- **Reviewer reads the actual diff.** Pass the PR URL or the diff
+  body, not a description-only summary.
+- **Reviewer is informed by patterns, not just code.** Cite the
+  specific pattern files the diff touches in the prompt.
+- **Reviewer's findings are quoted in the team-lead's verification
+  summary.** The human merger should know the reviewer ran and what
+  it said. Hidden reviews don't compound into trust.
+- **Reviewer is not a merge gate.** Findings get accepted or rejected
+  by the team-lead. A non-blocking finding is still a worth-flagging
+  finding — accept-with-note is fine.
+
+## What this isn't
+
+- **A CI step.** The reviewer agent is invoked manually by the
+  team-lead during review, not on every push. CI gates are
+  type-check, test, lint — those run regardless.
+- **A second human reviewer.** When the team grows past one human
+  contributor, branch-protection's required-review count goes to
+  `≥1` (see [`governance.md`](./governance.md)). The reviewer agent
+  doesn't substitute for that — it's a tool the human reviewer
+  uses, the same way the team-lead uses it today.
+- **A bug-finder.** The reviewer is best at *consistency* checks
+  (does this match the pattern / RFC / surrounding code) and
+  *coverage* checks (did the PR address what it claimed). It's not
+  a fuzzer or a static analyzer. Don't ask it to find race
+  conditions in concurrent code; ask it whether the diff matches
+  the pattern doc.
+
+## Open questions
+
+- **Should reviewer findings be persisted on the PR?** Today the
+  team-lead distills them into the verification summary. A "reviewer
+  comment thread" on the PR itself would let the human merger see
+  the raw output. Defer until the volume warrants it.
+- **Reviewer for content-class PRs.** Pure-content patterns (this
+  repo, blog posts, docs) currently skip the reviewer. If/when we
+  hit a class of content-bug that the human-only pass keeps missing,
+  the convention may grow.
+- **Multi-pattern reviews.** A PR that touches three patterns at
+  once — does each pattern get its own reviewer pass, or one
+  combined? Today: combined, one reviewer with all three patterns
+  cited. Revisit if combined reviewers start to miss things a
+  per-pattern split would catch.

--- a/patterns/service-to-service-auth.md
+++ b/patterns/service-to-service-auth.md
@@ -1,0 +1,161 @@
+# Service-to-service auth
+
+## Convention
+
+When one Parachute service calls another (vault → scribe webhook,
+future module → vault, etc.), the caller presents a **bearer token**
+in the `Authorization` header and the callee runs that token through
+**a single validator function** that returns `{valid, scopes}`.
+
+The trust broker for that token is the **CLI** at install time — it
+mints the secret, writes it to both ends, and never re-derives it.
+This pattern is what every service-to-service call in the ecosystem
+uses today, and the validator function is the seam where the future
+JWT cutover happens.
+
+## Today's shape (Phase 0+1)
+
+A random hex secret per pair. The CLI's `auto-wire` step on `parachute
+install`:
+
+1. Generates `SCRIBE_AUTH_TOKEN = randomBytes(32).toString("hex")` if
+   one isn't already in vault's `.env`.
+2. Writes it to **both** sides of the trust boundary:
+   - `~/.parachute/vault/.env` → `SCRIBE_AUTH_TOKEN=<hex>` (caller env)
+   - `~/.parachute/scribe/config.json` → `{ "auth": { "required_token": "<hex>" } }` (callee config)
+3. Idempotent — re-installs preserve the existing token, never
+   regenerate.
+4. Restarts vault if running so the worker re-reads the env (otherwise
+   it would keep the stale value and silently 401).
+
+Canonical implementation:
+[`parachute-cli/src/auto-wire.ts`](https://github.com/ParachuteComputer/parachute-cli/blob/main/src/auto-wire.ts).
+
+The callee (scribe) validates with a single function:
+
+```ts
+// parachute-scribe/src/auth.ts
+export function validateToken(token: string | undefined): AuthResult {
+  const required = process.env.SCRIBE_AUTH_TOKEN;
+  if (!required) return { valid: true, scopes: [] };
+  if (!token) return { valid: false, reason: "token-required" };
+  if (token !== required) return { valid: false, reason: "token-mismatch" };
+  return { valid: true, scopes: ["scribe:transcribe", "scribe:admin"] };
+}
+```
+
+The caller (vault) reads the token canonically via
+[`parachute-vault/src/scribe-env.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/scribe-env.ts)
+(`SCRIBE_AUTH_TOKEN` is the canonical name; an older `SCRIBE_TOKEN` is
+accepted with a deprecation warning).
+
+## Target shape (Phase B2)
+
+Hub-issued JWTs with service-specific scopes, validated via JWKS. The
+upgrade is a **validator-swap** — the body of `validateToken`
+changes; nothing else does:
+
+```ts
+// Phase B2 — same signature, same return type, JWT-aware body
+export function validateToken(token: string | undefined): AuthResult {
+  if (!token) return { valid: false, reason: "token-required" };
+  const claims = verifyJwt(token, process.env.PARACHUTE_HUB_JWKS);
+  if (!claims) return { valid: false, reason: "token-mismatch" };
+  return { valid: true, scopes: claims.scope.split(" ") };
+}
+```
+
+The shared scope-guard library is proposed in
+[`parachute-cli#59`](https://github.com/ParachuteComputer/parachute-cli/issues/59).
+Every service uses the same `verifyJwt(...)` helper and pins trust
+to the hub origin (see [`hub-as-issuer.md`](./hub-as-issuer.md)).
+
+This is why the existing `validateToken` already returns scopes from
+the shared-secret path — the scope vocabulary
+([`oauth-scopes.md`](./oauth-scopes.md)) is the same on both sides of
+the swap. Today the scopes are hard-coded on a successful match;
+tomorrow they come from JWT claims.
+
+## Key framing
+
+**Service-to-service auth is a separate trust axis from user OAuth.**
+
+| Axis | Issuer | Consent | Lifecycle |
+|---|---|---|---|
+| User OAuth | Hub origin ([`hub-as-issuer.md`](./hub-as-issuer.md)) | Per user, per app | Token revocable per user |
+| Service-to-service | CLI at install time | Implicit (operator runs install) | Rotates only on explicit re-issue |
+
+They use the **same scope vocabulary** but **different validators**
+today. Phase B2 converges them — the same JWKS-backed verifier
+validates both. Until then, don't conflate them: a `pvt_*` user token
+should never be accepted by an inter-service callee, and a service
+secret should never appear on a user-facing surface.
+
+## Rules
+
+- **One validator function per service.** A single seam — function
+  signature `(token) → {valid, scopes}` — is the only thing callees
+  consult on every request. Don't sprinkle auth checks across route
+  handlers.
+- **The CLI mints, both ends store.** Services never generate their
+  own inter-service secrets; the CLI is the only trust broker. Two
+  ends with the same secret is a service-pair contract.
+- **Idempotent install.** Existing secrets are preserved across
+  re-installs. Regenerating a token without coordinating both ends
+  would break a running deployment silently.
+- **Restart after rotation.** When a token changes, both processes
+  must re-read it before the next call. The CLI handles this for the
+  caller (vault); callees that hot-reload config get it for free.
+- **Loopback-only today.** Service-to-service traffic stays on
+  `127.0.0.1`. Never expose the inter-service surface publicly until
+  the JWT cutover lands — string-equal on a hex secret is fine for
+  loopback, not for the open internet.
+- **Scope-bearing return shape.** Even with a shared secret, the
+  validator should return scopes (`["scribe:transcribe", "scribe:admin"]`
+  on success). This keeps callers JWT-ready without a code change.
+- **Exempt only the obvious.** `/health` and `/.parachute/info` are
+  unauthenticated by convention (used by the CLI's status checks);
+  every other route auths.
+
+## Where this applies
+
+- **`parachute-vault` → `parachute-scribe`** — reference pair. Vault
+  posts audio attachments to scribe with `Authorization: Bearer
+  ${SCRIBE_AUTH_TOKEN}`. Scribe validates via
+  [`src/auth.ts`](https://github.com/ParachuteComputer/parachute-scribe/blob/main/src/auth.ts).
+- **`parachute-hub`** (`parachute-cli` today) — implements the trust
+  broker in `auto-wire.ts`. Future inter-service pairs (e.g.
+  channel → vault for triggered actions) follow the same pattern: a
+  named env on the caller, a config field on the callee, idempotent
+  generation.
+- **Future third-party modules** — declare an inter-service secret
+  env var in your `.parachute/module.json` (when
+  [`module-json-extensibility.md`](./module-json-extensibility.md)
+  lands). The CLI's auto-wire reads the declaration and provisions
+  the pair.
+
+## Open questions
+
+- **Rotation story.** Today rotation is "edit both ends, restart both
+  processes." Acceptable for loopback. After B2, JWT expiry handles
+  most rotation; explicit `parachute auth rotate <pair>` may still be
+  useful for revocation events.
+- **N-to-1 fan-in.** A service called by N callers (future hub →
+  vault for privileged writes) needs N secrets, or one secret + a
+  caller identifier in the token. JWT cutover solves this naturally
+  via `aud` / `azp` claims; pre-cutover we'd need to bend the shape.
+- **Cross-host (cloud) deployments.** Loopback-only is fine for the
+  single-machine install. A cloud topology where vault and scribe
+  run on different hosts needs the JWT cutover before it can ship —
+  string-equal-over-the-wire is not acceptable.
+
+## What's out of scope here
+
+- **User OAuth scopes and issuer** — see
+  [`oauth-scopes.md`](./oauth-scopes.md) and
+  [`hub-as-issuer.md`](./hub-as-issuer.md).
+- **`pvt_` user tokens** — see [`token-auth.md`](./token-auth.md).
+  Different trust axis; do not interchange with service secrets.
+- **Service-to-service over MCP** — MCP transport carries its own
+  bearer (typically a `pvt_*` user token, not a service secret).
+  Covered in [`mcp-transport.md`](./mcp-transport.md).

--- a/patterns/token-auth.md
+++ b/patterns/token-auth.md
@@ -1,13 +1,20 @@
 # Token auth — `pvt_` tokens
 
-## [DRAFT] — canonicalizing the shape across modules
-
 ## Convention
 
-Parachute-issued bearer tokens use a `pvt_` prefix ("parachute token"), are
-stored as sha256 hashes (never in clear), are scoped to a vault / tenant /
-agent, and are revealed to the user exactly once via the issuing surface —
-typically a cookie-gated modal after creation.
+Parachute-issued **personal access tokens** use a `pvt_` prefix
+("parachute token"), are stored as sha256 hashes (never in clear), are
+scoped to a vault / tenant / agent, and are revealed to the user
+exactly once via the issuing surface — typically a cookie-gated modal
+after creation.
+
+`pvt_*` tokens are the **user-facing PAT** path: a logged-in human
+generates one in the issuing module's UI and pastes it into a script,
+a CLI, or a third-party tool. They sit alongside the **OAuth bearer
+token** path ([`hub-as-issuer.md`](./hub-as-issuer.md)), which is for
+agent-to-service and service-to-service flows where the consumer goes
+through the consent dance. Same scope vocabulary on both — see
+[`oauth-scopes.md`](./oauth-scopes.md).
 
 ## Shape
 
@@ -29,7 +36,10 @@ sha256(pvt_...) hex → (tenant_id, scope, created_at, last_used_at, label)
   issuance. Comparing: hash the incoming bearer, look up by hash.
 - **Scope is required.** Every token has a named scope
   (`vault:read`, `vault:write`, `agent:invoke`, etc.). A token without
-  scope is a bug.
+  scope is a bug. Scope strings follow
+  [`oauth-scopes.md`](./oauth-scopes.md) — `pvt_*` and OAuth bearer
+  tokens share one vocabulary so a `vault:read` grant means the same
+  thing on either side of the validator seam.
 - **Reveal once.** The UI that issues a token shows the full `pvt_...`
   exactly one time, gated by the user's active session cookie. After modal
   close, the UI shows only a last-4 suffix + label. The caller is
@@ -49,10 +59,13 @@ sha256(pvt_...) hex → (tenant_id, scope, created_at, last_used_at, label)
 
 ## Where this applies
 
-- `parachute-vault` — vault tokens for REST / MCP auth.
-- `parachute-cloud` — tenant-scoped vault access tokens.
-- `@openparachute/agent` — inbound webhook tokens for trigger auth (when the
-  runner exposes a webhook endpoint).
+- `parachute-vault` — vault tokens for REST / MCP auth. Today this is
+  the only shipped issuer of `pvt_*` tokens.
+- Future modules with a user-facing PAT surface — same shape, same
+  scope vocabulary. Modules whose only credentialed callers are agents
+  or other services should prefer the OAuth bearer path
+  ([`hub-as-issuer.md`](./hub-as-issuer.md)) over minting their own
+  `pvt_*` issuer.
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

Single bundle PR for all in-flight pattern docs. Pivoted here after the per-pattern PR cascade hit migration-notes adjacency conflicts on every rebase. Aaron's directive: one PR to merge, all patterns together.

Nine commits, one per file, individually reviewable. Three are cherry-picked from previously-open PRs (#11/#12/#13, now closed in favor of this bundle); six are written fresh on this branch.

## Per-pattern checklist

- [ ] **`patterns/service-to-service-auth.md`** *(was #11)* — Inter-service auth via single `validateToken(token) → {valid, scopes}` seam on the callee. Today: shared-secret bearer minted by `parachute-cli`'s `auto-wire`. Phase B2: body-swap to JWT verify with no caller/callee changes. Cites vault `src/scribe-env.ts`, scribe `src/auth.ts`, cli `src/auto-wire.ts`. Tracker: cli#59.
- [ ] **`patterns/optimistic-concurrency.md`** *(was #12)* — Mutating endpoints over DB-backed resources require `if_updated_at` (or explicit `force: true`). Conflict → structured 409 with `current_updated_at`/`your_updated_at`/`path`. Missing precondition → structured 428 (RFC 6585). Symmetric across HTTP + MCP surfaces. Vault PR [#153](https://github.com/ParachuteComputer/parachute-vault/pull/153) is the reference impl.
- [ ] **`patterns/context-in-payload.md`** *(was #13)* — Provider pre-fetches narrowly-scoped context, ships inline as multipart `context` part (or top-level `context: {...}` on JSON sends). Consumer is stateless, parses tolerantly, never calls back. Reference pair: vault → scribe (vault PR [#156](https://github.com/ParachuteComputer/parachute-vault/pull/156)).
- [ ] **`patterns/mount-path-convention.md`** — Vite `base` → BrowserRouter `basename` + PWA manifest `scope`/`start_url`/`id` + OAuth redirect URI all read `import.meta.env.BASE_URL`. Cites parachute-notes PRs [#49](https://github.com/ParachuteComputer/parachute-notes/pull/49) / [#50](https://github.com/ParachuteComputer/parachute-notes/pull/50) / [#54](https://github.com/ParachuteComputer/parachute-notes/pull/54). `parachute-notes/CLAUDE.md` already forward-references this doc.
- [ ] **`patterns/module-json-extensibility.md`** — `.parachute/module.json` shape (target convention; CLI implementation deferred to Phase 3). **Status: target, partial implementation** stated up-front. **No `@openparachute/` scope or `parachute-*` prefix required** — that's the load-bearing extensibility claim. Cites design doc + `parachute-cli/src/service-spec.ts`.
- [ ] **`patterns/reviewer-agent.md`** — Convention (not enforcement) for fresh-spawn reviewer agent on auth / scope / schema / public-API / module-protocol / inter-service-contract PRs. Pairs with [governance.md](./patterns/governance.md) Rule 1.
- [ ] **`patterns/parallel-cross-repo-PRs.md`** — The dominant shipping shape for ecosystem-wide changes (OAuth Phase 0 = 4 simultaneous PRs; stateless-scribe was a similar fan-out). How to design parallel-safe scope, the per-steward brief, the rules. Names today's lesson — bundling shared-registry-touching PRs — as the inverse counter-pattern.
- [ ] **`patterns/token-auth.md`** *(refresh)* — Drop the `[DRAFT]` header, position `pvt_*` as the user-facing PAT path alongside the OAuth bearer path that landed with hub-as-issuer, cross-link [oauth-scopes.md](./patterns/oauth-scopes.md). Trim stale `parachute-cloud` / `@openparachute/agent` mentions in `Where this applies`.
- [ ] **`patterns/mcp-transport.md`** *(refresh)* — Acknowledge OAuth bearer alongside `pvt_*`, forward-link [well-known-discovery-rfc.md](./patterns/well-known-discovery-rfc.md) from the OAuth client-credentials section so authors know `token_url` can come from RFC 8414 discovery instead of being pinned in agent markdown.

## Migration-notes block

One block on this branch. Order under 2026-04-26: `hub-as-issuer` (#9, on main) → `well-known-discovery-rfc` (#10, on main) → `parallel-cross-repo-PRs` → `reviewer-agent` → `module-json-extensibility` → `mount-path-convention` → `service-to-service-auth` → `optimistic-concurrency` → `context-in-payload`. Token-auth and mcp-transport refreshes are in-place patches on existing docs and don't carry migration-notes entries.

## Conformance

Every pattern in this bundle documents already-shipped behavior or already-named target conventions. No code change is required to land the bundle.

- service-to-service-auth — already conformant in vault/scribe/cli; pattern documents what's there.
- optimistic-concurrency — already conformant in vault (PR #153). Notes adoption ongoing.
- context-in-payload — already conformant in vault → scribe pair (vault PR #156).
- mount-path-convention — already conformant in `parachute-notes`.
- module-json-extensibility — explicitly target-not-yet-implemented; CLI work tracked separately.
- reviewer-agent — convention adopted starting now.
- parallel-cross-repo-PRs — convention writes down what's already in active use.
- token-auth — bridges to oauth-scopes; vault is the only shipped issuer.
- mcp-transport — adds OAuth/discovery context; client_credentials already supported.

## Replaces

Closes #11, #12, #13 (their commits cherry-picked here cleanly against current main).

## Test plan

- [ ] `git diff origin/main..HEAD` shows 9 commits, 11 files changed (7 new patterns + 2 refreshes + migration-notes + 1 from each of the cherry-picked patterns).
- [ ] No conflict markers in `adoption/migration-notes.md`.
- [ ] Every new pattern doc has the standard sections (Convention, Why, Rules, What this isn't, Open questions where relevant).
- [ ] Cross-links resolve: token-auth ↔ oauth-scopes / hub-as-issuer; mcp-transport ↔ well-known-discovery-rfc / hub-as-issuer / token-auth; service-to-service-auth ↔ hub-as-issuer / oauth-scopes; optimistic-concurrency ↔ module-protocol; context-in-payload ↔ service-to-service-auth; mount-path → notes BASE_URL refs; module-json → design doc + service-spec.ts; reviewer-agent → governance.md; parallel-cross-repo-PRs → octopus + governance.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)