### PR TITLE
patterns(module-json): add managementUrl field (closes #20)

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,45 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-05-02 — `module.json` gains `managementUrl`
+
+**Change:** [`module-json-extensibility.md`](../patterns/module-json-extensibility.md)
+adds one optional field — `managementUrl?: string` — declaring where a
+module's admin UI lives.
+
+- Relative path (e.g. `"/admin"`) — hub resolves against the module's
+  well-known origin (`<module-url><managementUrl>`).
+- Full absolute URL — hub uses verbatim.
+- Absent — no link rendered (CLI-only management, or no admin surface).
+
+Aaron's call recorded 2026-05-02: per-module admin UIs live with the
+modules. Hub stays a thin directory + link-out; each module owns its
+admin surface end-to-end. Avoids hub leaking module-internal API shapes
+(vault's name list, scribe's job queue, etc.) into the portal.
+Backwards-compatible — same rule as `hasAuth` / `init` / `urlForEntry`:
+absent = "not present". Continues the schema work from
+[`parachute-patterns#19`](https://github.com/ParachuteComputer/parachute-patterns/pull/19).
+Closes [`parachute-patterns#20`](https://github.com/ParachuteComputer/parachute-patterns/issues/20).
+
+**Affected:**
+
+- `parachute-patterns` — pattern doc updated (this PR). No code change.
+- `parachute-vault` — will declare `managementUrl: "/admin"` once
+  vault-side SPA Phase A ships
+  ([`parachute-vault#216`](https://github.com/ParachuteComputer/parachute-vault/issues/216)).
+- `parachute-hub` — reads `managementUrl` from each module's well-known
+  doc and renders a "Manage <displayName>" link on the vault list /
+  directory page
+  ([`parachute-hub#158`](https://github.com/ParachuteComputer/parachute-hub/issues/158)).
+- `parachute-scribe`, `parachute-notes`, `paraclaw` — opportunity to
+  adopt later (each can ship its own admin UI if/when one materializes;
+  not on the immediate roadmap).
+
+**Status:** pattern doc landed (this PR). Vault adoption + hub render
+PRs pending.
+
+---
+
 ## 2026-04-30 — `module.json` gains `hasAuth`, `init`, `urlForEntry`
 
 **Change:** [`module-json-extensibility.md`](../patterns/module-json-extensibility.md)

--- a/patterns/module-json-extensibility.md
+++ b/patterns/module-json-extensibility.md
@@ -45,6 +45,7 @@ one file the author controls.
       "claude.ai": { "appendPath": "/mcp" }
     }
   },
+  "managementUrl": "/admin",
   "scopes": { "defines": ["my-service:read", "my-service:write"] },
   "dependencies": {
     "vault": { "optional": true, "scopes": ["vault:read"] }
@@ -66,6 +67,7 @@ one file the author controls.
 | `startCmd` | Argv the CLI invokes for `parachute start <name>`. Resolved relative to the installed package. |
 | `init` | Optional post-install one-shot the CLI runs after `parachute install <name>`. Object with a `command` argv. Safety: first arg must equal a bin defined by the installed npm package. See [Install-time behaviors](#install-time-behaviors). |
 | `urlForEntry` | Optional declarative URL adjustments keyed by consumer. Today's only operations: `appendPath` (append a suffix) or `replaceWith` (full override). See [Install-time behaviors](#install-time-behaviors). |
+| `managementUrl` | Optional path-or-full-URL where the module's admin UI lives. Hub renders a "Manage" link when present. See [Hub UI fields](#hub-ui-fields). |
 | `scopes.defines` | OAuth scopes the module owns. Namespaced by `name` so collisions don't happen — see [`oauth-scopes.md`](./oauth-scopes.md). |
 | `dependencies` | Other modules this one wants to talk to. Each entry has `optional` and `scopes` fields; CLI uses these to auto-wire on install (env-var injection) — see [`service-to-service-auth.md`](./service-to-service-auth.md). |
 
@@ -205,6 +207,53 @@ constant `/mcp` suffix; a regex lookup table is more complexity than the
 problem warrants. Re-evaluate if a third consumer needs a non-`appendPath`
 shape that doesn't reduce to `replaceWith`.
 
+## Hub UI fields
+
+Render-time fields the hub reads from a module's `module.json` (surfaced
+via the module's well-known doc) to shape its directory page. Optional;
+absent means "the hub renders nothing for this concern" — existing
+manifests stay valid unchanged.
+
+### `managementUrl: string`
+
+```ts
+managementUrl?: string;  // path or full URL
+```
+
+Where the module's admin UI lives. The hub reads this from the module's
+well-known doc and renders a "Manage <displayName>" link on its
+directory page. Added 2026-05-02 alongside the hub vault-management SPA
+work (parachute-hub#158, parachute-vault#216).
+
+**Resolution.**
+
+- **Relative path** (e.g., `"/admin"`): hub resolves against the module's
+  well-known origin — `<module-url><managementUrl>`. For first-party
+  modules under the hub origin this means `<hub-origin>/<short><managementUrl>`
+  (e.g., `https://parachute.tailnet/vault/admin`).
+- **Full absolute URL** (e.g., `"https://admin.example.com"`): hub uses
+  verbatim. Escape hatch for modules whose admin UI is hosted somewhere
+  other than the module's own origin.
+
+**Auth seam.** The module's UI handles its own auth — typically a
+hub-issued JWT scoped narrowly to that module (e.g., a vault-admin scope
+for vault's SPA). The hub doesn't proxy module internals or sniff auth
+headers; it links out and the module's own SPA boots up under its
+origin and runs its own OAuth dance against the hub if it needs one.
+
+**Backwards-compatible.** Absent field = no link rendered. Modules that
+manage purely via CLI, or have no admin surface at all, simply omit the
+field. Same rule as `hasAuth` / `init` / `urlForEntry`.
+
+**Why this lives with the module, not the hub.** Per-module admin UIs
+need to render module-internal API shapes — vault's name list, scribe's
+job queue, paraclaw's bot wiring. Putting the UI in the hub leaks those
+shapes into the portal and breaks the modular contract. Putting it
+under the module's own origin keeps the boundary clean: hub stays a
+thin directory + link-out; each module owns its admin surface
+end-to-end. Decision recorded 2026-05-02 (Aaron's call) after an
+initial pass at hub-side per-vault detail pages was reverted.
+
 ## Why this shape
 
 - **Author-controlled.** The package author declares everything in one
@@ -306,11 +355,12 @@ packages that pre-date the convention, then retires.
 ## Versioning
 
 The schema is **backwards-compatible**. Every field added to date —
-including the 2026-04-30 `hasAuth` / `init` / `urlForEntry` extension —
-is optional with a sensible "absent" default. Existing manifests stay
-valid; existing parsers ignore fields they don't understand. When (if)
-the shape evolves breakingly, we'll add a `manifestVersion: 1`
-discriminator. Defer until a v2 shape is real.
+including the 2026-04-30 `hasAuth` / `init` / `urlForEntry` extension
+and the 2026-05-02 `managementUrl` addition — is optional with a
+sensible "absent" default. Existing manifests stay valid; existing
+parsers ignore fields they don't understand. When (if) the shape
+evolves breakingly, we'll add a `manifestVersion: 1` discriminator.
+Defer until a v2 shape is real.
 
 ## Migration
 


### PR DESCRIPTION
## Summary

Extends `module.json` with one optional field — `managementUrl?: string` — declaring where a module's admin UI lives. Continues the schema work from #19 (which added `hasAuth` / `init` / `urlForEntry`).

- **Relative path** (e.g. `"/admin"`) — hub resolves against the module's well-known origin (`<module-url><managementUrl>`).
- **Full absolute URL** — hub uses verbatim.
- **Absent** — no link rendered (CLI-only management, or no admin surface).

Backwards-compatible — same rule as `hasAuth` / `init` / `urlForEntry`.

## Why

Aaron's call recorded 2026-05-02: per-module admin UIs live with the modules. Hub stays a thin directory + link-out; each module owns its admin surface end-to-end. Avoids hub leaking module-internal API shapes (vault's name list, scribe's job queue, paraclaw's bot wiring) into the portal. Decision came after an initial pass at hub-side per-vault detail pages was reverted.

## Lineage

- Continues #19 (hasAuth / init / urlForEntry — same backwards-compat rule, same "absent = not present" default).
- Closes #20.

## Cross-repo follow-on

- [`parachute-hub#158`](https://github.com/ParachuteComputer/parachute-hub/issues/158) — hub reads `managementUrl` from each module's well-known doc and renders a "Manage <displayName>" link on the vault list / directory page.
- [`parachute-vault#216`](https://github.com/ParachuteComputer/parachute-vault/issues/216) — vault declares `managementUrl: "/admin"` once vault-side SPA Phase A ships (first adopter).
- `parachute-scribe`, `parachute-notes`, `paraclaw` — opportunity to adopt later; not on the immediate roadmap.

## Changes

- `patterns/module-json-extensibility.md` — adds `managementUrl` to the example shape, the field table, a new "Hub UI fields" section detailing resolution / auth seam / rationale, and a Versioning note covering the 2026-05-02 addition.
- `adoption/migration-notes.md` — new top-of-log entry tracking the schema change and the cross-repo follow-on.

Docs-only, no rc bump (per the doc-only-skip-rc convention).

## Test plan

- [x] Renders correctly in markdown
- [x] Internal anchor `#hub-ui-fields` links from the field table
- [x] Cross-repo issue links resolve (hub#158, vault#216, patterns#19, patterns#20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)