### PR TITLE
docs(patterns): tag-data-model + MCP discovery — reflect vault 0.4.1-rc.4 shipped reality (multi-inheritance, _default, rename cascade, schema projection)

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,41 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-05-09 — Tag schema inheritance, `_default`, rename cascade, MCP discovery (vault)
+
+**Change:** [`tag-data-model.md`](../patterns/tag-data-model.md) refreshed
+top-to-bottom and [`vault-mcp-discovery.md`](../patterns/vault-mcp-discovery.md)
+added, reflecting four vault PRs that landed today against vault 0.4.1-rc.4:
+
+1. [`vault#269`](https://github.com/ParachuteComputer/parachute-vault/pull/269) (`f7c47f1`) — audit-driven cleanup. Ripped `note_schemas` + `schema_mappings` tables and the six MCP tools that authored them (`update-note-schema`, `delete-note-schema`, `list-note-schemas`, `set-schema-mapping`, `delete-schema-mapping`, `synthesize-notes`). MCP tool count: 16 → 9. Schema migration v16 → v17. The 2026-05-03 `_schemas/*` retirement entry below is now superseded — that subsystem existed for ~6 days before being consolidated back onto `tags.fields`.
+2. [`vault#272`](https://github.com/ParachuteComputer/parachute-vault/pull/272) (`fc8db55`) — multi-inheritance via `tags.parent_names`. A child tag inherits all ancestors' `fields` recursively (cycle-safe). `_default` is the implicit universal parent: when a `_default` row exists, its `fields` apply to every note as a low-precedence fallback (appended last in the resolver walk; never auto-written into any `parent_names` array). Conflict resolution: first-in-walk wins; the loser surfaces as a `schema_conflict` warning on `validation_status.warnings` (joins `type_mismatch` and `enum_mismatch`). `getTagDescendants("_default")` returns every tag, so `query-notes { tag: "_default" }` means "every note."
+3. [`vault#273`](https://github.com/ParachuteComputer/parachute-vault/pull/273) (`4ca781f`) — `vault-info` expanded with full schema projection (`tags`, `effective_parents`, `effective_fields`, `relationships`, `indexed_fields`, `query_hints`, optional `stats`). MCP `getServerInstruction` rewritten to render the same projection as a markdown brief at session `initialize`. Both surfaces tag-scope-filtered (symmetric — neither leaks out-of-scope tags). Single source: `core/src/vault-projection.ts::buildVaultProjection`.
+4. [`vault#275`](https://github.com/ParachuteComputer/parachute-vault/pull/275) (`5a278cc`) — full transactional tag-rename cascade. Single `BEGIN IMMEDIATE`, ROLLBACK on any throw. Pre-flight collision check returns `{error: "target_exists", conflicting: [...]}` without touching the DB. Cascades through `tags.name` PK + sub-tag prefixes (recursive), `note_tags.tag_name`, `tags.parent_names` JSON, `tokens.scoped_tags` JSON, `indexed_fields.declarer_tags` JSON, note body content (`#oldname` / `[[_tags/oldname]]`), and `_tags/<oldname>` paths. Returns structured cascade stats. Replaces the prior fail-closed 409 on token-referenced tags.
+
+**Affected:**
+
+- `parachute-patterns` — `tag-data-model.md` rewritten to describe the
+  shipped model (multi-inheritance, `_default`, schema_conflict warning,
+  rename cascade); migration history section added recording the
+  three-step arc (vault#245 → vault#249 → vault#269+#272). New
+  `vault-mcp-discovery.md` covers the projection + brief shape and the
+  scope-filtering symmetry.
+- `parachute-vault` — already shipped today; this patterns PR catches the
+  doc up to reality. Future-work issues filed against vault for auto-init
+  / title-templates / named-queries / AI commands (separate tracker).
+- `parachute-notes` / clients — no breaking change. The Notes UI still
+  reads tag schema via `list-tags { include_schema: true }` (unchanged
+  surface). Clients integrating MCP get the new connect-time brief
+  automatically. Clients that called the now-deleted note-schema /
+  schema-mapping / synthesize-notes MCP tools must migrate to writing
+  `fields` on tag records via `update-tag` (or `_default` for the
+  universal-fallback case).
+
+**Status:** patterns refresh: this PR. Vault implementation: complete in
+0.4.1-rc.4.
+
+---
+
 ## 2026-05-08 — `publicExposure` is a hub-side per-request layer-gate
 
 **Change:** [`module-json-extensibility.md`](../patterns/module-json-extensibility.md)
@@ -98,6 +133,8 @@ a breaking change for any minted bearer.
 ---
 
 ## 2026-05-03 — `_schemas/*` retirement to `note_schemas` + `schema_mappings` (vault)
+
+> **Superseded 2026-05-09 by vault#269.** The `note_schemas` + `schema_mappings` two-table subsystem and the six MCP tools introduced here were ripped six days later when an audit found zero operator use of the path-prefix mapping kind, and tag-mapped schemas were fully redundant with `tags.fields`. Note-validation now lives on `tags.fields` with `_default` as the universal-fallback ancestor. See the 2026-05-09 entry above. Entry kept for migration history.
 
 **Change:** [`tag-data-model.md`](../patterns/tag-data-model.md) approach extended to note-validation schemas. Companion to the tag-data-model reshape (#245). Retires the `_schemas/<name>` config-note pattern + the singleton `_schema_defaults` note in favor of two SQL tables: `note_schemas (name PK, fields JSON, description, required JSON)` for schema definitions, and `schema_mappings (schema_name FK, match_kind ENUM 'path_prefix' | 'tag', match_value)` for the path-prefix + tag-based mapping rules.
 

--- a/patterns/tag-data-model.md
+++ b/patterns/tag-data-model.md
@@ -166,7 +166,7 @@ How an AI client learns the vault's schema shape lives in [`vault-mcp-discovery.
 
 ```
 MCP tool: update-tag
-HTTP:     PATCH /vault/<name>/api/tags/<tag>
+HTTP:     PUT /vault/<name>/api/tags/<tag>
 SPA:      vault admin tag editor
 ```
 

--- a/patterns/tag-data-model.md
+++ b/patterns/tag-data-model.md
@@ -1,6 +1,6 @@
 # Tag data model
 
-> One-line summary: a tag is a single SQL row carrying its identity, description, indexed fields, declared typed relationships, and parent-tag pointers. No notes-as-config for tag concerns. Vault is SQLite; tags belong in tables.
+> One-line summary: a tag is a single SQL row carrying its identity, description, indexed fields, declared typed relationships, and parent-tag pointers. Schemas inherit through `parent_names`; `_default` is the implicit universal parent. No notes-as-config for tag concerns. Vault is SQLite; tags belong in tables.
 
 ## Convention
 
@@ -12,15 +12,15 @@ CREATE TABLE tags (
   description TEXT,                  -- markdown blurb describing the tag
   fields TEXT,                       -- JSON: indexed metadata fields per `query-operators.md`
   relationships TEXT,                -- JSON: typed-link declarations per §Typed relationships below
-  parent_names TEXT,                 -- JSON array of parent tag names (hierarchy)
+  parent_names TEXT,                 -- JSON array of parent tag names (multi-inheritance, see §Schema inheritance)
   created_at TEXT NOT NULL,
   updated_at TEXT
 );
 ```
 
-**One tag = one row.** No sidecar table for fields. No config notes for hierarchy parents. Authoring is via direct API (`update-tag` MCP tool / vault admin SPA).
+**One tag = one row.** No sidecar table for fields. No sidecar table for note-validation defaults. No config notes for hierarchy parents. Authoring is via direct API (`update-tag` MCP tool / vault admin SPA).
 
-The legacy `tag_schemas` sidecar table and `_tags/<name>` config-note pattern (and the parallel `_schemas/*` pattern for note-validation defaults) are retired in favor of in-table state.
+The legacy `tag_schemas` sidecar table, the `_tags/<name>` config-note pattern, the `_schemas/*` notes-as-config pattern, and the short-lived `note_schemas` + `schema_mappings` two-table subsystem are all retired in favor of in-table state on `tags`. See §Migration history.
 
 ## Why
 
@@ -30,7 +30,7 @@ The conflation between "this is a note" and "this is system configuration" was c
 
 ## Typed relationships
 
-A tag declares the **expected** typed-link shapes for notes carrying that tag. The declaration is informational — used by agents to understand what links a typed note "should" have, and used by the UI to surface affordances. It is **not enforced** at write time (Phase 1 — see §Future evolution).
+A tag declares the **expected** typed-link shapes for notes carrying that tag. The declaration is informational — used by agents to understand what links a typed note "should" have, and used by the UI to surface affordances. It is **not enforced** at write time (see §Future evolution).
 
 Schema shape (stored as JSON in `tags.relationships`):
 
@@ -74,11 +74,11 @@ The vault `links` table already stores edges as `(source_id, target_id, relation
 - Tells the UI what affordances to surface (an "Add author" button on a `#book` note's edit view)
 - Stays informational — doesn't reject writes if a `#book` note has no author
 
-Future enforcement (Phase 2 — see §Future evolution) layers validation on top.
+Future enforcement (see §Future evolution) layers validation on top.
 
 ## Hierarchy via `parent_names`
 
-Tag hierarchy moves from `_tags/<name>` config notes to a column on the tag row.
+Tag hierarchy lives as a column on the tag row.
 
 ```sql
 -- example data:
@@ -89,17 +89,84 @@ INSERT INTO tags (name, parent_names) VALUES
   ('health/food',  '[]');                      -- string-form sub-tag has no explicit parent
 ```
 
-The `getTagDescendants` resolver walks the `parent_names` graph backwards (build child→parent index, invert to parent→children, transitive closure). Functionally equivalent to today's `_tags/*` scanner; mechanically simpler.
+The `getTagDescendants` resolver walks the `parent_names` graph backwards (build child→parent index, invert to parent→children, transitive closure). Functionally equivalent to the historical `_tags/*` scanner; mechanically simpler.
 
-**Cache invalidation moves with the data source.** The current implementation invalidates the per-tag descendants cache on `_tags/*` note writes. Post-migration, the trigger is `tags` row writes (specifically when `parent_names` changes). The cache key + lookup shape is unchanged — only the write-side invalidation hook moves.
+**Cache invalidation moves with the data source.** Pre-migration the resolver invalidated on `_tags/*` note writes. The trigger now is `tags` row writes (specifically when `parent_names` changes). Same cache-key shape; only the write-side hook differs.
 
 The string-form sub-tag fallback (per `patterns/tag-scoped-tokens.md` §Storage details) STILL applies — `health/food` matches a `[health]`-allowlisted token via `rootOf("health/food") = "health"`, regardless of whether `parent_names` is set. The two mechanisms (parent_names-driven hierarchy + string-form fallback) coexist.
+
+## Schema inheritance
+
+Schema inheritance is real: a tag's effective field map is its own `fields` ∪ every ancestor's `fields`, with **first-in-walk** precedence. Shipped in vault#272 (closed vault#270).
+
+### Walk semantics
+
+For a note carrying tags `[A, B, ...]`, the resolver visits, in order:
+
+1. Each note tag, then its `parent_names` (depth-first, declaration order), cycle-protected via a visited Set.
+2. The implicit universal parent `_default` (see below), appended last.
+
+The first specification encountered for any field name wins. Operator-controlled precedence is therefore "first-in-`parent_names`-array wins" — a tag's earlier parents outrank its later parents.
+
+Conflicts (same field declared by two ancestors with diverging `type` or `enum`) surface as advisory `schema_conflict` warnings on the response's `validation_status.warnings`. The warning carries:
+
+- `field` — the contested field name
+- `schema` — the tag whose declaration won
+- `loser_schema` — the tag whose declaration was overridden (set only on `schema_conflict`)
+- `reason: "schema_conflict"`
+- `message` — human-readable
+
+`schema_conflict` joins the existing `type_mismatch` and `enum_mismatch` warning reasons. Validation remains advisory: writes are never blocked. Schemas guide; they don't gate.
+
+### `_default` is the implicit universal parent
+
+A tag named `_default` is special at *resolution* time only — it's never auto-written into any `parent_names` array, never auto-applied at the storage layer.
+
+- When a `_default` row exists in `tags`, it's appended to every note's effective ancestor walk (including untagged notes). Its `fields` apply to every note as a low-precedence fallback.
+- Because `_default` is appended **last**, any field a real tag declares wins over `_default`'s declaration of the same field.
+- `getTagDescendants("_default")` returns every tag — used by `query-notes { tag: "_default" }` to mean "every note."
+- When `_default` is *not* declared as a tag row, the magic is inert. The behavior is opt-in via `update-tag` like any other tag.
+
+`_default` can technically carry its own `parent_names` and the resolver handles it (cycle guard + visited Set), but the resulting interaction is non-obvious. Treat `_default` as a root tag in normal use.
+
+This collapses the prior `note_schemas` + `schema_mappings` two-table design into a single mechanism: instead of mapping schemas to notes by path-prefix or tag, schemas live on tags and inherit, with `_default` covering the universal-fallback case that `_schema_defaults` used to handle. Zero operator vaults used the path-prefix mapping kind, and tag-mapped schemas were fully redundant with `tags.fields` — see vault#267 for the audit.
+
+### Field reuse across tags
+
+The "discoverable shared field" pattern (Tana §8.1.b in `research/tana-deep-dive.md`) is implicitly delivered through inheritance: a tag with `parent_names: ["task"]` inherits task's `due`, `assignee`, etc., without redeclaring them. A field shared across many sibling tags becomes an ancestor-tag concern: declare once on the parent, every child inherits.
+
+## Tag rename is a transactional cascade
+
+Renaming a tag (`task` → `todo`, say) is a single transactional cascade across every surface where the old name lives. Shipped in vault#275 (closed vault#240 + vault#247). Replaces the prior fail-closed 409 on token-referenced tags.
+
+Surfaces touched by the cascade:
+
+1. `tags.name` PK row.
+2. Sub-tag rows: `task/work` → `todo/work`, recursively (sub-tags follow their root).
+3. `note_tags.tag_name` FK references for every renamed name.
+4. `tags.parent_names` JSON arrays in OTHER tag rows.
+5. `tokens.scoped_tags` JSON arrays.
+6. `indexed_fields.declarer_tags` JSON arrays.
+7. Note body `content`: `#oldname[/...]` references rewritten to `#newname[/...]`. `[[_tags/oldname]]` wikilinks rewritten.
+8. `_tags/<oldname>...` paths (post-v14 these are inert historical breadcrumbs, but renaming for hygiene keeps the vault internally consistent).
+
+**Atomicity:** a single `BEGIN IMMEDIATE` transaction. Any failure rolls back the entire cascade — no half-applied state. Pre-flight collision check covers the root rename and every sub-tag rename, so a partway-through `UNIQUE` violation can't happen.
+
+**Pre-flight conflict surface:** if any new name already exists as a tag and isn't itself being renamed away, the call returns `{error: "target_exists", conflicting: [...]}` without touching the database.
+
+**Reported stats:** the result includes per-surface counts (`renamed`, `sub_tags_renamed`, `parent_refs_updated`, `tokens_updated`, `indexed_field_declarers_updated`, `notes_rewritten`, `paths_renamed`) so REST/MCP responses describe what changed without a re-scan.
+
+**Cache invalidation:** both `_tagHierarchy` and `_schemaConfig` caches bust after the cascade, since `parent_names` and the tag-set both change.
+
+## MCP discovery surface
+
+How an AI client learns the vault's schema shape lives in [`vault-mcp-discovery.md`](./vault-mcp-discovery.md). Short version: the same projection (tags-with-schemas + indexed fields + query hints) is rendered as markdown at MCP `initialize` and returned as JSON from the `vault-info` tool — both surfaces scope-filtered when the caller is tag-scoped.
 
 ## Authoring surface
 
 ```
 MCP tool: update-tag
-HTTP:     PUT /vault/<name>/api/tags/<tag>
+HTTP:     PATCH /vault/<name>/api/tags/<tag>
 SPA:      vault admin tag editor
 ```
 
@@ -107,38 +174,24 @@ All three write to the same `tags` row. `update-tag` accepts `{ description, fie
 
 There is no path that authors tag state by editing a markdown note. The `_tags/<name>` and `_schemas/*` config-note conventions are retired.
 
-## Migration path
+## Migration history
 
-For a vault on the pre-existing model:
+The model arrived in three steps; this section records the arc so the migration-notes entries make sense.
 
-1. **Add new columns** to `tags`: `description`, `fields`, `relationships`, `parent_names`, `created_at`, `updated_at`. (Schema migration v13 → v14.)
-2. **Populate from sidecar table**: copy each `tag_schemas(tag_name, description, fields)` row into the new tag row's columns.
-3. **Populate parents**: for each note at `_tags/<name>`, parse `metadata.parents` and write to `tags.parent_names`.
-4. **Verify**: confirm all schemas + parents migrated; provide a one-shot diff tool.
-5. **Drop the sidecar**: `DROP TABLE tag_schemas`.
-6. **Leave `_tags/<name>` notes in place** post-migration as historical record — they're harmless once the resolver reads from the new column. Operator can delete them via the admin UI when ready.
-7. **Same for `_schemas/*` notes**: data lifts into a new `note_schemas` table (or a `tags.relationships`-style column on whatever surfaces it; out-of-scope for this doc).
+1. **2026-05-03 — `tag_schemas` + `_tags/*` retirement** (vault#245, schema v13 → v14). Added `description`, `fields`, `relationships`, `parent_names` columns on `tags`. Lifted data from the `tag_schemas` sidecar and `_tags/<name>` config notes. Dropped `tag_schemas`. Left `_tags/<name>` notes in place as historical breadcrumbs.
+2. **2026-05-03 — `_schemas/*` retirement** (vault#249, schema v14 → v15). Lifted `_schemas/<name>` notes and the `_schema_defaults` mapping note into a new `note_schemas` + `schema_mappings` two-table subsystem. MCP tool count went 10 → 16 with `update-note-schema`, `delete-note-schema`, `list-note-schemas`, `set-schema-mapping`, `delete-schema-mapping`, `synthesize-notes`.
+3. **2026-05-09 — `note_schemas` + `schema_mappings` ripped** (vault#269, schema v16 → v17). Audit found zero operator use of the path-prefix mapping kind, and tag-mapped schemas were redundant with `tags.fields`. Subsystem removed entirely; the six new MCP tools deleted; tool count went 16 → 9. Note-validation now lives where tag-validation lives: on `tags.fields`, with `_default` as the universal-fallback (vault#272, same-day).
 
-The migration is one-way — Phase 1 doesn't preserve the option to revert to config-as-note. Aaron approved this 2026-05-03; the cleaner break is worth the irreversibility.
-
-## Why retire config-as-note for these concerns
-
-Three reasons:
-
-1. **Conflates note vs configuration.** Operators look at the file tree and see `_tags/health` as a "note" — but it's not user content; it's system config. The leading underscore is a cargo-culted convention from filesystem-shaped systems (Obsidian, where a leading underscore is just a sort-prefix). In a SQLite-backed system, the convention earns its complexity poorly.
-
-2. **The "edit your config in your note editor" affordance assumes a markdown-file-on-disk model.** Vault is SQLite. Operators interact with the vault via the admin SPA + MCP, not by opening a folder of files. The config-as-note pattern was solving a problem that doesn't exist in this architecture.
-
-3. **The "vault export carries the config" argument** (cited in current `core/src/tag-hierarchy.ts` comments) collapses with this same realization. Export is its own surface (markdown export, JSON export). The export logic can serialize tag state from `tags` table → markdown frontmatter for Obsidian-shaped consumers, OR a dedicated `tags.json` for tooling consumers. Either way: the SOURCE of truth is the SQL row; the export is derived.
+The arc is one-way. Aaron approved the irreversible migrations 2026-05-03 (steps 1+2) and 2026-05-09 (step 3); the cleaner break beats keeping the subsystem alongside.
 
 ## Adoption
 
 | Module | Action |
 | --- | --- |
-| **vault** | Phase 1 implementation: schema migration v14, `update-tag` API gains `relationships` + `parent_names`, `getTagDescendants` resolver swap, retire `tag_schemas` sidecar, leave `_tags/<name>` notes in place post-migration as harmless historical record. Same for `_schemas/*` retirement. Single PR on `ag-unforced-dev`. |
+| **vault** | Shipped: schema v17, single-table tag model, multi-inheritance with `_default` magic, transactional rename cascade. See `core/src/schema-defaults.ts`, `core/src/notes.ts`, `core/src/vault-projection.ts`. |
 | **parachute-agent** | No change — parachute-agent doesn't touch tag schema state |
 | **hub** | No change |
-| **notes** | The Notes UI may surface tag schemas (declared fields + relationships) in note-edit views; tracked separately |
+| **notes** | The Notes UI surfaces tag schemas (declared fields + relationships) in note-edit views; tracked in the notes repo |
 
 ## Future evolution
 
@@ -146,13 +199,15 @@ Three reasons:
 | --- | --- | --- |
 | **Relationship enforcement** | Validate at write time that a `#book` note has an `author` link with cardinality `one`. Returns 400 on missing required relationship. | When operator pain emerges from notes lacking expected relationships |
 | **Reverse-relationship inference** | `#book` declares `author → person`. Vault auto-infers `person → book` reverse with relationship `wrote`. | Phase 2 if helpful for query semantics |
-| **Schema-defaults for note validation** (current `_schemas/*` pattern) | Move to a `note_schemas` table mirroring this design | Same arc; same sprint |
+| **`required` field markers** | Re-introduce required/optional on field specs (the prior `note_schemas` table carried this). | When a real "missing field" pain point emerges; advisory-only by default |
 | **Schema versioning** | Optional `schema_version` field on tag rows; track migrations across schema changes | When a real schema-evolution incident happens |
 | **Relationship typing per-link** (multiple authors with different roles) | Extend `links.metadata` JSON with `{ role: "primary-author" }` shape | When use-case appears |
 
 ## Adoption notes
 
-- Aaron approved this design 2026-05-03 in the architecture-review thread.
+- Aaron approved the original design 2026-05-03 in the architecture-review thread; the multi-inheritance + `_default` extension and the rename cascade landed 2026-05-09.
 - The retirement of config-as-note for tag concerns is a real simplification, not just refactor — the conceptual layer "what is a note" gets clearer.
-- This unlocks `vault#240` (tag-rename cascade) — the cascade now touches one row + the body-text-rewrite, not three places + a config-note pipeline.
-- Companion docs: `research/parachute-data-model-shape.md` (architectural reflection), `research/tana-deep-dive.md` (typed-graph context), `patterns/tag-scoped-tokens.md` (token-scope concerns layered on this model).
+- Tag rename is now operator-friendly across all surfaces (vault#275 — superseded the earlier fail-closed 409 on token-referenced tags).
+- Companion docs: `patterns/vault-mcp-discovery.md` (how clients see the schema), `research/parachute-data-model-shape.md` (architectural reflection), `research/tana-deep-dive.md` (typed-graph context), `patterns/tag-scoped-tokens.md` (token-scope concerns layered on this model).
+
+_Last updated: 2026-05-09 — current with vault 0.4.1-rc.4._

--- a/patterns/tag-scoped-tokens.md
+++ b/patterns/tag-scoped-tokens.md
@@ -128,7 +128,7 @@ If we later want third-party clients to request tag-scoped tokens via OAuth cons
 
 ## Lifecycle
 
-**Tag rename cascades** (Aaron's directive 2026-05-02). When operator runs `PATCH /api/tags/<old_name>` with `{ name: <new_name> }`:
+**Tag rename cascades** (Aaron's directive 2026-05-02). When operator runs `POST /api/tags/<old_name>/rename` with `{ new_name: <new_name> }`:
 
 1. The `tags` row's `name` PK is updated. `note_tags` and any other FK referencing `tags.name` cascade-update. (The legacy `tag_schemas` sidecar table was dropped in the v14 migration; no longer in scope for cascade.)
 2. Sub-tags whose name has prefix `<old_name>/` are renamed to `<new_name>/...` recursively (each is its own row in `tags` with its own `parent_names`).

--- a/patterns/vault-mcp-discovery.md
+++ b/patterns/vault-mcp-discovery.md
@@ -1,0 +1,115 @@
+# Vault MCP discovery
+
+> One-line summary: a Parachute-Vault MCP client learns the vault's shape (tags-with-schemas, indexed fields, query hints) two ways — a markdown brief in the `initialize` response, and a JSON projection from the `vault-info` tool — both built from the same `buildVaultProjection` source, both scope-filtered when the caller is tag-scoped.
+
+## Convention
+
+The vault projection is one document with three shapes (one source, two surfaces, optional stats):
+
+```ts
+interface VaultProjection {
+  tags: ProjectionTag[];               // tags carrying their own description or fields
+  indexed_fields: ProjectionIndexedField[];
+  query_hints: string[];               // verbatim catalog of query-notes shapes
+  stats?: VaultStats;                  // included on request only
+}
+
+interface ProjectionTag {
+  name: string;
+  description: string | null;
+  parents: string[];                   // verbatim from tags.parent_names
+  effective_parents: string[];         // walk-order ancestor closure, _default appended when present
+  fields: Record<string, TagFieldSchema> | null;       // own (verbatim from tags.fields)
+  effective_fields: Record<string, SchemaField>;       // own ∪ inherited, first-in-walk wins
+  relationships: TagRecord["relationships"] | null;
+}
+```
+
+Built by `core/src/vault-projection.ts::buildVaultProjection(db, { includeStats? })`. Pure read; no caches mutated.
+
+## Two surfaces, one source
+
+### `vault-info` MCP tool — JSON projection
+
+Returns the full `VaultProjection` JSON. Agents call this to refresh mid-session when schema or tags have changed (the connect-time brief is sent only once).
+
+Defaults to including `stats`; the caller can flip `include_stats: false` to skip the stats roll-up. The wrapper threads tag-scope filtering through (see §Scope filtering).
+
+### `getServerInstruction` — markdown brief at MCP `initialize`
+
+The MCP server returns a markdown brief in the `serverInfo.instructions` field of the `initialize` response. Same projection, rendered terse. Sent **once at connect**. Goal: every fact an agent needs to start using the vault sensibly, with explicit pointers for refresh.
+
+Shape:
+
+```
+You are connected to Parachute Vault "<name>".
+
+<vault description, if set>
+
+## Quick orientation (call `vault-info` for full schema)
+
+- N notes, M tags
+- K tags with schemas: <names>
+- Indexed metadata fields (queryable with operators):
+  - <field> (<type>; from #<tag>, #<tag>)
+  - ...
+
+## Querying
+
+- `query-notes { tag: "X" } — all notes with tag X (includes descendants per inheritance)`
+- `query-notes { tag: "X", metadata: { field: { op: value } } } — operator queries on indexed fields (eq/ne/gt/gte/lt/lte/in/not_in/exists)`
+- `query-notes { search: "..." } — full-text search across content`
+- `query-notes { near: { id: "..." }, depth: 2 } — graph neighborhood within N hops`
+- `query-notes { id: "<note-id-or-path>" } — fetch a single note by ID or path`
+
+## Refreshing context
+
+If schema or tags change during this session, call `vault-info` to refresh the full projection. Call `list-tags { include_schema: true }` for tag-only details.
+```
+
+Rendered by `projectionToMarkdown` in the same file. Token budget guideline: ~600 tokens for a small vault (~4 tags-with-schemas), under ~5K at 50 tags-with-schemas.
+
+## Scope filtering
+
+Both surfaces are symmetric for tag-scoped tokens.
+
+- When the caller's token has `scoped_tags`, the projection is filtered before rendering / returning. `tags` and `indexed_fields` are reduced to entries an in-scope tag contributes to. Aggregate counts in the markdown brief reflect the filtered view.
+- When the caller is unscoped (`scoped_tags === null`), no filter is applied — full projection.
+
+The filter is applied at the wrapper layer (`src/mcp-tools.ts::getServerInstruction` and the `vault-info` tool wrapper) so neither surface can leak out-of-scope tag names. A tag-scoped agent can't learn about tags outside its allowlist via the connect-time brief any more than it can via `list-tags`.
+
+## Why one source
+
+The brief and the JSON tool target different audiences (one-shot orient vs. on-demand refresh) and different formats (markdown vs. JSON), but they describe the same vault shape. Two computations would drift: a tag added to one surface but not the other, or different inheritance semantics, or asymmetric scope filtering.
+
+`buildVaultProjection` is the single read path. `projectionToMarkdown` and the `vault-info` JSON serializer are render functions over its output. The scope filter (`filterProjectionForTagScope`) wraps both. Adding a future surface (REST `GET /vault/<name>/projection`, or a CLI `parachute-vault info` command) reuses the same source.
+
+## Inheritance is visible
+
+`ProjectionTag.effective_parents` and `effective_fields` are computed via `resolveTagInheritance`, which calls into `resolveNoteSchemas({ tags: [tag] })` — the same resolver that drives runtime validation. Walk order, conflict precedence (first-in-walk wins), and `_default` semantics are guaranteed identical between projection and validation; an agent reading `effective_fields` sees exactly what the validator will check against.
+
+See [`tag-data-model.md`](./tag-data-model.md) §Schema inheritance for the inheritance model itself.
+
+## Adoption
+
+| Module | Action |
+| --- | --- |
+| **vault** | Shipped vault#273 (closed vault#270): `buildVaultProjection`, `projectionToMarkdown`, expanded `vault-info` tool, `getServerInstruction` rewrite. Both surfaces honor tag-scope. |
+| **parachute-agent** | No code change; the agent picks up the new brief automatically on connect via standard MCP handshake. |
+| **hub** | No change. |
+| **notes** | No change. The Notes UI reads schema from `list-tags { include_schema: true }`, which is a separate (un-projected) surface. |
+
+## Future evolution
+
+| Extension | Sketch | When to revisit |
+| --- | --- | --- |
+| **Brief truncation heuristic** | Cap rendered tags at N, link to `vault-info` for the rest | When a vault hits ~50+ tags-with-schemas and the brief gets noisy |
+| **Per-call refresh hints** | Surface "schema changed since you last connected" on `vault-info` responses | If agent confusion from stale connect-time briefs becomes real |
+| **REST projection endpoint** | `GET /vault/<name>/projection` returns the same JSON | When a non-MCP client (UI, CLI tool) needs the projection without going through MCP |
+
+## Adoption notes
+
+- Shipped 2026-05-09 in vault 0.4.1-rc.4 (vault#273).
+- Companion docs: [`tag-data-model.md`](./tag-data-model.md) (the schema model the projection describes), [`tag-scoped-tokens.md`](./tag-scoped-tokens.md) (the scope mechanism the filter respects), [`mcp-transport.md`](./mcp-transport.md) (the underlying MCP shape).
+
+_Last updated: 2026-05-09 — current with vault 0.4.1-rc.4._

--- a/patterns/vault-mcp-discovery.md
+++ b/patterns/vault-mcp-discovery.md
@@ -33,7 +33,9 @@ Built by `core/src/vault-projection.ts::buildVaultProjection(db, { includeStats?
 
 Returns the full `VaultProjection` JSON. Agents call this to refresh mid-session when schema or tags have changed (the connect-time brief is sent only once).
 
-Defaults to including `stats`; the caller can flip `include_stats: false` to skip the stats roll-up. The wrapper threads tag-scope filtering through (see §Scope filtering).
+Stats are omitted by default; pass `include_stats: true` to include note/tag counts and the monthly distribution. The connect-time markdown brief sets `includeStats: true` internally so the brief always carries counts — that's the brief's behavior, not the JSON tool's default. The wrapper threads tag-scope filtering through (see §Scope filtering).
+
+Only tags carrying their own `description` or `fields` appear in `tags[]`. Hierarchy-only tags — those that exist only as parents to other tags via `parent_names` — drive inheritance for descendants but do not surface as standalone entries in the projection. Their fields appear via descendants' `effective_fields`.
 
 ### `getServerInstruction` — markdown brief at MCP `initialize`
 


### PR DESCRIPTION
## Summary

Bring `tag-data-model.md` current with what vault actually ships, and add a sibling `vault-mcp-discovery.md` documenting the connect-time + on-demand schema-discovery surfaces. Doc-only — no code, no version bump.

## Vault PRs reflected (all merged 2026-05-09 against vault 0.4.1-rc.4)

| PR | Commit | What |
|---|---|---|
| [vault#269](https://github.com/ParachuteComputer/parachute-vault/pull/269) | `f7c47f1` | Audit cleanup. Ripped `note_schemas` + `schema_mappings` tables and the six MCP tools that authored them (`update-note-schema`, `delete-note-schema`, `list-note-schemas`, `set-schema-mapping`, `delete-schema-mapping`, `synthesize-notes`). MCP tool count: 16 → 9. Schema v16 → v17. |
| [vault#272](https://github.com/ParachuteComputer/parachute-vault/pull/272) | `fc8db55` | Multi-inheritance via `tags.parent_names`. `_default` is the implicit universal parent (resolver-magic, never auto-written). First-in-walk wins on conflict; new `schema_conflict` warning reason. `getTagDescendants("_default")` returns every tag. |
| [vault#273](https://github.com/ParachuteComputer/parachute-vault/pull/273) | `4ca781f` | `vault-info` expanded with full schema projection (`tags`, `effective_parents`, `effective_fields`, `relationships`, `indexed_fields`, `query_hints`). `getServerInstruction` rewritten to render the same projection as a markdown brief at session `initialize`. Both surfaces scope-filtered (symmetric). Single source: `buildVaultProjection`. |
| [vault#275](https://github.com/ParachuteComputer/parachute-vault/pull/275) | `5a278cc` | Full transactional tag-rename cascade. `BEGIN IMMEDIATE`, ROLLBACK on throw. Pre-flight collision check. Cascades through PK + sub-tag prefixes + `note_tags` + `parent_names` + `tokens.scoped_tags` + `indexed_fields.declarer_tags` + note bodies (`#oldname` / `[[_tags/oldname]]`) + `_tags/<oldname>` paths. Returns structured stats. Replaces prior fail-closed 409. |

## Doc changes

### `patterns/tag-data-model.md` — refreshed top-to-bottom
- New §Schema inheritance: walk semantics, first-in-walk precedence, `schema_conflict` warning shape (joins `type_mismatch` and `enum_mismatch`), `_default` universal-parent semantics + low-precedence-by-walk-order behavior, field-reuse pattern.
- New §Tag rename is a transactional cascade: full cascade-surface enumeration, atomicity model, `target_exists` pre-flight error shape, reported per-surface stats.
- New §MCP discovery surface: short cross-link to the new sibling doc.
- Updated §Hierarchy via `parent_names`: cache invalidation now fires on `tags` row writes.
- Updated §Authoring surface: HTTP verb fixed to `PATCH`.
- New §Migration history: records the three-step arc (vault#245 → vault#249 → vault#269+#272) so the migration-notes entries make sense end-to-end.
- Refreshed §Adoption + §Future evolution. `_schemas/*` row removed (it's history, not future); `note_schemas` row replaced with `required` field markers (the one piece of that subsystem worth preserving the option for).
- Footer: `Last updated: 2026-05-09 — current with vault 0.4.1-rc.4.`

### `patterns/vault-mcp-discovery.md` — new
- `VaultProjection` shape (TypeScript-style sketch).
- The two surfaces: `vault-info` JSON tool + `getServerInstruction` markdown brief at MCP `initialize`. Sample brief shape included.
- §Scope filtering: tag-scoped tokens get a filtered projection symmetrically across both surfaces (filter wraps both at the wrapper layer).
- §Why one source: same `buildVaultProjection` drives both; `projectionToMarkdown` and the JSON serializer are render functions.
- §Inheritance is visible: `effective_parents` and `effective_fields` use the same resolver as runtime validation, so what the agent sees is what gets validated against.

### `adoption/migration-notes.md` — 2026-05-09 entry on top
- Lists the four vault PRs with commit refs and per-PR semantics.
- Annotates the 2026-05-03 `_schemas/*` retirement entry as superseded by vault#269 (kept for migration history; not removed).

## Cross-link audit

Searched `patterns/` and `adoption/` for `note_schemas`, `schema_mappings`, `synthesize-notes`, `_schemas/`. All remaining references are either (a) intentional new content describing today's deltas, (b) intentional historical content in migration-notes (correctly preserved), or (c) annotated as superseded. No stale forward-looking references remain.

## Future-work issues filed against vault

Out of scope for this patterns PR but tracked for future patterns sweeps as they ship: auto-init / title-templates / named-queries / AI commands.

## Test plan

- [ ] `tag-data-model.md` reads correctly and reflects shipped semantics for inheritance + `_default` + rename cascade
- [ ] `vault-mcp-discovery.md` accurately describes the projection shape + scope-filter symmetry
- [ ] No remaining stale references to `note_schemas` / `schema_mappings` / `synthesize-notes` outside historical contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)