### PR TITLE
docs(patterns): module.json uiUrl — services declare their UIs

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -16,9 +16,11 @@ service, picking up `displayName` + `tagline` for the copy. Modules
 without `uiUrl` are still registered and routable; they just don't
 render a clickable card.
 
-Resolution rules mirror `managementUrl`: relative path (`"/notes"`)
-resolves against the hub origin; absolute URL is used verbatim;
-omitted = no tile rendered.
+Resolution: path form (`"/notes"`) is a path on **hub's origin** and
+hub renders the link as `<hub-origin>${uiUrl}` regardless of where the
+module itself is hosted — distinct from `managementUrl`'s relative
+form, which resolves against the module's own well-known origin.
+Absolute URL is used verbatim; omitted = no tile rendered.
 
 Today the hub's discovery page hardcodes `SERVICE_LABELS` + `SERVICE_ORDER`
 + a vault-name filter at the top of

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,67 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-05-10 — `module.json` gains `uiUrl` for dynamic discovery rendering
+
+**Change:** new pattern doc
+[`module-ui-declaration.md`](../patterns/module-ui-declaration.md). One
+optional top-level `module.json` field — `uiUrl?: string` — declares
+where a module's user-facing UI lives. Hub's discovery page reads it
+(via `/.well-known/parachute.json`) and renders one tile per declaring
+service, picking up `displayName` + `tagline` for the copy. Modules
+without `uiUrl` are still registered and routable; they just don't
+render a clickable card.
+
+Resolution rules mirror `managementUrl`: relative path (`"/notes"`)
+resolves against the hub origin; absolute URL is used verbatim;
+omitted = no tile rendered.
+
+Today the hub's discovery page hardcodes `SERVICE_LABELS` + `SERVICE_ORDER`
++ a vault-name filter at the top of
+[`parachute-hub/src/hub.ts`](https://github.com/ParachuteComputer/parachute-hub/blob/main/src/hub.ts);
+which-services-have-UIs and what-they're-called are baked in, and only
+the mount path comes from `services.json`. With `uiUrl` in `module.json`,
+that hardcoding retires.
+
+`uiUrl` is the discovery-side peer of `managementUrl` (added 2026-05-02
+for hub admin pages' "Manage `<name>`" link rendering). They serve
+different surfaces — discovery vs. hub admin pages — and a service may
+declare both, one, or neither.
+
+The first cut at the discovery section split tiles into "Use" vs
+"Admin"; that broke down because real service UIs combine use, config,
+and admin in one surface. Aaron's call: services declare what their UI
+*is*; hub renders one link per service.
+
+**Affected:**
+
+- `parachute-patterns` — pattern doc landed (this PR). No code change.
+- `parachute-notes` — declare `uiUrl: "/notes"` in
+  `.parachute/module.json`. One PR.
+- `parachute-agent` — declare `uiUrl: "/agent"` in
+  `.parachute/module.json`. One PR.
+- `parachute-vault`, `parachute-scribe` — no immediate change. Vault
+  intentionally omits `uiUrl` (vault content is browsed via Notes;
+  vault keeps its per-instance `managementUrl: "/admin"` for the
+  hub's vault-list page). Scribe omits today (CLI/API only) and adds
+  the field whenever a UI ships.
+- `parachute-hub` — read `uiUrl` from each module's well-known entry
+  and render the discovery section dynamically. Retire the hardcoded
+  `SERVICE_LABELS` map + `SERVICE_ORDER` array + `isVaultName` filter
+  in `src/hub.ts`. Retire the `module-manifest.ts` parser's
+  silent-ignore of unknown top-level fields for `uiUrl` (read it
+  through `composeServiceSpec` so it lands in `services.json` and
+  flows to `/.well-known/parachute.json`). One PR.
+
+Backwards-compatible with both directions: hub before its consumer
+update silently ignores the new field; modules before their `module.json`
+updates simply don't render tiles (same as today's hardcoded omission).
+The two sides can land in either order.
+
+**Status:** pattern doc landed (this PR). Module + hub PRs pending.
+
+---
+
 ## 2026-05-09 — Tag schema inheritance, `_default`, rename cascade, MCP discovery (vault)
 
 **Change:** [`tag-data-model.md`](../patterns/tag-data-model.md) refreshed

--- a/patterns/module-json-extensibility.md
+++ b/patterns/module-json-extensibility.md
@@ -242,6 +242,14 @@ via the module's well-known doc) to shape its directory page. Optional;
 absent means "the hub renders nothing for this concern" — existing
 manifests stay valid unchanged.
 
+For the discovery-side peer field `uiUrl` — a path on **hub's** origin
+declaring where a module's user-facing UI lives, rendered as a tile on
+hub's discovery page — see
+[`module-ui-declaration.md`](./module-ui-declaration.md). Note the
+resolution-base difference: `managementUrl`'s relative form resolves
+against the module's own origin; `uiUrl`'s relative form resolves
+against hub's origin.
+
 ### `managementUrl: string`
 
 ```ts

--- a/patterns/module-ui-declaration.md
+++ b/patterns/module-ui-declaration.md
@@ -1,0 +1,193 @@
+# Module UI declaration
+
+> **Status: target convention, not yet implemented.** Hub's discovery
+> page today hardcodes which services have UIs in a JS
+> `SERVICE_LABELS` map at the top of
+> [`parachute-hub/src/hub.ts`](https://github.com/ParachuteComputer/parachute-hub/blob/main/src/hub.ts)
+> (`notes`, `scribe`, `agent`) plus a vault-name filter that suppresses
+> vault entries. Titles, descriptions, ordering, and which-services-have-UIs
+> are baked in; only the mount `path` is read from `services.json`. This
+> doc captures the convention so the hardcoding can retire — services
+> declare their UIs, hub renders dynamically.
+
+## Convention
+
+Every module that has a user-facing UI **declares its UI URL in
+`module.json`** as a top-level optional field:
+
+```json
+{
+  "name": "parachute-notes",
+  "uiUrl": "/notes",
+  "displayName": "Notes",
+  "tagline": "Browse your vault content."
+}
+```
+
+The hub's discovery page reads `uiUrl` (via the well-known doc) and
+renders one tile per service that declares it — `displayName` as the
+title, `tagline` as the description, `uiUrl` as the link target. Modules
+that omit `uiUrl` are still registered (still appear in
+`/.well-known/parachute.json`, still routable for API consumers); they
+just don't render a clickable card on discovery.
+
+## Shape
+
+```ts
+uiUrl?: string;  // path under the hub origin, leading "/"
+```
+
+Resolution rules:
+
+- **Path on the hub origin** — `uiUrl: "/notes"`. Hub renders the link
+  as `<hub-origin>${uiUrl}` at click time. Leading `/` required; no
+  trailing slash. Same shape as `managementUrl`'s relative form (see
+  [`module-json-extensibility.md`](./module-json-extensibility.md#hub-ui-fields)).
+- **Absolute URL** — `uiUrl: "https://notes.example.com"`. Hub uses
+  verbatim. Escape hatch for modules whose UI is hosted somewhere
+  other than the hub origin.
+- **Omitted** — no tile rendered. Use this for API-only services
+  (vault today, scribe today) or services whose UI is only reachable
+  via another module (vault content browsed via Notes).
+
+The hub picks `displayName` and `tagline` for the tile from the same
+`module.json` fields it already reads
+([`module-json-extensibility.md` — Shape](./module-json-extensibility.md#shape))
+— no separate per-discovery-tile copy.
+
+## Why
+
+- **Discovery is no longer hub-side knowledge.** Hub doesn't ship a
+  hardcoded list of "which services have UIs and what they're called."
+  Adding a new service ships a new tile when its `module.json`
+  declares one.
+- **The use-vs-admin distinction stops mattering at the hub layer.**
+  The first cut at the discovery section split tiles into "Use" and
+  "Admin"; that broke down because real service UIs mix use, config,
+  and admin together (Notes is also where you administer Notes; Agent
+  has run + admin in one SPA). Services declare what their UI *is* —
+  combining concerns however they want — and hub renders one link.
+  See the rationale comment at the top of
+  [`parachute-hub/src/hub.ts`](https://github.com/ParachuteComputer/parachute-hub/blob/main/src/hub.ts).
+- **Author-controlled.** A third-party module that ships a `uiUrl` in
+  its `module.json` lights up on the hub's discovery page on install
+  with no hub-side change.
+- **Backwards-compatible.** Absent field = no tile. Existing
+  `module.json` files stay valid unchanged.
+
+## Relationship to `managementUrl`
+
+`managementUrl` (added 2026-05-02, see
+[`module-json-extensibility.md` — Hub UI fields](./module-json-extensibility.md#managementurl-string))
+already exists as an admin-specific link for hub-owned admin pages —
+specifically, the hub's vault-management SPA renders a
+"Manage `<displayName>`" link per vault instance pointing at
+`<vault-url><managementUrl>`. That covers the case where hub admin
+pages need to link out to per-instance module admin UIs.
+
+`uiUrl` is its discovery-side peer:
+
+| Field | Surface | Renders | Cardinality |
+| --- | --- | --- | --- |
+| `uiUrl` | Hub discovery page | One tile per service | Per service (or per-instance if a service runs multiple) |
+| `managementUrl` | Hub admin pages (e.g., vault list) | "Manage `<name>`" link per instance | Per instance |
+
+A service may declare both (e.g., a future combined notes admin SPA
+under `/notes` declares both `uiUrl: "/notes"` and `managementUrl:
+"/notes/admin"`), one, or neither. They serve different surfaces and
+don't conflict.
+
+## Examples
+
+- **`parachute-notes`** — declares `uiUrl: "/notes"`. The Notes PWA is
+  the module's UI. Hub discovery renders a Notes tile. No
+  `managementUrl` (admin and use are the same surface).
+- **`parachute-agent`** — declares `uiUrl: "/agent"`. The agent UI
+  combines run, config, and admin. Hub discovery renders an Agent tile.
+- **`parachute-scribe`** — omits `uiUrl` today (no UI; CLI- and
+  API-only). When the combined transcribe + config UI ships, it adds
+  `uiUrl: "/scribe"`.
+- **`parachute-vault`** — omits `uiUrl`. Vault content is browsed via
+  Notes; a "Vault" tile on discovery would dead-end at the hub-owned
+  vault-management SPA, which is the friction Aaron flagged earlier
+  ("clicked Vault, took me to hub management"). Vault keeps its
+  per-instance `managementUrl: "/admin"` for the hub's vault-list
+  page; that's the right surface for "manage this specific vault."
+
+## Rules
+
+- **Path-form `uiUrl` starts with `/`, no trailing slash.** Same
+  normalization as `managementUrl`. Hub joins origin + `uiUrl`
+  verbatim.
+- **`uiUrl` is for the hub discovery page.** Don't hand-jam admin-only
+  paths in here when the user-facing UI is what belongs on discovery —
+  that's what `managementUrl` is for. If a service has only an admin
+  UI and no public-facing surface, declaring it as `uiUrl` is fine
+  (Agent's UI is admin-flavored and ships there); the rule is about
+  framing, not gating.
+- **Hub doesn't sniff or parse the link target.** `uiUrl` is opaque to
+  hub. Auth, anonymous-access policy, and what's behind the link are
+  the module's concern.
+- **Display copy comes from `displayName` + `tagline`.** No separate
+  `uiTitle` / `uiDesc` field. If the module wants different copy on
+  discovery vs. elsewhere, that's a (rejected for now) signal of
+  YAGNI splintering.
+
+## Adoption sequencing
+
+Standard parallel-cross-repo shape (see
+[`parallel-cross-repo-PRs.md`](./parallel-cross-repo-PRs.md)):
+
+1. **This PR (parachute-patterns)** — define the convention.
+2. **Module `module.json` updates (one PR per module)** —
+   `parachute-notes` declares `uiUrl: "/notes"`;
+   `parachute-agent` declares `uiUrl: "/agent"`. Vault and scribe stay
+   absent at this step. Each module ships its updated `module.json`
+   inside its npm artifact.
+3. **Hub consumer-side update** — well-known doc carries `uiUrl`
+   through; discovery page (`hub.ts`) reads `uiUrl` from
+   `/.well-known/parachute.json` and renders one tile per declaring
+   service. The hardcoded `SERVICE_LABELS` + `SERVICE_ORDER` arrays
+   and the `isVaultName` filter retire. Tile order: stable by service
+   `name` alphabetical (or by an explicit `displayOrder` field if a
+   need for explicit ordering surfaces — defer until two services
+   actually conflict on natural order).
+
+Steps 2 and 3 are backwards-compatible with each other: hub before
+step 3 ignores the new field; modules before step 2 simply don't
+appear (same behavior as today's hardcoded omission). They can land
+in either order.
+
+## Open questions
+
+- **Per-instance `uiUrl` for multi-instance services.** Vault is
+  multi-instance (`default`, `boulder`, `techne`); if a future vault
+  grows a per-instance use-facing UI (not just admin), each instance
+  would want its own UI URL. The `services.json` row shape today is
+  per-instance, so the natural extension is "module declares `uiUrl`
+  template; vault writes it into each instance's `services.json` row
+  on init." Defer until a real use case lands.
+- **Auth requirements metadata.** Should `uiUrl` carry whether the UI
+  supports anonymous access vs. requires sign-in? Useful for hub to
+  hint "Sign in to use Agent" vs. "Open Notes" on the tile. Defer
+  until hub discovery actually wants to differentiate; today's "sign
+  in to hub, then click anything" flow doesn't need it.
+- **`displayOrder` for explicit ordering.** The current hardcoded
+  order (`notes`, `scribe`, `agent`) reflects Aaron's preferred
+  prominence; alphabetical by name happens to give the same result
+  for these three. If a service named `aardvark` later wanted
+  bottom-of-list placement, an explicit numeric `displayOrder` (lower
+  = earlier) is the obvious knob. Defer.
+- **Display kind beyond a single link.** `kind: "tool"` modules (no
+  one ships one yet) might want a launch-button vs. a card. Today
+  the tile is the only render shape; revisit if a tool-kind module
+  actually arrives.
+
+## Where this applies
+
+- **Today (target):** `parachute-notes` (`uiUrl: "/notes"`),
+  `parachute-agent` (`uiUrl: "/agent"`).
+- **Later:** any first- or third-party module that ships a UI under
+  the hub origin. Same field, same shape.
+- **Not in scope:** services with no UI (vault today, scribe today)
+  simply omit the field.

--- a/patterns/module-ui-declaration.md
+++ b/patterns/module-ui-declaration.md
@@ -1,5 +1,8 @@
 # Module UI declaration
 
+Services declare their user-facing UI URL in `module.json`; hub renders
+one discovery tile per declaring service.
+
 > **Status: target convention, not yet implemented.** Hub's discovery
 > page today hardcodes which services have UIs in a JS
 > `SERVICE_LABELS` map at the top of
@@ -39,10 +42,18 @@ uiUrl?: string;  // path under the hub origin, leading "/"
 
 Resolution rules:
 
-- **Path on the hub origin** — `uiUrl: "/notes"`. Hub renders the link
-  as `<hub-origin>${uiUrl}` at click time. Leading `/` required; no
-  trailing slash. Same shape as `managementUrl`'s relative form (see
-  [`module-json-extensibility.md`](./module-json-extensibility.md#hub-ui-fields)).
+- **Path form** — `uiUrl: "/notes"`. `uiUrl` is a path on **hub's
+  origin** (not the module's). Hub renders the link as
+  `<hub-origin>${uiUrl}` regardless of where the module itself is
+  hosted. Leading `/` required; no trailing slash. Hub is the renderer
+  of the discovery page; clicks happen from hub, so the relative path
+  resolves there. This is **distinct from `managementUrl`'s relative
+  form**, which resolves against the *module's own well-known origin*
+  — see
+  [`module-json-extensibility.md`](./module-json-extensibility.md#managementurl-string).
+  The two collapse to the same URL for first-party modules colocated
+  on hub's origin, but a third-party module hosted elsewhere would see
+  the two diverge.
 - **Absolute URL** — `uiUrl: "https://notes.example.com"`. Hub uses
   verbatim. Escape hatch for modules whose UI is hosted somewhere
   other than the hub origin.


### PR DESCRIPTION
## Summary

- New pattern doc `patterns/module-ui-declaration.md` introducing `uiUrl?: string` as an optional top-level `module.json` field. Modules declare where their user-facing UI lives; hub's discovery page reads it via `/.well-known/parachute.json` and renders one tile per declaring service.
- New migration-notes entry dated 2026-05-10 capturing the change, the relationship to `managementUrl`, and the per-repo follow-up PRs.

## Why now

Hub's discovery page today hardcodes `SERVICE_LABELS` + `SERVICE_ORDER` + an `isVaultName` filter at the top of `parachute-hub/src/hub.ts`. Which-services-have-UIs and what-they're-called are baked in; only the mount `path` comes from `services.json`. Aaron flagged this — services should declare their own UIs; hub should render dynamically.

The first cut at the discovery section split tiles into "Use" vs "Admin"; that broke down because real service UIs combine use, config, and admin in one surface. Aaron's call: services declare what their UI *is* — combining concerns however they want — and hub renders one link per service.

## Shape of the field

```json
{
  "name": "parachute-notes",
  "uiUrl": "/notes",
  "displayName": "Notes",
  "tagline": "Browse your vault content."
}
```

Resolution rules mirror `managementUrl`:
- relative path (`"/notes"`) resolves against the hub origin
- absolute URL is used verbatim
- omitted = no tile rendered (still registered, still routable for API consumers)

## Relationship to `managementUrl`

`managementUrl` (added 2026-05-02) renders "Manage `<name>`" links on hub's admin pages — specifically the vault-list SPA. Different surface from discovery. `uiUrl` is its discovery-side peer; the two coexist and a service can declare both, one, or neither. The doc has a small comparison table.

## Adoption sequencing (parallel cross-repo)

1. This PR (parachute-patterns) — define the convention.
2. `parachute-notes` declares `uiUrl: "/notes"`; `parachute-agent` declares `uiUrl: "/agent"`. Vault and scribe omit.
3. `parachute-hub` reads `uiUrl` from each module's well-known entry and renders the discovery section dynamically. Hardcoded `SERVICE_LABELS` + `SERVICE_ORDER` + `isVaultName` filter retire.

Steps 2 and 3 are backwards-compatible with each other and can land in either order.

## What's intentionally deferred

Listed under "Open questions" in the doc:
- Per-instance `uiUrl` for multi-instance services (vault future).
- Auth metadata on the declared UI.
- Explicit `displayOrder` (alphabetical-by-name suffices for the three current services).
- Render shapes beyond a single tile (for `kind: "tool"` modules).

## Test plan

- [ ] Patterns repo CI (markdown only, no code).
- [ ] Reviewer pass — focus on whether the field shape, the `managementUrl` relationship framing, and the adoption sequencing are clean enough for the per-module + hub consumer-side PRs to land off this doc without ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)