### PR TITLE
docs(cookbook): vault-portable-export — git projection + DR recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ brand/        palette, typography, motifs, canonical tokens.css
 schemas/      agent markdown, vault note metadata, lint rules
 patterns/     loadX sources, report contract, token auth, MCP transport, dev-auto-user
 guides/       long-form how-to references that explain how patterns combine
+cookbook/     short recipes — one outcome, one page, links out for depth
 research/     in-flight design notes for not-yet-committed direction
 adoption/     checklist for new modules, migration notes log
 ```

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -1,0 +1,15 @@
+# cookbook
+
+Concrete recipes — how to combine Parachute primitives for specific outcomes. One file per recipe, the same one-screen budget as `patterns/`.
+
+Cookbook entries differ from `patterns/` and `guides/`:
+
+- **`patterns/`** documents *conventions* (how Parachute modules align — names, schemas, contracts).
+- **`guides/`** documents *long-form how-to* references (builder-oriented, multi-chapter, "how do I X across the whole stack").
+- **`cookbook/`** documents *recipes* (one outcome, one short writeup, link out for depth).
+
+Reach for cookbook when the answer to "how do I do X" is short and concrete enough to fit on one page, but specific enough that it doesn't belong as a `pattern`.
+
+## Entries
+
+- [`vault-portable-export.md`](./vault-portable-export.md) — lossless markdown export of a vault, with recipes for git-as-projection and disaster-recovery snapshots.

--- a/cookbook/vault-portable-export.md
+++ b/cookbook/vault-portable-export.md
@@ -21,7 +21,8 @@ Use the legacy `core/src/obsidian.ts` only if you specifically need the flat-fro
 # Full export — every note, every schema-carrying tag.
 parachute-vault export <dir>
 
-# Pick a non-default vault.
+# Pick a non-default vault. (Defaults to the vault named `default` — use
+# `--vault <name>` if your vault has a different name.)
 parachute-vault export <dir> --vault <name>
 
 # Incremental — only notes whose updated_at >= ISO timestamp.
@@ -135,7 +136,7 @@ triggers:
       send: json
 ```
 
-The receiver doesn't have to do work synchronously — it just records "vault dirty since T" in a small state file. Sub-second response so vault's two-phase trigger marker (`<name>_rendered_at`) clears promptly.
+The receiver doesn't have to do work synchronously — it just records "vault dirty since T" in a small state file. Sub-second response keeps vault's two-phase trigger marker cycling promptly: `<name>_pending_at` is written on entry and cleared once `<name>_rendered_at` is written on success.
 
 **2.** Wire the projection itself as a cron job (or a debounced consumer of the nudge endpoint, your call) that exports the vault since the last cursor and commits the diff:
 
@@ -193,14 +194,14 @@ When PR 2 ships, restore is `parachute-vault import <untarred-dir> --blow-away`.
 
 ## Worked example — Gitcoin Brain
 
-The Gitcoin Brain build (week-1 architecture, [`from_parachute_round_2.md`](https://github.com/ParachuteComputer/parachute-vault/issues/308) Ask 1) is the load-bearing use case this primitive was reframed and extended for. Their model: vault is the source of truth for live state; a git repo of the export is the projection. Audit, recovery, time-travel, browseable code-review-style diff history — every property of "the team brain in git" without paying the dual-write tax of git-as-primary.
+The Gitcoin Brain build (week-1 architecture, `from_parachute_round_2.md` Ask 1) is the load-bearing use case this primitive was reframed and extended for. Their model: vault is the source of truth for live state; a git repo of the export is the projection. Audit, recovery, time-travel, browseable code-review-style diff history — every property of "the team brain in git" without paying the dual-write tax of git-as-primary.
 
 Concretely, the Gitcoin team:
 
 1. Run vault as the primary write surface (REST + MCP + Notes + Telegram).
 2. Wire a webhook trigger on high-stakes tags (commitments, decisions, donor pipeline) that nudges a projection daemon.
-3. Run `parachute-vault export --since <cursor>` on the nudge (debounced) and a full export weekly.
-4. Commit + push to a private git repo. Diffs are reviewable; history is the audit trail; restoration is `parachute-vault import --blow-away` (once PR 2 lands).
+3. Run `parachute-vault export "$PROJECTION_DIR" --since "$CURSOR"` on the nudge (debounced) and a full export weekly.
+4. Commit + push to a private git repo. Diffs are reviewable; history is the audit trail; restoration is `parachute-vault import "$PROJECTION_DIR" --blow-away` (once PR 2 lands).
 
 When the export primitive isn't right for them — when a Gitcoin-specific format or a richer drift signal matters — they build a sidecar and contribute the pattern back. Generic patterns extracted up to parachute; specific dashboards stay in Gitcoin's app code. The Round-2 reply spells the boundary out.
 

--- a/cookbook/vault-portable-export.md
+++ b/cookbook/vault-portable-export.md
@@ -1,0 +1,217 @@
+# Vault portable-markdown export
+
+> One-line summary: a lossless portable-markdown export of a parachute-vault that round-trips by design — same format every Obsidian/Logseq/Foam/Quartz/Dendron-shaped tool already consumes, but with IDs, typed links, tag schemas, and indexed metadata preserved so re-import reconstructs byte-equivalent vault state.
+
+This entry is a cookbook recipe — concrete patterns for using the export primitive in the wild. For the format spec, the [vault README's *Portable markdown export* section](https://github.com/ParachuteComputer/parachute-vault/blob/main/CLAUDE.md) and the code at [`core/src/portable-md.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/core/src/portable-md.ts) are authoritative.
+
+## When to reach for it
+
+- **Git-as-projection.** Vault is the source of truth; a git repo of the export is a deterministic projection (audit, time-travel, browseable, code-review-able). Mutation in vault → re-run export → commit. Mutation in git is a one-way fork.
+- **Disaster-recovery snapshot.** Periodic full export to a separate disk (or off-host) gives a tool-independent restore path. Pair with PR 2's `--blow-away` import to replay back to byte-equivalent state.
+- **Vault migration.** Moving from one parachute-vault host to another (local → VPS, or vice versa). Export from source, blow-away-import on the destination.
+- **Offline editing.** Drop the export into Obsidian/Logseq/Quartz/Dendron, edit, re-import. Round-trip preserves IDs and typed links — the consumer doesn't need to know about either.
+- **Sharing a knowledge graph as static files.** Hand someone a directory. They can read it with `less` or open it in any markdown tool. No vault required.
+- **Static-site generation.** Quartz, Hugo, Eleventy. The export is just markdown + YAML.
+
+Use the legacy `core/src/obsidian.ts` only if you specifically need the flat-frontmatter shape (no IDs, no `metadata:` block). It's deprecated — preserved for callers that were already wired into it.
+
+## CLI surface
+
+```bash
+# Full export — every note, every schema-carrying tag.
+parachute-vault export <dir>
+
+# Pick a non-default vault.
+parachute-vault export <dir> --vault <name>
+
+# Incremental — only notes whose updated_at >= ISO timestamp.
+# Useful as the "since-cursor" half of a projection cadence.
+parachute-vault export <dir> --since 2026-05-12T00:00:00Z
+```
+
+Output (per [`exportVaultToDir`](https://github.com/ParachuteComputer/parachute-vault/blob/main/core/src/portable-md.ts) in `core/src/portable-md.ts`):
+
+```
+<dir>/
+  .parachute/
+    vault.yaml                # vault meta + export_format_version
+    schemas/<tag>.yaml        # one file per schema-carrying tag
+    attachments/<id>/...      # binary files (PR 2; vault#308)
+  <note.path>.md              # one file per pathed note
+  _unpathed/<note-id>.md      # one file per pathless note
+```
+
+The sidecar directory is named `.parachute` so that walkers which skip dot-prefixed directories (including vault's own `walkMarkdownFiles`, Obsidian, Logseq, most SSGs) won't accidentally treat schemas or vault-meta as notes.
+
+**Import is still in flight.** PR 1 (rc.10, on `main`) is export-only. PR 2 lands:
+
+```bash
+parachute-vault import <dir>               # upsert notes/tags/schemas by ID
+parachute-vault import <dir> --blow-away   # drop + replay → byte-equivalent state (disaster recovery)
+```
+
+When PR 2 ships, this entry's CLI block gets the imports promoted out of *coming soon*.
+
+## Per-note frontmatter
+
+Fixed top-level key order, alpha-sorted nested keys — byte-identical re-emit of an unchanged vault is a guarantee, not a coincidence:
+
+```yaml
+---
+id: 01HGZ9...                      # ULID — durable across path renames
+path: Inbox/2026-05-12-meeting     # omit for pathless notes (filed under _unpathed/<id>.md)
+tags:
+  - donor-pipeline
+  - meeting
+metadata:                          # nested alpha-sorted
+  priority: high
+  state: drafted
+links:                             # typed (non-wikilink) relationships
+  - relationship: derived-from
+    target: 01HGZA...
+attachments:                       # PR 2 wires the file copy; PR 1 emits refs
+  - id: att_01HGZB...
+    mime_type: audio/mp4
+    path: 2026-05-12/audio.m4a
+created_at: 2026-05-12T10:00:00.000Z
+updated_at: 2026-05-12T11:23:45.123Z
+---
+
+Note body. [[Wikilinks]] are preserved verbatim — they're the source of
+truth for that link kind, so re-imports recover them from the content.
+```
+
+Key-order is fixed in [`FRONTMATTER_KEY_ORDER`](https://github.com/ParachuteComputer/parachute-vault/blob/main/core/src/portable-md.ts): `id` → `path` → `tags` → `metadata` → `links` → `attachments` → `created_at` → `updated_at`. Empty collections are omitted (no `metadata: {}` noise, no `tags: []`).
+
+## Per-tag sidecar schemas
+
+For every tag that declares at least one of `description` / `fields` / `relationships` / `parent_names`, the export writes `.parachute/schemas/<tag>.yaml`:
+
+```yaml
+description: A donor pipeline opportunity. State machine: prospect → engaged → committed.
+fields:
+  amount:
+    type: number
+  state:
+    type: enum
+    values: [prospect, engaged, committed]
+name: donor-pipeline
+parent_names:
+  - workspace-root
+relationships:
+  derived-from:
+    target_tag: meeting
+```
+
+Just-a-name tags (no schema content) don't get a file. Tag names containing `/` (sub-tag hierarchy) get `/` replaced with `__` in the filename only — the canonical name lives inside the file's `name:` key, so the round-trip recovers the slash form.
+
+## What round-trips losslessly
+
+Once PR 2 lands the import side, exporting a vault, blowing it away, and re-importing the export will reproduce byte-equivalent vault state across:
+
+- **IDs.** ULIDs survive. Wikilinks resolve by path or ID; typed `links` resolve by ID. Renaming a note's path doesn't break inbound links.
+- **Typed links.** Non-wikilink relationships (`derived-from`, `cites`, anything custom) serialized in the `links:` block. Sorted by `(relationship, target)` for stable output.
+- **Tag schemas.** Description, fields, relationships, parent_names — the full schema layer reconstructs from the sidecar.
+- **Indexed metadata.** Whatever your tag schemas index, the values come back in the same shape (booleans as `true`/`false`, numbers bare, strings quoted only when ambiguous).
+- **Multi-line strings.** Metadata values that contain newlines/tabs/control characters are double-quoted with YAML escape sequences (`\n`, `\xNN`) so the whole value stays on one physical YAML line. Single-quoted multi-line splits the parser — caught and pinned in vault#317 F1.
+- **Wikilinks in content.** Preserved verbatim. They're the content's job; the parser does not strip or rewrite them.
+- **Attachments.** Frontmatter refs ship today (PR 1); binary file copy under `.parachute/attachments/<att-id>/<filename>` ships in PR 2.
+- **Idempotency.** Re-export an unchanged vault → byte-identical bytes (modulo `exported_at` in `vault.yaml`, which callers wanting strict byte-equivalence can pin via the `exportedAt` API option). Clean git diffs.
+
+## Recipe: nightly git projection
+
+The webhook-driven version of Gitcoin Brain's vault-as-primary / git-as-projection architecture. One trigger, one cron, one git repo.
+
+**1.** In `~/.parachute/vault/config.yaml`, register a webhook trigger that fires on every note mutation in the namespaces you want projected. (Vault's [trigger framework](https://github.com/ParachuteComputer/parachute-vault/blob/main/README.md#webhook-triggers) is declarative — see the README for predicate fields.)
+
+```yaml
+triggers:
+  - name: git-projection-nudge
+    events: [created, updated]
+    when:
+      tags: [commitment, decision, donor-pipeline]  # high-stakes tags
+    action:
+      webhook: http://localhost:7777/projection-nudge
+      send: json
+```
+
+The receiver doesn't have to do work synchronously — it just records "vault dirty since T" in a small state file. Sub-second response so vault's two-phase trigger marker (`<name>_rendered_at`) clears promptly.
+
+**2.** Wire the projection itself as a cron job (or a debounced consumer of the nudge endpoint, your call) that exports the vault since the last cursor and commits the diff:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+PROJECTION_DIR="$HOME/projections/team-brain"
+CURSOR_FILE="$PROJECTION_DIR/.parachute/.last-cursor"
+mkdir -p "$PROJECTION_DIR/.parachute"
+
+SINCE="$(cat "$CURSOR_FILE" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
+NOW="$(date -u +%FT%TZ)"
+
+parachute-vault export "$PROJECTION_DIR" --since "$SINCE"
+
+cd "$PROJECTION_DIR"
+git add -A
+if ! git diff --cached --quiet; then
+  git commit -m "projection: vault changes since $SINCE"
+  git push
+fi
+echo "$NOW" > "$CURSOR_FILE"
+```
+
+Notes on this shape:
+
+- The cursor lives *inside* the projection's sidecar so it's co-located with the export but excluded from re-imports (its filename starts with `.`, so the directory walker skips it).
+- `--since` is best-effort incremental — a tombstone (deleted note) doesn't surface here; full periodic exports (weekly) catch deletions and orphan files. Schedule a `parachute-vault export <dir>` (no `--since`) on top of the incremental cadence for that reason.
+- A full export with the `git add -A` shape above will also produce deletions in the git tree for any note removed from vault, which is the projection-correct behavior.
+- For multi-vault servers, run one projection per vault into one repo each. Mixing vaults in one projection directory loses the 1:1 correspondence.
+
+## Recipe: cold-storage backup
+
+Disaster-recovery snapshot. Run on a different schedule than git projection (e.g. weekly) so the backup isn't a chain of incremental diffs — each backup is a self-contained restore point.
+
+```bash
+SNAPSHOT="$HOME/backups/vault-$(date -u +%Y%m%d).tar.zst"
+TMP="$(mktemp -d)"
+parachute-vault export "$TMP"
+tar --zstd -cf "$SNAPSHOT" -C "$TMP" .
+rm -rf "$TMP"
+```
+
+When PR 2 ships, restore is `parachute-vault import <untarred-dir> --blow-away`. Until then, the snapshot is read-only — the format is still human-recoverable (every note is a markdown file with YAML frontmatter), it just can't replay automatically.
+
+## Edge cases / gotchas
+
+- **Path traversal is refused, not aborted.** A note with `path: "../../escape"` would otherwise write outside the export directory. `exportVaultToDir` resolves the candidate path against the export root and refuses the write with a `console.warn`, then keeps going. Partial export beats no export. Self-inflicted at the vault level (operator owns the data), but real for programmatic callers ingesting from external systems. See [`isWithinDir`](https://github.com/ParachuteComputer/parachute-vault/blob/main/core/src/portable-md.ts) and the F3 fix in vault#317.
+- **Pathless notes land in `_unpathed/`.** Notes without a `path:` go to `_unpathed/<note-id>.md` so they don't collide with each other and so a user importing into Obsidian sees them in one folder rather than scattered at the root.
+- **`exported_at` is the one timestamp that won't be byte-identical across runs.** It lives in `.parachute/vault.yaml`. Callers wanting strict byte-equivalence (tests, fixture diffing) pass `exportedAt` to the `exportVaultToDir` API; the CLI always stamps live. If you're git-projecting and want minimal diff noise, the `vault.yaml` file changing every run is the cost.
+- **Schema drift on import (PR 2).** `import` without `--blow-away` warns on schema conflicts (export claims `fields.amount.type: number`, vault already has `fields.amount.type: string`). `--blow-away` replays the export's schemas exactly. Choose the verb that matches your intent.
+- **Attachments are refs in PR 1, files in PR 2.** Today's export emits `attachments:` frontmatter entries pointing at `.parachute/attachments/<id>/<filename>`, but doesn't copy the binary yet. If your projection depends on the file contents, hold for PR 2.
+- **The hand-rolled YAML parser is intentionally narrow.** It handles the subset of YAML the emitter produces plus the legacy Obsidian shapes the importer needs. It does *not* handle anchors, references, multi-document streams, or YAML 1.2 `\u<4hex>`/`\U<8hex>` escapes — none of which the emitter produces. If you hand-edit sidecar `.yaml` files, stay inside that subset.
+- **The 1M-note bulk-load ceiling.** `exportVaultToDir` materializes the full vault in memory before iterating. Defensive — the cap is a follow-up at vault#317 F5 if a real >>100k-note workload surfaces.
+
+## Worked example — Gitcoin Brain
+
+The Gitcoin Brain build (week-1 architecture, [`from_parachute_round_2.md`](https://github.com/ParachuteComputer/parachute-vault/issues/308) Ask 1) is the load-bearing use case this primitive was reframed and extended for. Their model: vault is the source of truth for live state; a git repo of the export is the projection. Audit, recovery, time-travel, browseable code-review-style diff history — every property of "the team brain in git" without paying the dual-write tax of git-as-primary.
+
+Concretely, the Gitcoin team:
+
+1. Run vault as the primary write surface (REST + MCP + Notes + Telegram).
+2. Wire a webhook trigger on high-stakes tags (commitments, decisions, donor pipeline) that nudges a projection daemon.
+3. Run `parachute-vault export --since <cursor>` on the nudge (debounced) and a full export weekly.
+4. Commit + push to a private git repo. Diffs are reviewable; history is the audit trail; restoration is `parachute-vault import --blow-away` (once PR 2 lands).
+
+When the export primitive isn't right for them — when a Gitcoin-specific format or a richer drift signal matters — they build a sidecar and contribute the pattern back. Generic patterns extracted up to parachute; specific dashboards stay in Gitcoin's app code. The Round-2 reply spells the boundary out.
+
+## Cross-references
+
+- **Format spec** — [`core/src/portable-md.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/core/src/portable-md.ts) (emitter + parser), [`core/src/portable-md.test.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/core/src/portable-md.test.ts) for behavior examples.
+- **CLI** — `parachute-vault export <dir>` in [`src/cli.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/cli.ts).
+- **Vault changelog** — `0.4.4-rc.9` and `0.4.4-rc.10` in [`CHANGELOG.md`](https://github.com/ParachuteComputer/parachute-vault/blob/main/CHANGELOG.md) cover PR 1 + the reviewer fold.
+- **Webhook triggers** — [vault README §Webhook triggers](https://github.com/ParachuteComputer/parachute-vault/blob/main/README.md#webhook-triggers).
+- **Tag data model** — [`patterns/tag-data-model.md`](../patterns/tag-data-model.md). What gets serialized into `.parachute/schemas/<tag>.yaml`.
+- **Multi-writer workspace guide** — [`guides/multi-writer-workspace.md`](../guides/multi-writer-workspace.md). The operator's-side view of how a team-shape vault accumulates the content the export then projects.
+- **Tracking issue** — [vault#308](https://github.com/ParachuteComputer/parachute-vault/issues/308) (umbrella), vault#317 (PR 1 reviewer fold).
+
+_Last updated: 2026-05-12 — current with vault 0.4.4-rc.10 (PR 1 of vault#308 on `main`, PR 2 in flight)._


### PR DESCRIPTION
## Summary

- Seeds a new top-level `cookbook/` directory alongside `patterns/` / `guides/` — short recipes (one outcome, one page, link out for depth).
- First entry: `cookbook/vault-portable-export.md` — concrete recipes for parachute-vault's lossless portable-markdown export (vault#308 PR 1, shipped in 0.4.4-rc.10).
- Authoritative reference for Gitcoin Brain's week-1 vault-as-primary + git-as-projection architecture (per `from_parachute_round_2.md` §2 Ask 1).

The entry covers:
- When to reach for the export primitive (git projection, DR snapshots, vault migration, offline editing, sharing as static files, SSG).
- CLI surface — `parachute-vault export <dir> [--vault <name>] [--since <iso>]` available today; `parachute-vault import [--blow-away]` flagged as PR 2 / coming in flight.
- Format shape — directory layout, fixed-key-order frontmatter, sidecar `.parachute/schemas/<tag>.yaml`, attachments shape.
- Lossless round-trip guarantees (IDs, typed links, schemas, indexed metadata, multi-line strings via double-quoted escapes from the vault#317 F1 fix, wikilinks in content, idempotent re-emit).
- Recipe — nightly git projection driven by a webhook trigger + cron, with a worked bash script and notes on the incremental/full cadence split.
- Recipe — cold-storage backup snapshot via `tar --zstd`.
- Edge cases / gotchas — path-traversal guard from vault#317 F3, `_unpathed/` directory, `exported_at` non-deterministic timestamp, schema drift on import, the parser's narrow YAML subset, 1M-note bulk-load ceiling.
- Worked example — Gitcoin Brain's projection shape, with the round-2 doc's boundary on what generalizes back to parachute.

Patterns repo is documentation-only, no published artifact, so the doc-only RC exemption applies (no version bump).

Cross-links to `patterns/tag-data-model.md`, `guides/multi-writer-workspace.md`, vault README §Webhook triggers, vault#308 + vault#317, and the source files in `core/src/portable-md.ts`.

## Test plan

- [ ] Render the rendered markdown on GitHub — verify code blocks, table-of-edge-cases, and cross-links resolve.
- [ ] Skim the `cookbook/README.md` section description against `patterns/` vs `guides/` framing — does the three-way distinction read cleanly?
- [ ] Confirm the CLI block matches `parachute-vault export` usage in `parachute-vault/src/cli.ts` (export-only on `main`; import flagged as PR 2).
- [ ] Confirm the format shape matches `core/src/portable-md.ts` (fixed key order, sidecar layout, `_unpathed/`, `__` tag-name encoding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)