### PR TITLE
docs(patterns): annotate pre-v14 research notes as superseded (closes #49)

### DIFF
--- a/research/parachute-data-model-shape.md
+++ b/research/parachute-data-model-shape.md
@@ -1,5 +1,7 @@
 # Parachute data model — paths, tags, schemas, links, scope
 
+> **Note (2026-05-09):** this doc predates vault v14 (2026-05-03) and the v17 consolidation (2026-05-09). The current tag/schema model is in [`patterns/tag-data-model.md`](../patterns/tag-data-model.md); the MCP discovery shape is in [`patterns/vault-mcp-discovery.md`](../patterns/vault-mcp-discovery.md). References to `tag_schemas`, `_tags/<name>` config notes, and "schema-as-derived-from-note-body" describe the pre-v14 architecture this doc helped motivate the move *away from*. Preserved as research history — read for the reasoning, not for current architecture.
+
 > Architectural reflection. Not a pattern to adopt yet — a reading of the current state, a clarification of conceptual layers Aaron and team-lead have been conflating, and a survey of paths forward. Written 2026-05-03 in response to Aaron's request to "make sure I'm understanding what we're doing even here."
 >
 > Living companion to: `research/tag-scoped-tokens-survey.md`, `research/knowledge-tool-data-models.md` (in flight).

--- a/research/tag-scoped-tokens-survey.md
+++ b/research/tag-scoped-tokens-survey.md
@@ -1,5 +1,7 @@
 # Tag-scoped tokens — industry survey
 
+> **Note (2026-05-09):** this doc predates vault v14 (2026-05-03). References to `_tags/<name>` config notes as the source of hierarchy + cache invalidation describe the pre-v14 architecture. The current source is `tags.parent_names`; see [`patterns/tag-data-model.md`](../patterns/tag-data-model.md). The auth-design reasoning here (subset minting, hierarchical inheritance, allow-list-only) survives unchanged — only the *storage* of the hierarchy moved. Preserved as research history.
+
 > Comparative survey of how mainstream auth systems handle token-scoped-by-data-slice authorization, written to validate or challenge the design in [`patterns/tag-scoped-tokens.md`](../patterns/tag-scoped-tokens.md) (patterns#24, merged 2026-05-02).
 
 **Author:** patterns tentacle. **Date:** 2026-05-02. **Status:** advisory; recommendations should be triaged into either the patterns doc or follow-up issues.


### PR DESCRIPTION
## Summary

Add disclaimer banners to two already-tracked research notes that describe pre-v14 / pre-v17 vault architecture, pointing readers at the current pattern docs. Bodies untouched — frozen-in-time research, valuable as history but not as current-architecture references.

Closes #49.

## Files

| File | State | Diff |
|---|---|---|
| `research/parachute-data-model-shape.md` | committed | +2 lines disclaimer |
| `research/tag-scoped-tokens-survey.md` | committed | +2 lines disclaimer |

Each disclaimer:
- Dates itself ("Note (2026-05-09)")
- Names the pre-v14 architecture the doc describes
- Links to the current pattern docs (`patterns/tag-data-model.md`, `patterns/vault-mcp-discovery.md`)
- Notes which parts of the doc's reasoning survive the migration unchanged

## Considered and dropped — `research/cloudflare-hosted-vault.md`

This untracked draft also has stale `_tags/*` refs and was initially included with a disclaimer. **Removed from this PR per team-lead direction.**

Reasoning: applying a disclaimer requires committing the ~388-line untracked draft, which goes against Aaron's standing guidance that the three persistent untracked research notes are drafts to leave alone. The disclaimer's audience-warning value is small (research/ readership is small); the cost of tracking ~400 lines against explicit guidance is bigger. If reader-confusion from that file materializes later, revisit then with explicit authority.

## Skipped (with rationale)

Two other untracked research notes (`research/knowledge-tool-data-models.md`, `research/tana-deep-dive.md`) also reference `_tags/<name>` — but those references appear in **tool-comparison context** (describing Parachute as a peer to Logseq, Tana, Anytype, etc.) rather than as architectural claims about the current vault. Lower mislead-risk. Same untracked-draft logic as cloudflare applies.

## Future-pattern guidance (per this PR's reviewer thread)

Research-disclaimer work going forward should follow the pattern: **only annotate already-tracked files; surface tracking-required cases as questions** rather than pre-emptively committing untracked drafts.

## Cross-link audit

After landing this PR, `grep -rn "_tags/" research/ patterns/ adoption/` matches:
- The two new disclaimer-bearing research files (this PR): readers warned at top.
- Three untracked research notes (skipped per above): unchanged.
- `patterns/tag-data-model.md`: mentions `_tags/<name>` only in §Migration history (correctly historical).
- `adoption/migration-notes.md`: historical entries with supersession annotations (PR #48).

No forward-looking architectural claims about `_tags/<name>` remain in active pattern docs.

## Test plan

- [ ] Disclaimer banners render correctly at the top of each affected research note
- [ ] Cross-links to `patterns/tag-data-model.md` and `patterns/vault-mcp-discovery.md` resolve
- [ ] No body content changed in either of the two docs
- [ ] cloudflare-hosted-vault.md remains untracked locally (not in commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)