### PR TITLE
docs(patterns): module-json-extensibility — refresh publicExposure runtime behavior post-hub#187 (closes #39)

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,49 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-05-08 — `publicExposure` is a hub-side per-request layer-gate
+
+**Change:** [`module-json-extensibility.md`](../patterns/module-json-extensibility.md)
+refreshed — the `hasAuth` section's runtime description was stale.
+`publicExposure` is now enforced **per request, in hub**, not at expose
+time. Every reverse-proxied request is tagged with the layer it arrived
+on (`loopback` / `tailnet` / `public`) and hub consults the target
+service's `publicExposure` to decide whether to proxy or 404. The expose
+surface collapses to a single hub catchall on the tailnet; per-service
+expose toggles are no longer independent state.
+
+Access matrix codified by [parachute-hub#187](https://github.com/ParachuteComputer/parachute-hub/pull/187):
+
+| `publicExposure` | Loopback | Tailnet | Public | Gated by |
+| --- | --- | --- | --- | --- |
+| `"allowed"` | reaches | reaches | reaches | service's own auth |
+| `"loopback"` | reaches | 404 | 404 | hub layer-gate |
+| `"auth-required"` | reaches | reaches | reaches | service's own auth |
+
+`"allowed"` and `"auth-required"` produce identical hub behavior; the
+distinction is documentary intent. `"loopback"` is the only value that
+withholds non-loopback traffic. The pre-#187 wording — "treated as
+loopback at expose time until the operator opts in explicitly" —
+described an at-expose-time filtering model that no longer matches the
+runtime; scrubbed.
+
+Closes [`parachute-patterns#39`](https://github.com/ParachuteComputer/parachute-patterns/issues/39).
+
+**Affected:**
+
+- `parachute-patterns` — pattern doc updated (this PR). No code change.
+- `parachute-hub` — already shipped the runtime in
+  [`#187`](https://github.com/ParachuteComputer/parachute-hub/pull/187).
+  Pattern doc now matches.
+- Module authors (vault, scribe, notes, agent, third-party) — no
+  manifest change required. `hasAuth` semantics are unchanged; only the
+  doc's description of how hub honors the derived `publicExposure` is
+  refreshed.
+
+**Status:** complete on 2026-05-08.
+
+---
+
 ## 2026-05-04 — `paraclaw` renamed to `parachute-agent`
 
 **Change:** the exploration package previously called `paraclaw` is

--- a/patterns/module-json-extensibility.md
+++ b/patterns/module-json-extensibility.md
@@ -93,10 +93,38 @@ bearer tokens on its own endpoints. The hub uses this to derive
 `publicExposure`'s default for `kind: "api" | "tool"` services: with
 `hasAuth: true` they default to `"allowed"` (safe to expose because the
 module gates itself); without it they default to `"auth-required"`
-(treated as loopback at expose time until the operator opts in
-explicitly). It also informs how `parachute expose` and the discovery
-surface treat bearer-bearing modules. `kind: "frontend"` modules ignore
-this field — they default to `"allowed"` regardless.
+(the module hasn't claimed auth, so non-loopback layers are gated by
+hub on its behalf). It also informs how `parachute expose` and the
+discovery surface treat bearer-bearing modules. `kind: "frontend"`
+modules ignore this field — they default to `"allowed"` regardless.
+
+#### Runtime behavior — hub-side per-request layer-gate
+
+`publicExposure` is enforced **per request, in hub**, not at expose
+time. Every reverse-proxied request is tagged with the layer it
+arrived on — `loopback` (127.0.0.1), `tailnet` (Tailscale), or
+`public` (Cloudflare Tunnel / Funnel) — and hub consults the target
+service's `publicExposure` value to decide whether to proxy or 404.
+The expose surface (tailnet, public) is collapsed to a single hub
+catchall; per-service expose toggles do not exist as independent
+state anymore. See [parachute-hub#187](https://github.com/ParachuteComputer/parachute-hub/pull/187)
+for the implementing change (2026-05-08).
+
+Access matrix:
+
+| `publicExposure` | Loopback | Tailnet | Public | Gated by |
+| --- | --- | --- | --- | --- |
+| `"allowed"` | reaches | reaches | reaches | service's own auth (none required by hub) |
+| `"loopback"` | reaches | 404 | 404 | hub layer-gate (the service never sees the request) |
+| `"auth-required"` | reaches | reaches | reaches | service's own auth (same gate behavior as `"allowed"`; the value documents "I have auth and I'm enforcing it" vs. `"allowed"`'s "no opinion / open") |
+
+Concretely: `"loopback"` is the only value that withholds traffic
+from non-loopback layers. `"allowed"` and `"auth-required"` produce
+identical hub behavior — the difference is documentary: `"allowed"`
+asserts the service is intentionally open or has no sensitive
+surface; `"auth-required"` asserts the service is enforcing auth on
+its own endpoints. Hub forwards in both cases and trusts the service
+to handle authn/z.
 
 Trivially declarative — the value doesn't change at runtime. If a
 module's auth gate is conditional on a config flag (e.g., scribe with /


### PR DESCRIPTION
## Summary

Closes [#39](https://github.com/ParachuteComputer/parachute-patterns/issues/39).

`patterns/module-json-extensibility.md`'s `hasAuth` section described `publicExposure: \"auth-required\"` as *\"treated as loopback at expose time until the operator opts in explicitly.\"* That **at-expose-time filtering** model is stale — [parachute-hub#187](https://github.com/ParachuteComputer/parachute-hub/pull/187) (merged 2026-05-08) moved enforcement to a **per-request, hub-side layer-gate** that consults `publicExposure` on every reverse-proxied request.

The new runtime contract (codified by hub#187):

| `publicExposure` | Loopback | Tailnet | Public | Gated by |
| --- | --- | --- | --- | --- |
| `\"allowed\"` | reaches | reaches | reaches | service's own auth |
| `\"loopback\"` | reaches | 404 | 404 | hub layer-gate |
| `\"auth-required\"` | reaches | reaches | reaches | service's own auth |

`\"allowed\"` and `\"auth-required\"` produce identical hub behavior — the difference is documentary intent (`\"allowed\"` = no opinion / open; `\"auth-required\"` = service has auth and is enforcing it). `\"loopback\"` is the only value that withholds non-loopback traffic.

## Changes

- `patterns/module-json-extensibility.md` — scrub the stale wording in the `hasAuth` section; add a *Runtime behavior — hub-side per-request layer-gate* subsection with the access-control matrix and a permalink to hub#187.
- `adoption/migration-notes.md` — new dated entry (2026-05-08) explaining the shift, the matrix, and that no module-author manifest changes are required (semantics of `hasAuth` are unchanged; only the doc's description of how hub honors the derived `publicExposure` is refreshed).

No other patterns referenced expose-time filtering — verified by grepping `expose.time | expose-time | withheld | loopback at expose | at expose time | treated as loopback` across the repo. The only remaining match after this PR is the deliberate quotation in the new migration-notes entry calling out the old wording as scrubbed.

## Why no version bump

Doc-only change in a documentation-only repo. `parachute-patterns` has no `package.json` / `CHANGELOG` / `VERSION` artifact and ships nothing to npm — no `-rc.N` cycle applies. Per Aaron's memory rule on doc-only diffs, no RC validation gate.

## Test plan

- [ ] Reviewer confirms the matrix matches what hub#187 actually implements.
- [ ] Reviewer confirms no other pattern doc still claims at-expose-time filtering or implies `publicExposure` is enforced by writing the value into per-service expose-state at toggle time.
- [ ] Reviewer confirms the `hasAuth` defaulting story (`hasAuth: true` → `\"allowed\"`; absent → `\"auth-required\"`) is still accurate post-#187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)