### PR TITLE
docs(patterns): governance — add Rule 4 (PR cadence: bundle by session)

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,47 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-05-13 — governance.md gains Rule 4 (PR cadence)
+
+**Change:** [`governance.md`](../patterns/governance.md) extended from
+three rules to four. New **Rule 4 — PR cadence: bundle by session/theme,
+not by issue.** The unit of review is the PR; the unit of change is the
+commit. One PR per coherent session of work; multiple commits inside it;
+reviewer reads commit-by-commit. Bundle when changes share a theme or
+touch overlapping files; split only on genuinely independent surfaces,
+urgent-ship-needed-while-sibling-in-design, or ~800-1000 LOC ceiling.
+
+**Why now.** Overnight 2026-05-13 cron loop cost Aaron 6 merge-clicks
+across 4 repos when 3-4 would have sufficed — repeated PRs in the same
+repo on the same theme that could have stacked as commits in one bundle.
+Earlier shipping practice had drifted toward one-PR-per-issue as a
+mistaken corollary of the `feedback_serial_pr_flow` memory; that memory
+is about *parallelism* (don't open N PRs against shared files
+concurrently), not about *granularity*. Rule 4 names the distinction
+explicitly so future readers don't conflate them.
+
+Header bumped from "Three rules" to "Four rules." Existing rules
+(no-auto-merge / RC versioning / patterns check) are unchanged.
+
+**Affected:**
+
+- `parachute-patterns` — rule landed (this PR).
+- All Parachute repos with shipping tentacles (`parachute-hub`,
+  `parachute-vault`, `parachute-notes`, `parachute-scribe`,
+  `parachute-agent`, `parachute.computer`) — adopt the bundle-by-session
+  default on next session of work. No code-side change required; the
+  shift is in tentacle briefing + reviewer dispatch shape (one PR per
+  session theme, commits-as-narrative inside).
+- Tentacle briefs should reflect the new default: when a session has
+  multiple related issues to address, dispatch one bundle PR with the
+  set of issues named in body + closed-by lines, rather than one PR per
+  issue.
+
+**Status:** doc-only refresh. No code-side behavior change; the shift
+is in how team-lead briefs tentacles and dispatches PRs going forward.
+
+---
+
 ## 2026-05-12 — `guides/building-a-surface.md` lands (patterns#58)
 
 **Change:** new guide

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,7 +5,7 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
-## 2026-05-13 — governance.md gains Rule 4 (PR cadence)
+## 2026-05-15 — governance.md gains Rule 4 (PR cadence)
 
 **Change:** [`governance.md`](../patterns/governance.md) extended from
 three rules to four. New **Rule 4 — PR cadence: bundle by session/theme,
@@ -22,7 +22,8 @@ Earlier shipping practice had drifted toward one-PR-per-issue as a
 mistaken corollary of the `feedback_serial_pr_flow` memory; that memory
 is about *parallelism* (don't open N PRs against shared files
 concurrently), not about *granularity*. Rule 4 names the distinction
-explicitly so future readers don't conflate them.
+explicitly so future readers don't conflate them. Drafted 2026-05-13,
+landed 2026-05-15 — entry dated per landing.
 
 Header bumped from "Three rules" to "Four rules." Existing rules
 (no-auto-merge / RC versioning / patterns check) are unchanged.

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -110,10 +110,11 @@ Discipline inside a bundle:
   the PR for reviewers but collapses on `main`.
 
 **Why this is its own rule.** Earlier shipping practice drifted toward
-one-PR-per-issue because the [`feedback_serial_pr_flow`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/adoption/migration-notes.md)
-memory says "one PR at a time — serialize, don't batch." That memory is
-about *parallelism* (don't run N PRs against the same shared file
-concurrently), not about *granularity*. The two are independent axes:
+one-PR-per-issue because of a team-lead-private memory called
+`feedback_serial_pr_flow` that says "one PR at a time — serialize,
+don't batch." That memory is about *parallelism* (don't run N PRs
+against the same shared file concurrently), not about *granularity*.
+The two are independent axes:
 
 - **Serialize, don't parallelize.** Finish a PR through merge before
   opening the next, especially when they touch overlapping surfaces.
@@ -126,6 +127,8 @@ concurrently), not about *granularity*. The two are independent axes:
 Most session-shaped work satisfies both: one bundle PR (granularity),
 landed before the next session begins (serial).
 
+## Why these rules
+
 The first two months of post-launch shipping (April 2026 → ?) are the period
 of most rapid change. In that window:
 
@@ -134,10 +137,13 @@ of most rapid change. In that window:
 - Every untagged `@latest` publish is a chance for new users to install a
   half-validated artifact.
 - Every undocumented pattern becomes harder to retrofit later.
+- Every fragmented PR set is a click-cost that scales with the wrong axis
+  (issues touched), not the right one (sessions of work).
 
 The cost of these rules is small (one extra click for merge, one extra
-command for promotion, one extra paragraph in review). The benefit is
-durable alignment across modules and humans.
+command for promotion, one extra paragraph in review, one extra
+discipline on bundling). The benefit is durable alignment across modules
+and humans.
 
 ## Open questions
 

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -1,7 +1,7 @@
 # Governance: PR review, RC versioning, patterns alignment
 
 > One short doc covering how Parachute repos ship code post-launch (v0.x,
-> April 2026 onward). Three rules, one shared shape.
+> April 2026 onward). Four rules, one shared shape.
 
 ## Rule 1 — No auto-merge
 
@@ -82,7 +82,49 @@ The patterns repo's steward (the `patterns` tentacle) is an active
 participant in this loop — flagged when a new pattern is established,
 involved in updates that affect cross-cutting conventions.
 
-## Why these rules
+## Rule 4 — PR cadence: bundle by session/theme, not by issue
+
+**The unit of review is the PR; the unit of change is the commit.** One
+PR per coherent session of work; multiple commits inside it; reviewer
+reads commit-by-commit.
+
+**Bundle** when changes share a theme (e.g. "Capture flow polish"),
+touch overlapping files, or naturally read as one shipping unit. The
+default is to bundle.
+
+**Split** only when:
+
+- changes touch genuinely independent surfaces, or
+- one needs urgent ship while a sibling is in design, or
+- the bundle would push past ~800-1000 LOC and a reviewer would lose
+  the thread.
+
+Discipline inside a bundle:
+
+- PR title names the bundle theme, not any one issue.
+- PR body lists every issue closed (`Closes #123`, `Closes #124`).
+- Each commit message stays tight — one logical change per commit, so
+  the commit-by-commit read tracks the work narrative.
+- Squash-merge on land (same as today). Squash-commit message
+  summarizes the bundle; the commit-by-commit history is preserved on
+  the PR for reviewers but collapses on `main`.
+
+**Why this is its own rule.** Earlier shipping practice drifted toward
+one-PR-per-issue because the [`feedback_serial_pr_flow`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/adoption/migration-notes.md)
+memory says "one PR at a time — serialize, don't batch." That memory is
+about *parallelism* (don't run N PRs against the same shared file
+concurrently), not about *granularity*. The two are independent axes:
+
+- **Serialize, don't parallelize.** Finish a PR through merge before
+  opening the next, especially when they touch overlapping surfaces.
+  Still right.
+- **Bundle, don't fragment.** Within one PR, pull in every coherent
+  change from the session. Each repo-owner click costs the same
+  whether the PR carries one fix or four; spreading four PRs out costs
+  four clicks. The cadence catches up faster when bundled.
+
+Most session-shaped work satisfies both: one bundle PR (granularity),
+landed before the next session begins (serial).
 
 The first two months of post-launch shipping (April 2026 → ?) are the period
 of most rapid change. In that window:


### PR DESCRIPTION
## Summary

- Adds **Rule 4 — PR cadence: bundle by session/theme, not by issue** to `patterns/governance.md`. Captures the policy Aaron pushed back on 2026-05-13: PRs were getting opened one-per-issue, costing more merge-clicks than the unit-of-work required (6 clicks across 4 repos when 3-4 would have sufficed).
- Names the distinction earlier practice conflated: the `feedback_serial_pr_flow` memory entry (team-lead private) — "one PR at a time — serialize, don't batch" — is about **parallelism**, not **granularity**. The new rule is the granularity axis; serial-not-parallel is the concurrency axis. Both apply.
- Header bumped from "Three rules" to "Four rules." Existing rules untouched.
- Migration-notes entry recorded (drafted 2026-05-13, landed 2026-05-15).

## Patterns check

- **Touches:** `patterns/governance.md`, `adoption/migration-notes.md` (entry only).
- **Conforms:** yes. This *is* a governance rule update; the patterns#17/#58/etc. workflow continues unchanged.
- **Establishes / changes:** establishes a new rule (Rule 4). All shipping tentacles in the ecosystem adopt the bundle-by-session default on next session of work. No code-side change required.

## Test plan

- [ ] Read the new rule for clarity. Bundle-vs-split criteria should read as concrete, not aspirational.
- [ ] Verify the "Why this is its own rule" paragraph correctly distinguishes parallelism (serial-not-parallel) from granularity (bundle-not-fragment). These are real-and-separate axes; the rule should leave no ambiguity.
- [ ] Confirm migration-notes entry calls out the practical shift for tentacle briefs (one bundle PR per session vs one PR per issue).

Doc-only PR — no RC bump (patterns is docs-only; doc-only convention applies).