### PR TITLE
docs(patterns): governance + cli-as-port-authority refresh (closes #43, #44)

### DIFF
--- a/patterns/canonical-ports.md
+++ b/patterns/canonical-ports.md
@@ -19,7 +19,7 @@ chosen port into the service's `.env`. See
 assignment algorithm, idempotency rules, and the service-side contract
 this doc's reservations get enforced through.
 
-## Reservations (state of the world, 2026-04-25)
+## Reservations (state of the world, 2026-05-08)
 
 | Port | Service | Tier | Status | Notes |
 |---|---|---|---|---|
@@ -27,8 +27,8 @@ this doc's reservations get enforced through.
 | 1940 | `parachute-vault` | committed core | assigned | REST + MCP at `/vault/<name>/`. |
 | 1942 | `parachute-notes` | committed core | assigned | Static server over the PWA bundle. |
 | 1943 | `parachute-scribe` | committed core | assigned | Whisper-compatible transcription API at root. |
+| 1944 | `parachute-agent` | committed core | assigned | Web UI + agent runtime. De facto since launch; formally assigned 2026-05-08 to reflect agent's compiled-in default and `module.json` services.json seed. |
 | 1941 | `parachute-channel` | working module | assigned | Daemon. Exploratory; may retire — not part of the committed ecosystem. |
-| 1944 | unassigned | — | reserved | |
 | 1945 | unassigned | — | reserved | |
 | 1946 | unassigned | — | reserved | |
 | 1947 | unassigned | — | reserved | |
@@ -36,9 +36,7 @@ this doc's reservations get enforced through.
 | 1949 | unassigned | — | reserved | |
 
 The **committed core** is the set of modules the Parachute ecosystem
-commits to maintaining: hub, vault, notes, scribe, agent. Agent is
-also committed-core but doesn't reserve a port in this range — it
-ships its own `services.json` entry via `module.json`. **Working
+commits to maintaining: hub, vault, notes, scribe, agent. **Working
 modules** like channel exist and run, but the ecosystem does not
 commit to them as long-term first-party citizens.
 
@@ -91,7 +89,7 @@ than walking up into a service's slot.
 - **A registry of running services.** That's `~/.parachute/services.json`
   — see [module-protocol.md](./module-protocol.md). The reservation
   table says what *should* be at a port; services.json says what *is*.
-- **A roadmap.** Slots `1944–1949` are unassigned, not earmarked.
+- **A roadmap.** Slots `1945–1949` are unassigned, not earmarked.
   Whichever module ships first into the range claims the next free slot.
 
 ## Open questions

--- a/patterns/cli-as-port-authority.md
+++ b/patterns/cli-as-port-authority.md
@@ -3,11 +3,17 @@
 ## Convention
 
 `parachute-hub` is the **port authority** for the Parachute ecosystem. At
-install time the CLI picks a port for each service, persists it as
-`PORT=<port>` in `~/.parachute/<svc>/.env`, and reflects the chosen port in
-`~/.parachute/services.json`. Services read `PORT` from env on boot with a
-compiled-in fallback (e.g. vault → 1940), so a stand-alone `bun run` still
-works — but the CLI's value wins on installs the CLI manages.
+install time the CLI picks a port for each service and reflects the chosen
+port in `~/.parachute/services.json` (also stamping `PORT=<port>` into
+`~/.parachute/<svc>/.env` as a dev-shell convenience).
+
+Services resolve their listen port at boot via a four-tier ladder:
+**`services.json` entry → service-specific env (`<SERVICE>_PORT`) → bare
+`PORT` env → compiled-in canonical default**. The hub's `parachute install`
+and the operator's manifest edits both feed `services.json`; env tiers are
+dev-shell / PaaS overrides; the canonical default (e.g. vault → 1940) is
+the final fallback so a stand-alone `bun run` still works. See
+"Service-side contract" below.
 
 The authoritative implementation is
 [`parachute-hub/src/port-assign.ts`](https://github.com/ParachuteComputer/parachute-hub/blob/main/src/port-assign.ts).
@@ -131,11 +137,16 @@ migrated (a port carried over from a previous host). Treating
 fallback closes the loop where a service's own boot rewrites the
 operator's manifest from a stale env.
 
-The ladder is the same shape for every service. Scribe and agent
-implement it today (see "Implementing changes" below); vault and notes
-have services.json reads for other purposes but haven't yet adopted the
-ladder for port resolution — adoption is the follow-up work. Operators
-reading the rule from one service should not be surprised by another.
+The ladder is the same shape for every service. Scribe implements all
+four tiers today
+([`parachute-scribe#41`](https://github.com/ParachuteComputer/parachute-scribe/pull/41)).
+Agent implements three — `services.json` → `PARACHUTE_AGENT_WEB_PORT` →
+default — pending
+[`parachute-agent#147`](https://github.com/ParachuteComputer/paraclaw/issues/147)
+to add the bare `PORT` env tier for full symmetry. Vault and notes have
+services.json reads for other purposes but haven't yet adopted the ladder
+for port resolution — adoption is the follow-up work. Operators reading
+the rule from one service should not be surprised by another.
 
 The CLI's `lifecycle.start` merges `~/.parachute/<svc>/.env` into the
 spawn env before exec, so a CLI-managed boot still sees the assigned

--- a/patterns/cli-as-port-authority.md
+++ b/patterns/cli-as-port-authority.md
@@ -103,29 +103,78 @@ To force a re-pick: delete the `PORT=` line from
 
 ## Service-side contract
 
-Services don't have to change to participate. They keep doing what they
-already do:
+A service resolves its listen port at boot via this precedence ladder
+(highest priority first):
 
-1. Read `PORT` from `process.env` on boot.
-2. If absent, fall back to a compiled-in default (vault → 1940, notes →
-   1942, scribe → 1943).
-3. Bind and serve.
+1. **`services.json` entry's `port`** for the service's name in
+   `~/.parachute/services.json`. This is the operator-canonical record.
+2. **`<SERVICE>_PORT` env** — service-scoped explicit override
+   (`PARACHUTE_SCRIBE_PORT`, `PARACHUTE_AGENT_WEB_PORT`, etc.).
+3. **`PORT` env** — generic / PaaS-style override and what the hub's
+   port-assigner writes into `~/.parachute/<svc>/.env` at install time.
+4. **Compiled-in canonical default** (vault → 1940, notes → 1942,
+   scribe → 1943, agent → 1944).
+
+The service then binds and serves. On `EADDRINUSE` (or any bind error)
+the service **fails loudly** with a named conflict — port number, the
+source the port came from (`services.json` / env var name / `default`),
+and an actionable hint — and exits non-zero. **It does not silently
+re-pick** another port at runtime: re-picking would let services drift
+out of the manifest the hub uses to compute proxy targets, exactly the
+class of bug up-front assignment exists to prevent.
+
+Why `services.json` outranks env: env values can be stale (the hub's
+port-assigner stamps a value once and never clears it; a later
+operator-edited `services.json` is the more authoritative record) or
+migrated (a port carried over from a previous host). Treating
+`services.json` as the source of truth and env as a first-run / dev-shell
+fallback closes the loop where a service's own boot rewrites the
+operator's manifest from a stale env.
+
+The ladder is the same shape for every service. Scribe and agent
+implement it today (see "Implementing changes" below); vault and notes
+have services.json reads for other purposes but haven't yet adopted the
+ladder for port resolution — adoption is the follow-up work. Operators
+reading the rule from one service should not be surprised by another.
 
 The CLI's `lifecycle.start` merges `~/.parachute/<svc>/.env` into the
-spawn env before exec, so a CLI-managed boot sees the assigned `PORT`. A
-direct `bun run` outside the CLI still works on the compiled-in fallback.
+spawn env before exec, so a CLI-managed boot still sees the assigned
+`PORT` if no `services.json` entry exists (first install). A direct
+`bun run` outside the CLI works the same way — env override or
+compiled-in default.
 
-This means: **third-party modules need no integration with the port
-authority to coexist.** Drop them in, point `parachute install` at them,
-and they'll land on a free slot in the reserved range or a warned slot
-outside it.
+This means: **third-party modules participate by implementing the
+ladder.** A module that only reads env (skipping `services.json`) won't
+respect operator edits to the manifest after first install. The
+implementation is small (one resolver function + a manifest read) and
+the service-scoped env name (`<SERVICE>_PORT`) is the module's choice.
+
+**Implementing changes:**
+
+- [`parachute-scribe#41`](https://github.com/ParachuteComputer/parachute-scribe/pull/41) /
+  commit [`9f28ad2`](https://github.com/ParachuteComputer/parachute-scribe/commit/9f28ad27c508f95bc5ebc678ada28b5a338ce324)
+  — landed the ladder in scribe; pure `resolvePort()` helper +
+  `readServiceEntry()` accessor + named bind-failure logging.
+- [`parachute-agent#146`](https://github.com/ParachuteComputer/paraclaw/pull/146) /
+  commit [`b919fc2`](https://github.com/ParachuteComputer/paraclaw/commit/b919fc2da5c9dfbd230225bea80e2a5f135fa78a)
+  — symmetric fix in agent (the GitHub repo slug is still `paraclaw`
+  pending the rename to `parachute-agent`; see
+  [`adoption/migration-notes.md`](../adoption/migration-notes.md#2026-05-04--paraclaw-renamed-to-parachute-agent)).
+  Initial cut had `env > services.json`; reviewer fold-fix inverted to
+  match scribe.
+
+Both shipped 2026-05-08 in response to a real collision: stale
+`PORT=1944` env on scribe + agent's hardcoded slot raced for the same
+port, services.json edits were silently reverted on every boot. The
+ladder change makes the manifest stick.
 
 ## Rules
 
 - **The CLI is the authority on installed services.** A service that
-  hard-codes a port without honoring `process.env.PORT` breaks the
-  authority and will collide on contested machines. Always read env first,
-  fall back compiled-in second.
+  hard-codes a port — or ignores the resolution ladder above — breaks the
+  authority and will collide on contested machines. Resolve in order:
+  `services.json` entry → `<SERVICE>_PORT` env → `PORT` env → compiled-in
+  default.
 - **Don't write `PORT` from inside a service's own init.** The CLI writes
   it during install. A service init that also writes `PORT` creates two
   sources of truth and an idempotency hole.

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -10,9 +10,12 @@ open PRs and report status; team-lead reviews and writes a verification
 summary; the repo owner (currently Aaron) clicks merge.
 
 - All Parachute repos with code or content (`parachute-hub`, `parachute-vault`,
-  `parachute-notes`, `parachute-scribe`, `parachute.computer`,
-  `parachute-patterns`) have **branch protection on `main`**: no force-push,
-  no branch deletion, PR-required for changes.
+  `parachute-notes`, `parachute-scribe`, `parachute-agent`,
+  `parachute.computer`, `parachute-patterns`) have **branch protection on
+  `main`**: no force-push, no branch deletion, PR-required for changes.
+  `parachute-agent` joined this set on its committed-core promotion
+  (2026-05-05) and is subject to the same review-discipline / RC-versioning /
+  patterns-check rules as the original five.
 - **Required-review count is calibrated to team size**:
   - **Solo human team (today):** required approvals = `0`. The single human
     *is* both reviewer and merger; a separate "approve" click before "merge"


### PR DESCRIPTION
## Summary

Two related stale-doc fixes bundled into one PR — both pre-existing gaps surfaced today, both content-only, both in `patterns/`. Doc-only, no version bump (and no version artifact in this repo to bump anyway).

## #43 — `governance.md` missing `parachute-agent`

`patterns/governance.md` listed the branch-protected committed-core repos but didn't include `parachute-agent`, which was promoted to committed-core on 2026-05-05 (per workspace `CLAUDE.md`). A reader using governance.md as the canonical "which repos enforce what" reference got a stale list — especially confusing when onboarding a new agent tentacle.

Fix: add `parachute-agent` to the list with a short date-anchored note (2026-05-05 promotion) so the lineage of the original five vs. the late addition is preserved.

## #44 — `cli-as-port-authority.md` service-side contract is stale post-scribe#41 / agent#146

The "Service-side contract" section described the boot-time port resolution as "read `PORT` from env, fall back to compiled-in default." After [`parachute-scribe#41`](https://github.com/ParachuteComputer/parachute-scribe/pull/41) and [`parachute-agent#146`](https://github.com/ParachuteComputer/paraclaw/pull/146) (both merged 2026-05-08), the contract is:

**`services.json` entry → `<SERVICE>_PORT` env → `PORT` env → canonical default.**

The change addressed a real bug class on Aaron's box: hub's port-assigner stamps `PORT=1944` into a service's `.env` once and never clears it, so on every subsequent boot a stale env value clobbered any operator edit to `services.json`. Making `services.json` the highest-priority source means operator edits stick.

Fix:
- Rewrote "Service-side contract" with the four-tier ladder, the rationale (services.json is operator-canonical; env can be stale or migrated), and the bind-failure expectation (named conflict + non-zero exit, not silent re-pick).
- Added "Implementing changes" subsection with deep links to scribe#41 (commit `9f28ad2`) and agent#146 (commit `b919fc2`). Note: agent's GitHub repo slug is still `paraclaw` pending the rename to `parachute-agent`; cross-linked to `adoption/migration-notes.md` for that context.
- Updated the conflicting "Rules" bullet ("Always read env first, fall back compiled-in second") to match the new ladder.
- Tempered the symmetry claim — scribe + agent implement the ladder today; vault + notes have services.json reads for other purposes but haven't yet adopted the ladder for port resolution.

## Review folds (commit `9b97f6a`, 2026-05-08)

Reviewer came back **Changes requested** with three real issues. All three folded in a single commit:

1. **Convention summary refresh.** The TL;DR at the top of `cli-as-port-authority.md` still described the old 2-step contract — a reader stopping at the summary walked away with the wrong mental model. Rewrote it to reference the 4-tier ladder and point down to the full Service-side contract section.

2. **Agent ladder qualification.** Prior text claimed "scribe and agent implement [the ladder] today." Reality: scribe implements all 4 tiers; agent implements 3 (missing the bare `PORT` env tier). Qualified concretely — scribe implements all four (parachute-scribe#41), agent implements three pending [`parachute-agent#147`](https://github.com/ParachuteComputer/paraclaw/issues/147) to add the bare `PORT` env tier for full symmetry.

3. **Cross-doc contradiction reconcile (chosen path: assign 1944 to agent in canonical-ports.md).** `cli-as-port-authority.md` cites "agent → 1944" as a default; `canonical-ports.md` had said 1944 is "unassigned / reserved" with a caveat that agent doesn't reserve a port in the range. Resolved by **formally assigning 1944 to parachute-agent in `canonical-ports.md`** — agent has been hardcoding 1944 since launch and now defaults to 1944 in its module.json services.json seed, so the reservation is de facto. Updated the table row, dropped the "doesn't reserve a port in this range" caveat, bumped the "state of the world" date to 2026-05-08, and updated the "1944–1949 unassigned" line to "1945–1949". Chose this over the alternative (remove the agent → 1944 claim from cli-as-port-authority) because aligning the doc with the code's reality is the more honest current-state reflection.

## Process

- Branch: `ag-unforced-dev`, three commits (one per issue + one fold-commit, kept separate for diff readability — squash-merge is fine).
- No version bump (doc-only + no version artifact).
- Closes #43, closes #44.

## Test plan

- [ ] Visual review of `patterns/governance.md` — `parachute-agent` listed alongside the original five, 2026-05-05 anchor preserved
- [ ] Visual review of `patterns/cli-as-port-authority.md` — Convention summary references the 4-tier ladder; Service-side contract describes the four-tier ladder; scribe#41 + agent#146 + agent#147 deep links resolve; Rules bullet aligns with the new ladder; agent's 3-tier-pending-symmetry status is qualified
- [ ] Visual review of `patterns/canonical-ports.md` — 1944 row shows `parachute-agent` / committed core / assigned with the de-facto-since-launch note; "doesn't reserve a port" caveat removed; 1945–1949 reserved; date stamp updated to 2026-05-08
- [ ] Spot-check the deep links — `parachute-scribe/pull/41` returns 200, `paraclaw/pull/146` returns 200, `paraclaw/issues/147` returns 200 (parachute-agent slug 404s for now; expected pre-rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)