### PR TITLE
patterns(oauth-scopes): register claw + parachute:host:admin; mark vault scopes resource-bound

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,46 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-04-28 — Vault scopes are resource-bound (`vault:<name>:<verb>`)
+
+**Change:** the hub's OAuth picker rewrites an unnamed `vault:<verb>`
+request to `vault:<picked>:<verb>` before issuing the auth code; vault
+rejects bare `vault:<verb>` from hub-issued JWTs and strict-checks
+`aud=vault.<name>` on each request. `pvt_*` tokens unaffected (legacy
+direct-token path bypasses JWT validation). Closes the design discussion
+in [`parachute-vault#179`](https://github.com/ParachuteComputer/parachute-vault/pull/179);
+landed in [`parachute-vault#180`](https://github.com/ParachuteComputer/parachute-vault/pull/180)
+and [`parachute-hub#95`](https://github.com/ParachuteComputer/parachute-hub/pull/95).
+Pattern doc: [`oauth-scopes.md`](../patterns/oauth-scopes.md).
+
+Also captured in the same pattern update:
+- `claw:read` / `claw:write` / `claw:admin` registered (paraclaw vocabulary
+  with admin ⊇ write ⊇ read inheritance).
+- `parachute:host:admin` introduced as the first **non-requestable**
+  operator-only scope (cross-vault host admin, used for hub-orchestrated
+  vault provisioning via `POST /vaults`).
+
+**Affected:**
+
+- `parachute-vault` — reference implementation (PR #180 + #184 + #187).
+  Hub-JWT bearers now go through resource-bound + audience-bound
+  enforcement.
+- `parachute-hub` — picker UI + `POST /vaults` + `NON_REQUESTABLE_SCOPES`
+  enforcement (PR #95). Operator tokens auto-include
+  `parachute:host:admin` on next mint.
+- `parachute-notes` / `paraclaw` / `parachute-scribe` — no current code
+  carries hardcoded `vault:read|write|admin` strings (verified at write
+  time). New OAuth flows will pick up the picker rewrite automatically.
+  Watch for any future hardcoded scope literal — they'd start receiving
+  401s from JWT-validating vault paths.
+- Existing `pvt_*` tokens keep working without change (different code
+  path, no audience check). Operator-token rotation needed to pick up
+  `parachute:host:admin` (run `parachute auth rotate-operator`).
+
+**Status:** complete on 2026-04-28.
+
+---
+
 ## 2026-04-26 — Hub is the OAuth issuer
 
 **Change:** the hub origin is the canonical OAuth issuer for the

--- a/patterns/oauth-scopes.md
+++ b/patterns/oauth-scopes.md
@@ -22,12 +22,16 @@ Parachute OAuth tokens carry **whitespace-separated scope strings**
 
 | Scope | Grants |
 | --- | --- |
-| `vault:read` | Read any vault via REST + MCP |
-| `vault:write` | Write + read (inheritance) |
-| `vault:admin` | Write + read + `/.parachute/config*` |
+| `vault:<name>:read` | Read the named vault via REST + MCP |
+| `vault:<name>:write` | Write + read (inheritance) |
+| `vault:<name>:admin` | Write + read + `/.parachute/config*` |
 | `scribe:transcribe` | POST audio to scribe's transcription endpoint |
 | `scribe:admin` | Manage scribe config |
-| `hub:admin` | Reserved; not yet enforced |
+| `claw:read` | Read agent groups + vault attachments via paraclaw API/MCP |
+| `claw:write` | Mutate agent groups, secrets, channel wires, sessions |
+| `claw:admin` | Full paraclaw admin (write + create/delete groups) |
+| `hub:admin` | Manage hub services catalog + OAuth config (Reserved; not yet enforced) |
+| `parachute:host:admin` | Provision new vaults via hub `POST /vaults` and other host-level admin (operator-only-mintable; not requestable from third-party clients) |
 | `channel:send` | Post messages via channel |
 
 Third-party modules declare their own namespace (`my-service:read`, etc.)
@@ -36,33 +40,63 @@ and the hub renders consent for those scopes the same way.
 ## Inheritance
 
 ```
-admin ⊇ write ⊇ read       (for vault)
+admin ⊇ write ⊇ read       (for vault and claw)
 ```
 
-- `vault:admin` satisfies any check for `vault:write` or `vault:read`.
-- `vault:write` satisfies `vault:read`.
-- **Non-vault scopes exact-match only.** `scribe:admin` does **not**
+- `vault:<name>:admin` satisfies any check for `vault:<name>:write` or
+  `vault:<name>:read` on the same vault. Inheritance is per-resource —
+  `vault:work:admin` does **not** satisfy a `vault:personal:read` check.
+- `claw:admin` satisfies `claw:write` and `claw:read` (single-namespace,
+  no per-resource binding — paraclaw is one-installation-one-resource).
+- **Non-inheritance scopes exact-match only.** `scribe:admin` does **not**
   currently imply `scribe:transcribe` — each non-inheritance-tree scope
   stands alone. This is deliberate: we add inheritance per-service
   when the verb set clearly lines up as read/write/admin.
 
-Canonical implementation:
-[`parachute-vault/src/scopes.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/scopes.ts)
-(`hasScope`, `parseScopes`, `scopeForMethod`). Enforcement landed in
-[PR #97](https://github.com/ParachuteComputer/parachute-vault/pull/97).
+Canonical implementations:
+- vault — [`parachute-vault/src/scopes.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/scopes.ts)
+  (`hasScope`, `hasScopeForVault`, `findBroadVaultScopes`,
+  `parseScopes`, `verbForMethod`). Per-vault narrowing landed in
+  [PR #180](https://github.com/ParachuteComputer/parachute-vault/pull/180).
 
 ## Parser rules
 
 - **Split on whitespace** for the scope string; **split on `:`** for each
   scope.
-- **`vault:<name>:<verb>` collapses** to `vault:<verb>` during parse
-  (Phase 2 synonym — per-vault narrowing is a Phase 2+ feature).
+- **`vault:<name>:<verb>` is the enforced shape** — hub-issued JWTs MUST
+  carry resource-bound vault scopes. The hub's OAuth picker rewrites a
+  client's unnamed `vault:<verb>` request to `vault:<picked>:<verb>`
+  before issuing the auth code (see [parachute-hub/src/oauth-handlers.ts]).
+  Vault rejects bare `vault:<verb>` from JWT-shaped bearers.
+- **Per-vault audience binding.** Hub-issued vault JWTs carry
+  `aud=vault.<name>` and vault strict-checks it on each request — a token
+  scoped for one vault cannot be replayed against another.
+- **`pvt_*` tokens are unaffected.** They predate the resource-bound
+  shape; they're scoped at issue-time inside vault's own DB and the JWT
+  validation layer is bypassed for them.
 - **Empty resource segments are preserved verbatim** (`vault::read` stays
-  `vault::read`, so it can't satisfy a `vault:read` check — a one-line
-  defence against a malformed DB row).
+  `vault::read`, so it can't satisfy any vault check — a one-line defence
+  against a malformed DB row).
 - **Unknown scopes pass through** the parser untouched. They simply won't
   match anything, which is the right failure mode for a future-scope that
   reaches an old server.
+
+## Operator-only scopes
+
+Some scopes are marked **non-requestable** — the hub will refuse to issue
+them to any third-party OAuth client. They can only be minted on the
+operator-token path (the locally-stored `~/.parachute/operator.token`
+that ships with hub install).
+
+- `parachute:host:admin` — provisioning new vaults via hub `POST /vaults`.
+  Cross-vault data sovereignty; high blast radius. The asymmetry vs
+  `hub:admin` (which IS requestable) is deliberate: `hub:admin` manages
+  service registration, `parachute:host:admin` creates new long-lived
+  data resources on the host filesystem.
+
+Implementation: hub maintains a `NON_REQUESTABLE_SCOPES` set checked at
+`/oauth/authorize` request time; `invalid_scope` per RFC 6749 if a third
+party requests one.
 
 ## 403 response shape
 


### PR DESCRIPTION
## Summary

Catches the canonical scope-pattern doc up to what shipped in vault Phase 1 + hub Phase 1 on 2026-04-28.

Closes #16. Refs [vault#179](https://github.com/ParachuteComputer/parachute-vault/pull/179) design doc.

### Changes

**patterns/oauth-scopes.md:**
- Vault scopes flip from \`vault:<verb>\` to \`vault:<name>:<verb>\` (per-vault resource-bound). Inheritance is still admin⊇write⊇read but per-resource.
- \`claw:read\` / \`claw:write\` / \`claw:admin\` registered with same inheritance pattern.
- \`parachute:host:admin\` added as the first **non-requestable** operator-only scope (cross-vault host admin). Documents the asymmetry vs \`hub:admin\` (which IS requestable).
- Parser-rules section flipped: \`vault:<name>:<verb>\` is now the enforced shape, not a "Phase 2 synonym."
- Per-vault audience binding (\`aud=vault.<name>\`) documented.
- pvt_* token bypass noted (different code path).

**adoption/migration-notes.md:**
- New 2026-04-28 entry covering the resource-bound vault scope flip + claw + parachute:host:admin.
- Lists affected repos and what (if anything) each needs to do.

### Why

Per [parachute-patterns CLAUDE.md](../CLAUDE.md): pattern files document what's real. Phase 1 made vault scopes resource-bound and added claw + parachute:host:admin to the active set; the pattern doc was lagging.

## Test plan
- [x] No code in this repo; markdown-only change.
- [x] Cross-checked against [vault#180](https://github.com/ParachuteComputer/parachute-vault/pull/180) (scope-narrowing impl) and [hub#95](https://github.com/ParachuteComputer/parachute-hub/pull/95) (picker + non-requestable enforcement).
- [x] Reviewed inheritance + parser-rules sections for consistency with the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)