### PR TITLE
docs(patterns): tag-scoped-tokens refresh — proposal → shipped (closes #17)

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,52 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-05-12 — `tag-scoped-tokens.md` refresh (patterns#17)
+
+**Change:** [`tag-scoped-tokens.md`](../patterns/tag-scoped-tokens.md)
+reframed from proposal-flavored prose to shipped-reality documentation.
+Concrete edits:
+
+- Top-line "Status: shipped" banner with the canonical vault implementation
+  link ([`src/tag-scope.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/tag-scope.ts))
+  and the vault#241 / rc.30 (2026-05-03) landing reference.
+- Convention section reframed: the two axes (OAuth `vault:<name>:<verb>`
+  scope claim + `scoped_tags` per-token attribute) are separate by design.
+  The colon-syntax shape proposed in patterns#17's title was rejected;
+  rationale in §"Why not extend the OAuth scope string."
+- Auth-check pseudocode aligned to the real `scoped_tags` field name
+  (was `tagAllowlist`) and routed through the actual function names
+  (`expandTokenTagScope`, `noteWithinTagScope`).
+- §"Hierarchy match semantics" cites the full resolver chain with file:line
+  refs (`expandTokenTagScope` → `Store.expandTagsWithDescendants` →
+  `getTagDescendants`).
+- §Lifecycle updated: tag-rename cascade is the shipped reality (`vault#275`,
+  2026-05-04), replacing the originally-specced fail-closed 409 design that
+  was carried in `vault#240`. Tag-delete still fails closed; the doc now
+  distinguishes rename (cascade — identity-as-meaning preserved) from
+  delete/merge (fail-closed — destructive op, dependency must be acknowledged).
+- §"How it composes" dropped reference to retired tools
+  (`update-note-schema`, `set-schema-mapping` — retired in vault#269).
+- §Adoption table converted from "Phase 1" framing to status-of-each-module,
+  with the rename-cascade row added.
+- New cross-link to [`guides/multi-writer-workspace.md`](../guides/multi-writer-workspace.md)
+  §2 (operator-facing worked example).
+- Removed the standalone two-line "Storage" stub that duplicated
+  §"Storage details" further down.
+
+**Affected:**
+
+- `parachute-patterns` — doc refreshed (this PR). No code-side changes.
+- `parachute-vault`, `parachute-hub`, `parachute-notes`, `parachute-agent`
+  — no follow-up required. Doc tracks reality; reality is already shipped.
+- Tracking issue [`patterns#17`](https://github.com/ParachuteComputer/parachute-patterns/issues/17)
+  can close on merge — the doc now answers the issue.
+
+**Status:** doc-only refresh. No `tag-scoped-tokens` behavior changed; the
+edits track the as-shipped surface vault has carried since 2026-05-03.
+
+---
+
 ## 2026-05-12 — `guides/multi-writer-workspace.md` lands
 
 **Change:** new `guides/` directory + first guide

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -25,10 +25,12 @@ Concrete edits:
   refs (`expandTokenTagScope` → `Store.expandTagsWithDescendants` →
   `getTagDescendants`).
 - §Lifecycle updated: tag-rename cascade is the shipped reality (`vault#275`,
-  2026-05-04), replacing the originally-specced fail-closed 409 design that
-  was carried in `vault#240`. Tag-delete still fails closed; the doc now
-  distinguishes rename (cascade — identity-as-meaning preserved) from
-  delete/merge (fail-closed — destructive op, dependency must be acknowledged).
+  merged 2026-05-09 inside the bundled vault sprint — documented in this
+  file's 2026-05-09 entry, item 4), replacing the originally-specced
+  fail-closed 409 design that was carried in `vault#240`. Tag-delete still
+  fails closed; the doc now distinguishes rename (cascade — identity-as-meaning
+  preserved) from delete/merge (fail-closed — destructive op, dependency
+  must be acknowledged).
 - §"How it composes" dropped reference to retired tools
   (`update-note-schema`, `set-schema-mapping` — retired in vault#269).
 - §Adoption table converted from "Phase 1" framing to status-of-each-module,

--- a/patterns/tag-scoped-tokens.md
+++ b/patterns/tag-scoped-tokens.md
@@ -1,27 +1,33 @@
 # Tag-scoped tokens
 
-> One-line summary: a vault token can be narrowed to a specific set of root tags. The token only sees and writes notes that carry one of those tags (or a sub-tag of one of them).
+> **Status: shipped.** A vault token can be narrowed to a specific set of root tags. The token only sees and writes notes that carry one of those tags (or a sub-tag of one of them). Vault implementation: [`src/tag-scope.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/tag-scope.ts), shipped in [`vault#241`](https://github.com/ParachuteComputer/parachute-vault/pull/241) at rc.30 (2026-05-03).
 
 ## Convention
 
-A vault token (`pvt_*`) optionally declares a **tag-allowlist** at mint time. Once set, the token's effective access is the intersection of:
+A vault token (`pvt_*`) optionally declares a **tag-allowlist** at mint time. Two axes compose:
 
-1. **Scope** (existing) — `vault:<name>:read | write | admin` per `oauth-scopes.md`
-2. **Tag allowlist** (new) — list of root tag names. Sub-tags inherit per the `tags.parent_names` hierarchy (see [`tag-data-model.md`](./tag-data-model.md)). The allowlist is **immutable** for the life of the token; editing the allowlist means minting a new token and revoking the old.
+1. **OAuth scope** — `vault:<name>:read | write | admin` per [`oauth-scopes.md`](./oauth-scopes.md). Verb-level capability.
+2. **Tag allowlist** — list of root tag names stored on the token row as `scoped_tags`. Sub-tags expand per the `tags.parent_names` hierarchy (see [`tag-data-model.md`](./tag-data-model.md)).
 
-Pseudocode for the auth check:
+The two axes are **separate by design**. The OAuth scope claim stays untouched — `vault:<name>:<verb>` — so hub-issued JWTs don't carry a noisy per-tag claim. The `scoped_tags` allowlist is a per-token vault-internal attribute, read at request time from the `tokens` row. Rationale in §"Why not extend the OAuth scope string."
+
+The allowlist is set at mint time and not editable thereafter (no `PATCH /tokens/<id> { scoped_tags: ... }`); revise by minting a new token and revoking the old. The one exception is tag-rename cascade (§Lifecycle): a vault-side `POST /api/tags/<old>/rename` rewrites every `tokens.scoped_tags` row referencing `<old>` to `<new>` atomically, so the token's *content* tracks the renamed identity. The token id, label, and scope remain stable across the cascade.
+
+Pseudocode for the auth check (real code: [`src/tag-scope.ts:31-101`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/tag-scope.ts)):
 
 ```ts
 function authCheck(token, note, action) {
   if (!hasScope(token, `vault:${vault}:${action}`)) return forbidden();
-  if (token.tagAllowlist === null) return ok();           // unscoped — current behavior
-  const noteTags = note.tags;                              // including hierarchy expansion
-  if (noteTags.some(t => token.tagAllowlist.includes(rootOf(t)))) return ok();
+  if (token.scoped_tags === null) return ok();             // unscoped — full vault access
+  const allowed = expandTokenTagScope(store, token.scoped_tags);
+  if (noteWithinTagScope(note, allowed, token.scoped_tags)) return ok();
   return forbidden();
 }
 ```
 
-Where `rootOf(t)` is `t.split('/')[0]` so `health/food` resolves to `health` for the allowlist check.
+Where `expandTokenTagScope` returns the union of `{root} ∪ descendants(root)` for each allowlisted root, via `store.expandTagsWithDescendants` which in turn calls `getTagDescendants` on the in-memory hierarchy built from `tags.parent_names`. `noteWithinTagScope` evaluates the expanded set AND a string-form fallback (`t.split("/")[0]` against the raw allowlist) so orphan sub-tags stay accessible — see §Storage details.
+
+For operator-facing guidance on standing up a multi-writer workspace using these tokens, see [`guides/multi-writer-workspace.md`](../guides/multi-writer-workspace.md) §2 (the concrete worked example walks Alice/Bob/Carol through scoped-token issuance).
 
 ### Hierarchy match semantics
 
@@ -32,17 +38,19 @@ A token whose allowlist contains `health` matches:
 - A note tagged ONLY with `#health/doctor` (same)
 - A note tagged with `#health/food/breakfast` (recursive sub-tag)
 
-The expansion uses vault's `getTagDescendants` resolver (reads from `tags.parent_names` per [`tag-data-model.md`](./tag-data-model.md); same path `query-notes` routes through). See §Storage details below for the full evaluation including the string-form fallback.
+The expansion routes through vault's `expandTokenTagScope` ([`src/tag-scope.ts:31-37`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/tag-scope.ts)) → `Store.expandTagsWithDescendants` ([`core/src/store.ts:299-307`](https://github.com/ParachuteComputer/parachute-vault/blob/main/core/src/store.ts)) → `getTagDescendants` ([`core/src/tag-hierarchy.ts:119`](https://github.com/ParachuteComputer/parachute-vault/blob/main/core/src/tag-hierarchy.ts)), which walks the in-memory hierarchy built from `tags.parent_names` (same resolver `query-notes` routes through; see [`tag-data-model.md`](./tag-data-model.md)). See §Storage details below for the full evaluation including the string-form fallback.
 
 ## Why
 
-[From Aaron's notes 2026-04-27 + 2026-04-30]
+Originating motivation, Aaron's notes 2026-04-27 + 2026-04-30:
 
 > *"...scoped tokens that can only write within a schema... other agents such as little telegram bots just have permission to modify stuff within that; only working with the tags you give it access to."*
 
 > *"If I make a tag called #health and then a sub-tag #health/food, then I could have a bot that is just scoped on all of my #health tags including any sub-tags."*
 
-The use case: per-purpose parachute-agent instances. A `#health` agent, a `#work` agent, a `#journal` agent — each spawned from the same vault, but with isolated visibility into the slice of notes the operator has tagged for it. Currently isolation is per-vault (separate `default` / `boulder` / `techne` vaults); this lets you slice within one vault.
+The use case: per-purpose parachute-agent instances and per-purpose downstream bots. A `#health` agent, a `#work` agent, a `#journal` agent — each spawned from the same vault, but with isolated visibility into the slice of notes the operator has tagged for it. Per-vault isolation already existed (separate `default` / `boulder` / `techne` vaults); this lets you slice within one vault.
+
+[Tracking issue: [`patterns#17`](https://github.com/ParachuteComputer/parachute-patterns/issues/17). The issue title proposed an OAuth-scope-string shape `vault:<name>:tag:<tagname>:<action>`; the shipped reality uses the `scoped_tags` token-attribute approach instead. See §"Why not extend the OAuth scope string" for the rationale.]
 
 Schema-on-tag is a load-bearing concept in this design — see [`tag-data-model.md`](./tag-data-model.md) for the schema authoring shape. Each tag carries its own schema (description + indexed fields + typed relationships) directly on the `tags` row.
 
@@ -51,8 +59,8 @@ Schema-on-tag is a load-bearing concept in this design — see [`tag-data-model.
 - **Read paths** — query-notes / GET /api/notes/:id / list-attachments filter results to only return notes with at least one allowlisted-root-tag (or sub-tag thereof).
 - **Write paths** — POST /api/notes / PATCH require the new note to carry at least one allowlisted root-tag. POST without any matching tag returns `403 forbidden`.
 - **Delete paths** — DELETE /api/notes/:id requires the existing note to be within scope. A token can't delete a note it can't read.
-- **Tag operations** — list-tags returns only tags reachable from the allowlist (root tags + sub-tags). `update-tag` (the upsert tool — see [`tag-data-model.md`](./tag-data-model.md)) is allowed only if the target tag is at-or-under one of the allowlisted roots; same gate on `delete-tag`.
-- **Schema operations** — the `update-tag` API (which writes to the `tags` row's schema columns: `description`, `fields`, `relationships`, `parent_names`) is gated by `vault:<name>:admin` + tag-in-allowlist. A tag-scoped admin CAN modify the schema for tags within their allowlist. Same gating applies to `update-note-schema` / `set-schema-mapping` for note-validation schemas.
+- **Tag operations** — `list-tags` returns only tags reachable from the allowlist (root tags + sub-tags). `update-tag` (the upsert tool — see [`tag-data-model.md`](./tag-data-model.md)) is allowed only if the target tag is at-or-under one of the allowlisted roots; same gate on `delete-tag`.
+- **Schema operations** — `update-tag` (which writes the `tags` row's schema columns: `description`, `fields`, `relationships`, `parent_names`) is gated by `vault:<name>:admin` + tag-in-allowlist. A tag-scoped admin CAN modify the schema for tags within their allowlist.
 
 ## Composability with existing scopes
 
@@ -75,7 +83,7 @@ A tag-scoped admin **cannot** mint new tokens with broader allowlists. The mint 
 
 ## Token issuance
 
-The `POST /vaults/<name>/tokens` endpoint (post-#220) gains an optional field:
+The `POST /vaults/<name>/tokens` endpoint accepts an optional `tags` field:
 
 ```json
 {
@@ -86,35 +94,25 @@ The `POST /vaults/<name>/tokens` endpoint (post-#220) gains an optional field:
 }
 ```
 
-When `tags` is omitted or `null`, the token is unscoped (current behavior). When present, the values must be existing root-tag names (no path separators).
+When `tags` is omitted or `null`, the token is unscoped (full vault access). When present, the values must be existing root-tag names (no path separators).
 
-The token mint UI (vault admin SPA, currently at `/admin/tokens` post-#220) gains a tag-picker step.
-
-## Storage
-
-Migration on the `tokens` table in vault DB:
-
-```sql
-ALTER TABLE tokens ADD COLUMN scoped_tags TEXT;  -- JSON-encoded array, NULL = unscoped
-```
-
-JSON-encoded so the column stays SQLite-portable. Validation at the API boundary (no schemaless mush).
+The token mint UI in vault's admin SPA at `/admin/tokens` carries a tag-picker step that validates against existing root-tags via `list-tags`.
 
 ## Why not extend the OAuth scope string
 
-OAuth 2.0 §3.3 scope strings *could* express this as `vault:<name>:tag:<tag>:<action>`, but:
+Patterns#17 originally proposed `vault:<name>:tag:<tag>:<action>` as an OAuth scope shape. We rejected it in favor of a `scoped_tags` token attribute. Three reasons:
 
-1. Multi-tag tokens would have unbounded scope-string length (`vault:default:tag:health:read vault:default:tag:wellness:read vault:default:tag:fitness:read ...`)
-2. Hub-issued JWTs would carry a noisy claim that's actually a vault-internal concern
-3. The `tags` field is a per-token attribute, not a per-action capability — the existing `read/write/admin` hierarchy still applies WITHIN the tag scope
+1. **Unbounded scope-string length.** A multi-tag token would emit `vault:default:tag:health:read vault:default:tag:wellness:read vault:default:tag:fitness:read ...`. Token headers / cookies bloat linearly with allowlist size.
+2. **Wrong layer for vault-internal concern.** The OAuth scope claim is what hub-issued JWTs and resource servers exchange. Tag-level narrowing is a vault-internal authorization detail; emitting it in the OAuth-layer claim leaks an implementation choice into the cross-module contract.
+3. **Per-token attribute, not per-action capability.** `read`/`write`/`admin` form a verb hierarchy within whatever scope is granted. Tags aren't a verb hierarchy — they're a content-shape attribute the token carries alongside its verbs. Mixing the two in one string conflates orthogonal axes.
 
-Keeping `tags` as a separate token field is cleaner. Hub-issued JWTs only carry the existing `vault:<name>:<action>` claim; the tag-allowlist is read by vault from its own `tokens` table at request time.
+Shipped shape: hub-issued JWTs carry the existing `vault:<name>:<action>` claim; vault reads the tag-allowlist from its own `tokens.scoped_tags` JSON column at request time. The two axes compose at the boundary without colliding in the wire format.
 
 ## Hub awareness
 
-Hub doesn't need to know about tag-allowlists at the OAuth level. Tokens with tag scope are minted via vault's `/admin/tokens` endpoint, not via the hub OAuth flow. The hub is the directory + issuer for cross-module tokens; tag-scoped tokens are within-vault.
+Hub doesn't need to know about tag-allowlists at the OAuth scope level. The `vault:<name>:<verb>` scope claim shape stays untouched on hub-issued JWTs; the per-tag narrowing is a vault-internal token attribute, evaluated at request time against the `tokens.scoped_tags` JSON column. Today's tag-scoped tokens are minted via vault's `/admin/tokens` endpoint (vault is the issuer of its own per-vault tokens — see [`patterns/hub-as-issuer.md`](./hub-as-issuer.md) Phase 0+1).
 
-If we later want third-party clients to request tag-scoped tokens via OAuth consent, that's a separate conversation about scope-string shape.
+If third-party clients ever need to request tag-scoped tokens via the hub OAuth consent flow, that's a separate conversation about scope-string shape — see §"Why not extend the OAuth scope string" for the constraints we'd want to preserve.
 
 ## Semantics
 
@@ -136,9 +134,9 @@ If we later want third-party clients to request tag-scoped tokens via OAuth cons
 4. Tokens whose `scoped_tags` JSON array contains `<old_name>` (root-form) are auto-updated to contain `<new_name>` instead. Allowlist content changes; token id, label, and scope are preserved. Sub-tag renames (e.g., `health/food` → `health/snack`) are a no-op for token allowlists, since only root-form entries are stored there.
 5. Note bodies referencing `#<old_name>` or `#<old_name>/...` are auto-updated.
 
-The cascade is transactional — partial failure rolls back. Audit log entry per cascade with old → new mapping. **Implementation is filed as `vault#240`** (separate from Phase 1 of patterns#24); the v13 auth check stays robust to rename via the string-form fallback (per §Storage details mechanism 2). Note: tags use `name TEXT PRIMARY KEY` — no separate stable-id column; rename is a multi-table data migration not a single-column update.
+The cascade is transactional — single `BEGIN IMMEDIATE`, ROLLBACK on any throw. Pre-flight collision check returns `{error: "target_exists", conflicting: [...]}` without touching the DB. **Shipped in [`vault#275`](https://github.com/ParachuteComputer/parachute-vault/pull/275)** (2026-05-04), replacing an earlier fail-closed-on-token-reference design that was carried in `vault#240`. The string-form fallback (§Storage details mechanism 2) backs the auth check so a partial cascade or pending rebuild never silently hides notes. Note: tags use `name TEXT PRIMARY KEY` — no separate stable-id column; rename is a multi-table data migration, not a single-column update.
 
-**Tag delete fails closed if tokens reference it.** When operator runs `DELETE /api/tags/<name>` and any token has `<name>` (root-form) in its `scoped_tags` allowlist, the delete returns `409 Conflict` with the list of referencing token labels. Operator must revoke or re-mint those tokens (with the tag removed from allowlist) before retrying the delete. This is loud-fail by design: tag deletion is destructive and the operator should notice the dependency.
+**Tag delete fails closed if tokens reference it.** When operator runs `DELETE /api/tags/<name>` and any token has `<name>` (root-form) in its `scoped_tags` allowlist, the delete returns `409 Conflict` with `error_type: "tag_in_use_by_tokens"` and the list of referencing tokens. Operator must revoke or re-mint those tokens (with the tag removed from allowlist) before retrying the delete. **Tag merge is the same shape** — `POST /api/tags/merge` runs the same dependency check and 409s on the same envelope. This is loud-fail by design: tag deletion (and merge-with-consumption) is destructive, and the operator should notice the dependency rather than have allowlists silently orphaned. Reference: [`src/routes.ts:1338-1361`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/routes.ts) (delete), `routes.ts:1180-1200` (merge). The rename path *cascades* (above) rather than fail-closing, because rename preserves the tag's identity-as-meaning — only the string changes.
 
 **Orphan sub-tag — fail-open.** A note carries tag `#health/food`. There's no `tags` row for `health/food`, or its `parent_names` doesn't include `health`. A token with allowlist `[health]` evaluating against this note: the auth check still returns true. The string-form `/`-prefix hierarchy (`rootOf("health/food") = "health"`) is the source of truth; a missing or incomplete `tags`-row hierarchy doesn't gate access. The `tags` row carries indexed fields and declared relationships, not auth state.
 
@@ -181,19 +179,21 @@ The following extensions are explicitly deferred. Each is sound; none block Phas
 
 ## Adoption
 
-| Module | Action |
+| Module | Status |
 | --- | --- |
-| **vault** | Phase 1 — schema migration, auth-check, query-notes filtering, mint UI in admin SPA, regression tests. Shipped in [`vault#241`](https://github.com/ParachuteComputer/parachute-vault/pull/241) at rc.30 (2026-05-03). |
-| **vault** | Tag-rename-cascade implementation: `vault#240` (separate, post-Phase 1). |
-| **vault** | Path/folder/name split design: `vault#238` (deferred design exploration). |
-| **vault** | Wikilinks + tag-scope handling: `vault#239` (deferred design exploration). |
-| **parachute-agent** | Update `attach-vault` flow to optionally accept a tag-list; surface in agent-group settings UI; pass through to spawned-container env. |
-| **hub** | No change at the OAuth layer — token shape stays the same. |
-| **notes** | No change — Notes app uses operator-scope tokens (full access) by default. |
+| **vault** | **Shipped.** Schema migration v13 (`scoped_tags TEXT` column on `tokens`), auth-check via [`src/tag-scope.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/tag-scope.ts), query-notes filtering, mint UI in admin SPA, regression tests. Landed in [`vault#241`](https://github.com/ParachuteComputer/parachute-vault/pull/241) at rc.30 (2026-05-03). |
+| **vault** | **Shipped.** Tag-rename cascade across `tokens.scoped_tags` (and every other surface) — transactional `BEGIN IMMEDIATE` + ROLLBACK on throw. Landed in [`vault#275`](https://github.com/ParachuteComputer/parachute-vault/pull/275) (2026-05-04, replacing the prior fail-closed 409 design). |
+| **vault** | Path/folder/name split design: [`vault#238`](https://github.com/ParachuteComputer/parachute-vault/issues/238) (deferred design exploration). |
+| **vault** | Wikilinks + tag-scope handling: [`vault#239`](https://github.com/ParachuteComputer/parachute-vault/issues/239) (deferred design exploration). |
+| **parachute-agent** | Update `attach-vault` flow to optionally accept a tag-list; surface in agent-group settings UI; pass through to spawned-container env. **Not yet filed.** |
+| **hub** | No change at the OAuth layer — `vault:<name>:<verb>` claim shape unchanged. Tag-allowlist is a vault-internal token attribute, not exposed in OAuth consent for Phase 1. |
+| **notes** | No change — Notes app uses operator-scope tokens (full access) by default. Out-of-scope cells from any scoped token materialize as 404 from vault. |
+| **patterns (this repo)** | Documented here + cross-linked from [`guides/multi-writer-workspace.md`](../guides/multi-writer-workspace.md). |
 
 ## Adoption notes
 
 - Aaron approved this design 2026-05-02 (PR #24).
 - Vault Phase 1 shipped 2026-05-03 ([`vault#241`](https://github.com/ParachuteComputer/parachute-vault/pull/241), rc.30); the mint flow's tag-picker validates against existing root-tags via list-tags.
-- Migration-notes entry: `adoption/migration-notes.md` (2026-05-03 — Tag-scoped tokens Phase 1).
+- Tag-rename cascade shipped 2026-05-04 ([`vault#275`](https://github.com/ParachuteComputer/parachute-vault/pull/275)) — `scoped_tags` rewriting on rename replaced the fail-closed 409 originally specced in §Lifecycle.
+- Migration-notes entries: [`adoption/migration-notes.md`](../adoption/migration-notes.md) — "2026-05-03 — Tag-scoped tokens Phase 1" and "2026-05-04 — Tag-scoped tokens — rename cascade replaces fail-closed 409."
 - Outstanding follow-up: parachute-agent `attach-vault` integration (no issue filed yet).

--- a/patterns/tag-scoped-tokens.md
+++ b/patterns/tag-scoped-tokens.md
@@ -134,7 +134,7 @@ If third-party clients ever need to request tag-scoped tokens via the hub OAuth 
 4. Tokens whose `scoped_tags` JSON array contains `<old_name>` (root-form) are auto-updated to contain `<new_name>` instead. Allowlist content changes; token id, label, and scope are preserved. Sub-tag renames (e.g., `health/food` → `health/snack`) are a no-op for token allowlists, since only root-form entries are stored there.
 5. Note bodies referencing `#<old_name>` or `#<old_name>/...` are auto-updated.
 
-The cascade is transactional — single `BEGIN IMMEDIATE`, ROLLBACK on any throw. Pre-flight collision check returns `{error: "target_exists", conflicting: [...]}` without touching the DB. **Shipped in [`vault#275`](https://github.com/ParachuteComputer/parachute-vault/pull/275)** (2026-05-04), replacing an earlier fail-closed-on-token-reference design that was carried in `vault#240`. The string-form fallback (§Storage details mechanism 2) backs the auth check so a partial cascade or pending rebuild never silently hides notes. Note: tags use `name TEXT PRIMARY KEY` — no separate stable-id column; rename is a multi-table data migration, not a single-column update.
+The cascade is transactional — single `BEGIN IMMEDIATE`, ROLLBACK on any throw. Pre-flight collision check returns `{error: "target_exists", conflicting: [...]}` without touching the DB. **Shipped in [`vault#275`](https://github.com/ParachuteComputer/parachute-vault/pull/275)** (merged 2026-05-09 as part of a bundled vault sprint), replacing an earlier fail-closed-on-token-reference design that was carried in `vault#240`. The string-form fallback (§Storage details mechanism 2) backs the auth check so a partial cascade or pending rebuild never silently hides notes. Note: tags use `name TEXT PRIMARY KEY` — no separate stable-id column; rename is a multi-table data migration, not a single-column update.
 
 **Tag delete fails closed if tokens reference it.** When operator runs `DELETE /api/tags/<name>` and any token has `<name>` (root-form) in its `scoped_tags` allowlist, the delete returns `409 Conflict` with `error_type: "tag_in_use_by_tokens"` and the list of referencing tokens. Operator must revoke or re-mint those tokens (with the tag removed from allowlist) before retrying the delete. **Tag merge is the same shape** — `POST /api/tags/merge` runs the same dependency check and 409s on the same envelope. This is loud-fail by design: tag deletion (and merge-with-consumption) is destructive, and the operator should notice the dependency rather than have allowlists silently orphaned. Reference: [`src/routes.ts:1338-1361`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/routes.ts) (delete), `routes.ts:1180-1200` (merge). The rename path *cascades* (above) rather than fail-closing, because rename preserves the tag's identity-as-meaning — only the string changes.
 
@@ -176,24 +176,26 @@ The following extensions are explicitly deferred. Each is sound; none block Phas
 | **Multi-vault tokens** | Token allowlist becomes `{ "default": ["health"], "boulder": ["health"] }`. Cross-vault scoping via single token. | When operators want a single agent identity working across multiple vaults. |
 | **Scope by metadata** | Token carries metadata-conditions (e.g., `source: "prism"`). Composes with tag-scope. Filed as `parachute-patterns#25`. | Phase 2+ of the agents-as-channels arc. |
 | **Time-bounded per-tag scope** | `scoped_tags: [{tag: "health", until: "2026-12-31"}]` — different tags have different lifetimes. | When token-level expiry isn't enough granularity. |
+| **Path / folder / name split** | Disentangle the three roles `path` currently plays (storage location, wikilink target, hierarchy hint). Filed as [`vault#238`](https://github.com/ParachuteComputer/parachute-vault/issues/238). | Design exploration — touches more than tag-scope; will resurface when surface-direction or richer ACLs need it. |
+| **Wikilinks + tag-scope interaction** | When a scoped token traverses a wikilink to an out-of-scope target, today's behavior is silent filtering (the link appears unresolved). Filed as [`vault#239`](https://github.com/ParachuteComputer/parachute-vault/issues/239). | When a real workflow surfaces friction with partial-graph reads. |
 
 ## Adoption
 
 | Module | Status |
 | --- | --- |
 | **vault** | **Shipped.** Schema migration v13 (`scoped_tags TEXT` column on `tokens`), auth-check via [`src/tag-scope.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/tag-scope.ts), query-notes filtering, mint UI in admin SPA, regression tests. Landed in [`vault#241`](https://github.com/ParachuteComputer/parachute-vault/pull/241) at rc.30 (2026-05-03). |
-| **vault** | **Shipped.** Tag-rename cascade across `tokens.scoped_tags` (and every other surface) — transactional `BEGIN IMMEDIATE` + ROLLBACK on throw. Landed in [`vault#275`](https://github.com/ParachuteComputer/parachute-vault/pull/275) (2026-05-04, replacing the prior fail-closed 409 design). |
-| **vault** | Path/folder/name split design: [`vault#238`](https://github.com/ParachuteComputer/parachute-vault/issues/238) (deferred design exploration). |
-| **vault** | Wikilinks + tag-scope handling: [`vault#239`](https://github.com/ParachuteComputer/parachute-vault/issues/239) (deferred design exploration). |
+| **vault** | **Shipped.** Tag-rename cascade across `tokens.scoped_tags` (and every other surface) — transactional `BEGIN IMMEDIATE` + ROLLBACK on throw. Landed in [`vault#275`](https://github.com/ParachuteComputer/parachute-vault/pull/275) (merged 2026-05-09, replacing the prior fail-closed 409 design). |
 | **parachute-agent** | Update `attach-vault` flow to optionally accept a tag-list; surface in agent-group settings UI; pass through to spawned-container env. **Not yet filed.** |
 | **hub** | No change at the OAuth layer — `vault:<name>:<verb>` claim shape unchanged. Tag-allowlist is a vault-internal token attribute, not exposed in OAuth consent for Phase 1. |
 | **notes** | No change — Notes app uses operator-scope tokens (full access) by default. Out-of-scope cells from any scoped token materialize as 404 from vault. |
 | **patterns (this repo)** | Documented here + cross-linked from [`guides/multi-writer-workspace.md`](../guides/multi-writer-workspace.md). |
 
+Two vault-side deferred design explorations moved to §Future evolution (path/folder/name split; wikilinks + tag-scope handling) so the Adoption table holds *current commitments* and §Future holds *what's logged for later*.
+
 ## Adoption notes
 
 - Aaron approved this design 2026-05-02 (PR #24).
 - Vault Phase 1 shipped 2026-05-03 ([`vault#241`](https://github.com/ParachuteComputer/parachute-vault/pull/241), rc.30); the mint flow's tag-picker validates against existing root-tags via list-tags.
-- Tag-rename cascade shipped 2026-05-04 ([`vault#275`](https://github.com/ParachuteComputer/parachute-vault/pull/275)) — `scoped_tags` rewriting on rename replaced the fail-closed 409 originally specced in §Lifecycle.
-- Migration-notes entries: [`adoption/migration-notes.md`](../adoption/migration-notes.md) — "2026-05-03 — Tag-scoped tokens Phase 1" and "2026-05-04 — Tag-scoped tokens — rename cascade replaces fail-closed 409."
+- Tag-rename cascade ([`vault#275`](https://github.com/ParachuteComputer/parachute-vault/pull/275)) merged 2026-05-09 as part of the bundled "Tag schema inheritance, `_default`, rename cascade, MCP discovery" sprint — `scoped_tags` rewriting on rename replaced the fail-closed 409 originally specced in §Lifecycle.
+- Migration-notes references: [`adoption/migration-notes.md`](../adoption/migration-notes.md) — the "2026-05-03 — Tag-scoped tokens Phase 1 (vault)" entry covers Phase 1; the rename-cascade work is documented inside the "2026-05-09 — Tag schema inheritance, `_default`, rename cascade, MCP discovery (vault)" entry as item 4 of that bundle.
 - Outstanding follow-up: parachute-agent `attach-vault` integration (no issue filed yet).


### PR DESCRIPTION
## Summary

- Reframes [`patterns/tag-scoped-tokens.md`](../../tree/ag-unforced-dev/patterns/tag-scoped-tokens.md) from proposal-flavored prose to shipped-reality documentation. The pattern landed in [`vault#241`](https://github.com/ParachuteComputer/parachute-vault/pull/241) at rc.30 (2026-05-03); the doc text still read in places as if it described future work.
- Resolves [`patterns#17`](https://github.com/ParachuteComputer/parachute-patterns/issues/17) by documenting the shipped `scoped_tags` per-token-attribute design and the rationale for rejecting the issue's originally-proposed OAuth scope-string syntax (`vault:<name>:tag:<tagname>:<action>`).
- Adds cross-link to [`guides/multi-writer-workspace.md`](../../tree/ag-unforced-dev/guides/multi-writer-workspace.md) §2 for the operator-facing worked example.

## Patterns check

- **Touches:** `tag-scoped-tokens.md` (this doc), `oauth-scopes.md` (cross-link target, unchanged), `tag-data-model.md` (cross-link target, unchanged), `hub-as-issuer.md` (cross-link target, unchanged), `guides/multi-writer-workspace.md` (cross-link target, unchanged).
- **Conforms:** yes. This is a documentation refresh tracking already-shipped vault behavior; no pattern semantics changed.
- **Establishes / changes:** no new pattern; existing pattern's framing updated.

## Test plan

- [ ] Read the refreshed doc end-to-end for coherence.
- [ ] Verify the file:line citations resolve in `parachute-vault` (e.g. `src/tag-scope.ts:31-101`, `core/src/store.ts:299-307`, `core/src/tag-hierarchy.ts:119`).
- [ ] Confirm the §Lifecycle distinction (rename cascades, delete/merge fail-closed) matches `parachute-vault/src/routes.ts:1180-1361`.
- [ ] On merge: close [`patterns#17`](https://github.com/ParachuteComputer/parachute-patterns/issues/17) (the doc now answers the issue).

This is doc-only — no RC bump (patterns is a docs-only repo and the doc-only convention applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)