### PR TITLE
patterns: vault#249 adoption note + tag-scoped-tokens vocab scrub

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,7 +5,29 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
-## 2026-05-03 — Tag data model reshape (vault — pending)
+## 2026-05-03 — `_schemas/*` retirement to `note_schemas` + `schema_mappings` (vault)
+
+**Change:** [`tag-data-model.md`](../patterns/tag-data-model.md) approach extended to note-validation schemas. Companion to the tag-data-model reshape (#245). Retires the `_schemas/<name>` config-note pattern + the singleton `_schema_defaults` note in favor of two SQL tables: `note_schemas (name PK, fields JSON, description, required JSON)` for schema definitions, and `schema_mappings (schema_name FK, match_kind ENUM 'path_prefix' | 'tag', match_value)` for the path-prefix + tag-based mapping rules.
+
+Schema migration v14 → v15: additive; data migration copies existing `_schemas/<name>` notes' metadata + `_schema_defaults` mappings → new tables. Migration is transactional (BEGIN IMMEDIATE / COMMIT or ROLLBACK), idempotent on re-runs, and verified on byte-identical copies of all three of Aaron's real DBs.
+
+New MCP/HTTP authoring surface: `update-note-schema` / `delete-note-schema` / `list-note-schemas` / `set-schema-mapping` / `delete-schema-mapping`. MCP tool count: 10 → 16.
+
+Tag-scope auth-check is threaded through `handleNoteSchemas` consistent with the `handleTags` precedent — tag-scoped tokens cannot enumerate or write `tag`-kind mappings outside their allowlist. `path_prefix` mappings are orthogonal to tag scope (no filter applied). String-form fallback honored.
+
+`_schemas/<name>` notes + `_schema_defaults` note left in place post-migration as harmless historical record.
+
+**Affected:**
+
+- `parachute-vault` — adopted in [`vault#249`](https://github.com/ParachuteComputer/parachute-vault/pull/249), shipped at rc.33
+- `parachute-patterns` — `tag-scoped-tokens.md` had stale references to `_schemas/<name>` notes scrubbed out alongside this entry (same patterns PR)
+- `parachute-notes` / clients — Notes app and other vault clients should migrate any direct reads/writes against `_schemas/<name>` paths to the new MCP/HTTP surface; legacy reads still work for backwards-compat but won't reflect the latest schema state
+
+**Status:** Shipped. Arc complete (tag-data-model + schemas-retirement landed across vault#245 + vault#249).
+
+---
+
+## 2026-05-03 — Tag data model reshape (vault)
 
 **Change:** [`tag-data-model.md`](../patterns/tag-data-model.md) introduced.
 Retires the notes-as-config pattern for tag concerns: collapses
@@ -34,8 +56,7 @@ markdown from tables when needed.
   it fires on `tags` row writes. Update on next patterns PR alongside the
   vault implementation merge
 
-**Status:** Design merged via patterns#29. Implementation tracking issue
-vault#244. Block on vault implementation landing before declaring "done."
+**Status:** Design merged via patterns#29. Implementation shipped in [`vault#245`](https://github.com/ParachuteComputer/parachute-vault/pull/245) at rc.31. Companion `_schemas/*` retirement shipped at rc.33 via vault#249 — see entry above. Arc complete.
 
 ---
 

--- a/patterns/tag-scoped-tokens.md
+++ b/patterns/tag-scoped-tokens.md
@@ -28,7 +28,7 @@ Where `rootOf(t)` is `t.split('/')[0]` so `health/food` resolves to `health` for
 A token whose allowlist contains `health` matches:
 
 - A note tagged `#health` (direct match)
-- A note tagged ONLY with `#health/food` (hierarchy expansion via `_tags/<name>`)
+- A note tagged ONLY with `#health/food` (hierarchy expansion via `tags.parent_names`)
 - A note tagged ONLY with `#health/doctor` (same)
 - A note tagged with `#health/food/breakfast` (recursive sub-tag)
 
@@ -44,7 +44,7 @@ The expansion uses vault's existing `getTagDescendants` machinery (same path tha
 
 The use case: per-purpose paraclaw bots. A `#health` Claw, a `#work` Claw, a `#journal` Claw — each spawned from the same vault, but with isolated visibility into the slice of notes the operator has tagged for it. Currently isolation is per-vault (separate `default` / `boulder` / `techne` vaults); this lets you slice within one vault.
 
-Schema = tag in this design — the `_tags/<name>` config note IS the schema for tag `<name>`.
+Schema-on-tag is a load-bearing concept in this design — see [`tag-data-model.md`](./tag-data-model.md) for the schema authoring shape. Each tag carries its own schema (description + indexed fields + typed relationships) directly on the `tags` row.
 
 ## How it composes
 
@@ -52,7 +52,7 @@ Schema = tag in this design — the `_tags/<name>` config note IS the schema for
 - **Write paths** — POST /api/notes / PATCH require the new note to carry at least one allowlisted root-tag. POST without any matching tag returns `403 forbidden`.
 - **Delete paths** — DELETE /api/notes/:id requires the existing note to be within scope. A token can't delete a note it can't read.
 - **Tag operations** — list-tags returns only tags reachable from the allowlist (root tags + sub-tags). create-tag is allowed only if the new tag is a sub-tag of one of the allowlisted roots.
-- **Schema operations** — `_tags/<name>` config notes are write-protected unless the token has `vault:<name>:admin` AND the tag is in the allowlist. A tag-scoped admin CAN modify the schema for tags within their allowlist.
+- **Schema operations** — the `update-tag` API (which writes to the `tags` row's schema columns: `description`, `fields`, `relationships`, `parent_names`) is gated by `vault:<name>:admin` + tag-in-allowlist. A tag-scoped admin CAN modify the schema for tags within their allowlist. Same gating applies to `update-note-schema` / `set-schema-mapping` for note-validation schemas.
 
 ## Composability with existing scopes
 
@@ -65,10 +65,13 @@ Schema = tag in this design — the `_tags/<name>` config note IS the schema for
 
 A tag-scoped admin **cannot** mint new tokens with broader allowlists. The mint endpoint enforces: *"a token's allowlist must be a subset of the minter's allowlist."* This prevents privilege escalation via mint:
 
-- Admin with `[health]` minting a token with `[health, work]` → `403 forbidden`
-- Admin with `[health]` minting a token with `[health/food]` → OK (subset)
+- Admin with `[health]` minting a token with `[health, work]` → `403 forbidden` (broader)
+- Admin with `[health, work]` minting a token with `[health]` → OK (subset)
 - Admin with `[health]` minting a token with `[health]` → OK (equal)
+- Admin with `[health]` minting a token with `[health/food]` → `400 bad request` (path-form values are rejected; only root-tag names allowed in the allowlist)
+- Admin with `[health]` minting a token with `tags` field omitted → `403 forbidden` (would widen to unscoped)
 - Admin with `null` (unscoped) minting any allowlist → OK (null is the universe)
+- Admin with `null` minting with `tags` omitted → produces an unscoped token (back-compat)
 
 ## Token issuance
 

--- a/patterns/tag-scoped-tokens.md
+++ b/patterns/tag-scoped-tokens.md
@@ -7,7 +7,7 @@
 A vault token (`pvt_*`) optionally declares a **tag-allowlist** at mint time. Once set, the token's effective access is the intersection of:
 
 1. **Scope** (existing) — `vault:<name>:read | write | admin` per `oauth-scopes.md`
-2. **Tag allowlist** (new) — list of root tag names. Sub-tags inherit per the existing `_tags/<name>` hierarchy machinery (vault#214 / store-routing fix). The allowlist is **immutable** for the life of the token; editing the allowlist means minting a new token and revoking the old.
+2. **Tag allowlist** (new) — list of root tag names. Sub-tags inherit per the `tags.parent_names` hierarchy (post-vault#244; previously backed by `_tags/<name>` config notes per vault#214 / store-routing fix). The allowlist is **immutable** for the life of the token; editing the allowlist means minting a new token and revoking the old.
 
 Pseudocode for the auth check:
 
@@ -124,13 +124,13 @@ If we later want third-party clients to request tag-scoped tokens via OAuth cons
 
 **Out-of-scope writes return 403 (not 404).** Writes are gated *before* the write happens; the existence of the target isn't being probed. Returning 403 here is the correct shape — the operator/agent attempted a write outside their allowlist; the system tells them so explicitly.
 
-**Tag string is the authority.** A note's `note_tags` rows are what the auth check evaluates against. The `_tags/<name>` config notes provide schema (indexed fields, descriptions) but don't gate the auth check directly. A tag string `#health/food` on a note participates in scope evaluation regardless of whether `_tags/health/food` exists as a schema note (the string-form `/`-prefix hierarchy is sufficient).
+**Tag string is the authority.** A note's `note_tags` rows are what the auth check evaluates against. The `tags` row carries the schema (description, fields, relationships, parent_names) but doesn't gate the auth check directly. A tag string `#health/food` on a note participates in scope evaluation regardless of whether `health/food` has a `tags.parent_names` entry pointing at `health` (the string-form `/`-prefix hierarchy is sufficient — see §Storage details mechanism 2).
 
 ## Lifecycle
 
 **Tag rename cascades** (Aaron's directive 2026-05-02). When operator runs `PATCH /api/tags/<old_name>` with `{ name: <new_name> }`:
 
-1. The `tags` row's `name` PK is updated. `note_tags`, `tag_schemas` (legacy, retired post-vault#244), and any other FK referencing `tags.name` cascade-update.
+1. The `tags` row's `name` PK is updated. `note_tags` and any other FK referencing `tags.name` cascade-update. (The legacy `tag_schemas` sidecar table was dropped in the v14 migration; no longer in scope for cascade.)
 2. Sub-tags whose name has prefix `<old_name>/` are renamed to `<new_name>/...` recursively (each is its own row in `tags` with its own `parent_names`).
 3. **`tags.parent_names` cascade** (post-vault#244): every tag with `<old_name>` in its `parent_names` JSON is rewritten to `<new_name>`. Without this, the hierarchy edge silently breaks on rename.
 4. Tokens whose `scoped_tags` JSON array contains `<old_name>` (root-form) are auto-updated to contain `<new_name>` instead. Allowlist content changes; token id, label, and scope are preserved. Sub-tag renames (e.g., `health/food` → `health/snack`) are a no-op for token allowlists, since only root-form entries are stored there.


### PR DESCRIPTION
Closes patterns#31. Two doc-only updates closing the tag-data-model arc:

## 1. `adoption/migration-notes.md`

- New entry for vault#249 (`_schemas/*` retirement shipped at rc.33)
- Updates the prior tag-data-model entry's status from "pending" to "shipped"

## 2. `patterns/tag-scoped-tokens.md` vocabulary scrub

Per patterns#31 — references to `_tags/<name>` config notes that are now stale post-v14/#245:

- §Hierarchy match semantics: "via `_tags/<name>`" → "via `tags.parent_names`"
- §Why: replace "Schema = tag... `_tags/<name>` config note IS the schema" with explicit cross-reference to `tag-data-model.md`
- §How it composes — Schema operations: replace stale config-note write-protection language with the actual API surface (`update-tag` / `update-note-schema` / `set-schema-mapping`)
- §Mint authority — sixth bullet: replace incorrect path-form-as-subset example with the actual rejection (path-form values are rejected at mint per vault#241/#245). Plus the omit-tags privesc rule that was missing from the canonical mint authority section.

## Status

Tag-data-model arc completion summary:
- patterns#29 (design) ✅
- patterns#30 (vocab refresh, partial) ✅
- vault#245 (tag data model implementation, rc.31) ✅
- vault#249 (`_schemas/*` retirement, rc.33) ✅
- patterns#31 (full vocab scrub) ← this PR
- vault#247, #248, future patterns issues — backlog tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)