### PR TITLE
patterns: post-merge cleanup (migration-notes audit + cross-link sweep)

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -30,11 +30,11 @@ with [`patterns/oauth-scopes.md`](../patterns/oauth-scopes.md).
   begin OAuth enforcement, validate `iss` against the hub origin (not
   their own URL). No code change needed before they implement OAuth.
 - Phase B2 cutover (hub becomes IdP itself) tracked in
-  [cli#58](https://github.com/ParachuteComputer/parachute-cli/issues/58)
+  [hub#58](https://github.com/ParachuteComputer/parachute-hub/issues/58)
   and
   [vault#169](https://github.com/ParachuteComputer/parachute-vault/issues/169).
 
-**Status:** Phase 0+1 complete on 2026-04-23. Phase B2 in design.
+**Status:** Phase 0+1 complete on 2026-04-20. Phase B2 in design.
 
 ---
 
@@ -55,10 +55,10 @@ pairs with [`patterns/hub-as-issuer.md`](../patterns/hub-as-issuer.md).
   after the `/vault/<name>/` URL migration; path-append routes have
   been there since launch. Reference: top of `route()` in
   `src/routing.ts`.
-- `parachute-hub` (renaming from `parachute-cli` —
+- `parachute-hub` (renamed from `parachute-cli` —
   [cli#55](https://github.com/ParachuteComputer/parachute-cli/issues/55))
   — picks this up when the hub becomes the IdP itself in Phase B2
-  ([cli#58](https://github.com/ParachuteComputer/parachute-cli/issues/58)).
+  ([hub#58](https://github.com/ParachuteComputer/parachute-hub/issues/58)).
   Hub origin has no path component, so insertion and append collapse
   to the same `/.well-known/<type>` URL — the distinction only
   matters for issuers with a path.
@@ -66,7 +66,7 @@ pairs with [`patterns/hub-as-issuer.md`](../patterns/hub-as-issuer.md).
   begin serving OAuth metadata, serve both shapes for any path-rooted
   issuer they advertise.
 
-**Status:** complete for vault on 2026-04-23 (PR #149). Other modules
+**Status:** complete for vault on 2026-04-20 (PR #149). Other modules
 not yet OAuth-enforcing.
 
 ---
@@ -135,13 +135,13 @@ file shipped in the npm package; `name` / `manifestName` /
 `startCmd` / `scopes` / `dependencies`. **No `@openparachute/` scope or
 `parachute-*` prefix required** — the contract is what makes a module
 a Parachute module, not its name. **Status: target, not yet
-implemented in `parachute install`.** Today the CLI uses a hardcoded
+implemented in `parachute install`.** Today the hub uses a hardcoded
 `SERVICE_SPECS` fallback — a first-party shortcut, not an
 architectural limit.
 
 **Affected:**
 
-- `parachute-cli` — needs the `module.json` reader / validator /
+- `parachute-hub` — needs the `module.json` reader / validator /
   installer step before this is real. Tracked as Phase 3 work in the
   design doc. Hardcoded `SERVICE_SPECS` retires (or shrinks to a
   transitional fallback) when `module.json` lands.
@@ -153,7 +153,7 @@ architectural limit.
   [`parachute.computer/design/2026-04-20-module-architecture.md`](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-04-20-module-architecture.md)
   (extensibility section). The pattern doc is the durable reference.
 
-**Status:** convention documented; CLI implementation deferred to
+**Status:** convention documented; hub implementation deferred to
 Phase 3.
 
 ---
@@ -210,7 +210,7 @@ and [`patterns/oauth-scopes.md`](../patterns/oauth-scopes.md).
 
 **Affected:**
 
-- `parachute-cli` — already implements the trust broker in
+- `parachute-hub` — already implements the trust broker in
   `src/auto-wire.ts` (mints `SCRIBE_AUTH_TOKEN`, writes to vault `.env`
   and scribe `config.json`, idempotent, restarts vault). No code
   change needed; pattern documents what's there.
@@ -222,7 +222,7 @@ and [`patterns/oauth-scopes.md`](../patterns/oauth-scopes.md).
   with a one-shot warning.
 - Phase B2 cutover (`validateToken` body becomes JWT verify; shared
   scope-guard library) tracked in
-  [cli#59](https://github.com/ParachuteComputer/parachute-cli/issues/59).
+  [hub#59](https://github.com/ParachuteComputer/parachute-hub/issues/59).
 - Future inter-service pairs — declare the env var name in
   `.parachute/module.json` and `auto-wire` provisions on install.
 

--- a/patterns/cli-as-port-authority.md
+++ b/patterns/cli-as-port-authority.md
@@ -66,7 +66,8 @@ written at install time is the contract for the next boot, and
 
 The `occupied` set is built by `collectOccupiedPorts` in `install.ts`:
 union of (a) every `port` already in `services.json` for *other* services,
-and (b) any port in `1939–1949` that responds to a 150ms TCP probe at
+and (b) any port in the [`1939–1949`](./canonical-ports.md) range that
+responds to a 150ms TCP probe at
 `127.0.0.1:<port>`. The probe is fail-open — timeouts and errors return
 `false` so a flaky probe never blocks an install.
 

--- a/patterns/context-in-payload.md
+++ b/patterns/context-in-payload.md
@@ -162,7 +162,8 @@ provider doesn't try to format for the consumer.
   becomes an MCP client and pulls what it needs, with auth.
 - **An auth or trust mechanism.** The context payload is in the
   request body, alongside the actual workload. It piggybacks on
-  whatever inter-service auth (`service-to-service-auth.md`)
+  whatever inter-service auth
+  ([`service-to-service-auth.md`](./service-to-service-auth.md))
   already protects the request.
 
 ## Open questions

--- a/patterns/mcp-transport.md
+++ b/patterns/mcp-transport.md
@@ -76,9 +76,10 @@ the endpoint or skip discovery.
 - **Never inline a token in the markdown** when the file is checked into a
   repo or stored in vault. Use `token_env` and supply the secret via the
   runner's environment.
-- **Scope the token.** Follow `patterns/token-auth.md` — every Parachute
-  token has a declared scope; MCP tokens typically have something like
-  `vault:read` or `agent:invoke`.
+- **Scope the token.** Follow [`token-auth.md`](./token-auth.md) — every
+  Parachute token has a declared scope; MCP tokens typically have something
+  like `vault:read` or `agent:invoke` (see
+  [`oauth-scopes.md`](./oauth-scopes.md) for the shared vocabulary).
 - **Path convention.** Servers should mount MCP at `/mcp` (not `/api/mcp`,
   not `/v1/mcp`). Keeps client URLs uniform.
 


### PR DESCRIPTION
Two small post-merge cleanup tasks bundled. Per-file commits for reviewability.

## Migration-notes audit (commit 1)

Walked every entry in `adoption/migration-notes.md` and verified PR numbers, status claims, and affected-repo lists against actual repo state. Findings applied:

- **Status dates corrected.** `hub-as-issuer` and `well-known-discovery-rfc` both said `2026-04-23` (launch day) but the underlying PRs (#147/#152 and #149) merged on `2026-04-20`. Fixed both.
- **Forward-looking issue refs.** `cli#58` and `cli#59` (Phase B2 trackers) → `hub#58` / `hub#59`. The repo was renamed via `cli#55` so forward-looking issues now live on `parachute-hub`.
- **Current-code references.** `parachute-cli — already implements...` → `parachute-hub — already implements...` in the module-json-extensibility and service-to-service-auth entries. The current source lives at `parachute-hub/src/auto-wire.ts`.
- **Historical refs preserved.** `cli#55` (the rename issue itself) and `parachute-cli/pull/54` (the port-authority PR — landed before the rename) stay as-is. Historical, accurate.
- All other PR numbers, status claims, and affected-repo lists verified accurate.

## Cross-link sweep (commit 2)

Walked the patterns directory looking for places that mention concepts defined in another pattern doc without a relative link. Findings applied:

- `cli-as-port-authority.md` — bare `1939–1949` mention → linked to `canonical-ports.md`.
- `context-in-payload.md` — `service-to-service-auth.md` filename in parens but not a hyperlink → wrapped as `[service-to-service-auth.md](./service-to-service-auth.md)`.
- `mcp-transport.md` — `patterns/token-auth.md` (full path, no link) → relative `[token-auth.md](./token-auth.md)`. Same line, added link to `oauth-scopes.md` at the first mention of `vault:read` / `agent:invoke`.

False positives (already linked) skipped.

## Patterns check

Touches `adoption/migration-notes.md` (the cross-cutting index per `parallel-cross-repo-PRs.md`) and three pattern files. Pure content / link hygiene — no new conventions, no breaking shape changes.