### PR TITLE
docs(patterns): post-0.4.5 refresh — Rule 5 + umbrellas + format-aware research + stale triage

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -50,6 +50,40 @@ forward.
 
 ---
 
+## 2026-05-17 — `module-discovery.md` umbrella lands
+
+**Change:** new umbrella pattern
+[`module-discovery.md`](../patterns/module-discovery.md). Single
+"if you're trying to X, read Y" reference that signposts across
+the 5 module-cluster pattern docs (`module-protocol`,
+`module-json-extensibility`, `module-ui-declaration`,
+`vault-mcp-discovery`, `mcp-transport`). Includes a lifecycle
+diagram (publish → install → discovery → MCP connect), a worked
+end-to-end example (vault declaring itself via `module.json`),
+and the two seams with the auth cluster (`hasAuth: true` +
+`urlForEntry.perConsumer`).
+
+**Why now.** Same shape as the auth-stack umbrella sibling — the
+module cluster had grown enough that a reader landing on one file
+struggled to discover the rest. Pattern-per-file mandate stays;
+umbrella solves discovery without merging.
+
+**Affected:**
+
+- `parachute-patterns` — umbrella landed (this PR). No change to
+  the five underlying single-concept docs.
+- Downstream repos — none. Pure documentation reorg; nothing to
+  adopt.
+- Module authors (first- and third-party) — when authoring a new
+  `module.json`, the worked-example section is the fastest read.
+  No required change to existing modules.
+
+**Status:** doc-only. The five underlying docs can gain a top-of-
+file "see also: [module-discovery.md](./module-discovery.md)" link
+on next touch.
+
+---
+
 ## 2026-05-17 — `auth-stack.md` umbrella lands
 
 **Change:** new umbrella pattern

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -50,6 +50,41 @@ forward.
 
 ---
 
+## 2026-05-17 — `auth-stack.md` umbrella lands
+
+**Change:** new umbrella pattern
+[`auth-stack.md`](../patterns/auth-stack.md). Single "if you're
+trying to X, read Y" reference that signposts across the 7
+auth-cluster pattern docs (`hub-as-issuer`, `oauth-scopes`,
+`oauth-dcr-approval`, `token-auth`, `tag-scoped-tokens`,
+`service-to-service-auth`, `well-known-discovery-rfc`) and the
+deeper [`research/auth-architecture-shape.md`](../research/auth-architecture-shape.md).
+Includes a stack-diagram, the two-token-paths table (OAuth bearer
+vs `pvt_*` PAT), and a "how the cluster composes" cheatsheet for
+PR reviewers.
+
+**Why now.** The auth cluster had grown to the point where a reader
+landing on one file struggled to discover the other six. Per
+CLAUDE.md ("one pattern per file"), the cluster can't be merged;
+the umbrella solves discovery without merging.
+
+**Affected:**
+
+- `parachute-patterns` — umbrella landed (this PR). No change to
+  the seven underlying single-concept docs.
+- Downstream repos — none. Pure documentation reorg; nothing to
+  adopt.
+- Reviewers — when a PR's `## Patterns check` per
+  [`governance.md`](../patterns/governance.md) Rule 3 names an
+  auth-cluster pattern, surfacing the umbrella alongside is a
+  reasonable courtesy. Not required.
+
+**Status:** doc-only. The seven underlying docs can gain a top-of-
+file "see also: [auth-stack.md](./auth-stack.md)" link on next
+touch, but no audit was performed in this PR to bulk-add them.
+
+---
+
 ## 2026-05-15 — governance.md gains Rule 4 (PR cadence)
 
 **Change:** [`governance.md`](../patterns/governance.md) extended from

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -50,6 +50,42 @@ forward.
 
 ---
 
+## 2026-05-17 — Research: format-aware notes design space
+
+**Change:** new research doc
+[`research/format-aware-notes.md`](../research/format-aware-notes.md)
+covering the format-aware-notes design space — vault#328 (extension
+column + sidecar metadata, shipped at vault 0.4.5) + notes#138
+(Phase 2 PWA rendering dispatch, deferred for v0.5) + the emerging
+pattern of surfaces consuming vault's `extension` field to dispatch
+renderers.
+
+Open questions captured: where format validation lives (Q1),
+third-party surface capability declaration (Q2), sidecar lifecycle
+across multi-writer edits (Q3), MDX bundle weight (Q4),
+extension-vs-attachment boundary (Q5).
+
+Research-tier (not patterns/) per
+[`CLAUDE.md`](../CLAUDE.md) — pattern docs are for resolved
+patterns. Promotion tracker filed at
+[parachute-patterns#65](https://github.com/ParachuteComputer/parachute-patterns/issues/65).
+
+**Affected:**
+
+- `parachute-patterns` — research doc landed (this PR). Tracker
+  issue #65 opened.
+- `parachute-vault` — context for the shipped vault#328 work; no
+  new ask. Future Q1 resolution may affect substrate-side
+  validation.
+- `parachute-notes` — context for notes#138 (deferred v0.5
+  follow-up); no new ask. Future Q2/Q4 resolution affects the
+  PWA's renderer-fleet declaration.
+
+**Status:** research-tier. Promote to a pattern doc when Q1 + Q2
+resolve across vault + notes implementation.
+
+---
+
 ## 2026-05-17 — `module-discovery.md` umbrella lands
 
 **Change:** new umbrella pattern

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -57,8 +57,9 @@ the six: four close as already-fixed-or-deferred (#27 fix already
 in `tag-scoped-tokens.md` §Mint authority line 80; #34 paragraph
 already past-tensed at `tag-data-model.md` line 94; #38 pseudocode
 already replaced by `expandTokenTagScope` + `noteWithinTagScope`
-shape with explicit string-form fallback; #25 deferred past v0.5
-pending the hub-as-sole-AS migration arc); one folds into this PR
+shape with explicit string-form fallback; #25 closed pending the
+hub-as-sole-AS migration arc — reopen when hub#212 resolves); one
+folds into this PR
 as a small inline addition (#35 — trailing-slash recommendation
 appended to `managementUrl` semantics in
 [`module-json-extensibility.md`](../patterns/module-json-extensibility.md));

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -50,6 +50,41 @@ forward.
 
 ---
 
+## 2026-05-17 — Stale-issue triage + module-json fragment-slash recommendation
+
+**Change:** triage pass on six 12-14-day-stale patterns issues. Of
+the six: four close as already-fixed-or-deferred (#27 fix already
+in `tag-scoped-tokens.md` §Mint authority line 80; #34 paragraph
+already past-tensed at `tag-data-model.md` line 94; #38 pseudocode
+already replaced by `expandTokenTagScope` + `noteWithinTagScope`
+shape with explicit string-form fallback; #25 deferred past v0.5
+pending the hub-as-sole-AS migration arc); one folds into this PR
+as a small inline addition (#35 — trailing-slash recommendation
+appended to `managementUrl` semantics in
+[`module-json-extensibility.md`](../patterns/module-json-extensibility.md));
+one stays open with priority comment (#37 — the R1-R15
+tag-scoped-tokens-survey triage is real + ready-to-execute but too
+big for this PR's scope; queued for next session).
+
+The trailing-slash recommendation captures the vault#252→#254→#255
+fragment-loss-through-301 lesson: SPA admin UIs receiving tokens
+via URL fragment should emit the canonical trailing-slash form
+from `managementUrl` to avoid the 301 dropping the fragment.
+
+**Affected:**
+
+- `parachute-patterns` — this PR. `module-json-extensibility.md`
+  gains the fragment-slash paragraph; five issues closed (#25,
+  #27, #34, #35, #38); one stays open (#37) with priority comment.
+- Module authors emitting `managementUrl` for fragment-token SPAs
+  — emit trailing-slash form. Today's only known affected module
+  (vault) is already conformant.
+
+**Status:** doc-only. Triage decisions logged per-issue via
+`gh issue close` comments; this entry summarizes.
+
+---
+
 ## 2026-05-17 — Research: format-aware notes design space
 
 **Change:** new research doc

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,51 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-05-17 — governance.md gains Rule 5 (CHANGELOG discipline)
+
+**Change:** [`governance.md`](../patterns/governance.md) extended from
+four rules to five. New **Rule 5 — CHANGELOG discipline: match the
+release log to the npm record.** The CHANGELOG carries two readers
+(consumers want "what's in `@latest`"; developers want per-bump
+archaeology) and both deserve space. Shape: stable section per
+published `@latest`, headlining the rc-chain narrative; per-rc-bump
+detail section *only when that rc actually publishes to `@rc`*. An
+rc bump that doesn't `npm publish --tag rc` gets no CHANGELOG entry —
+entries for versions that don't exist on npm are fiction.
+
+**Why now.** vault's `0.3.6-rc.X` chain accumulated ~28 ghost-version
+CHANGELOG entries (rc.1 plus rc.30–rc.39 written down; only four
+versions actually live on npm — `0.3.0-rc.1`, `0.3.0`, `0.3.1`,
+`0.3.3`). Rule 2 (RC versioning) covered the publish discipline;
+nothing covered the CHANGELOG discipline that has to ride alongside
+it. Rule 5 names it. Drafted + landed 2026-05-17.
+
+Header bumped from "Four rules" to "Five rules." Existing rules
+(no-auto-merge / RC versioning / patterns check / PR cadence) are
+unchanged.
+
+**Affected:**
+
+- `parachute-patterns` — rule landed (this PR).
+- All Parachute repos with shipping tentacles (`parachute-hub`,
+  `parachute-vault`, `parachute-notes`, `parachute-scribe`,
+  `parachute-agent`, `parachute.computer`) — on next CHANGELOG touch,
+  audit existing entries against `npm view <pkg> versions` and reconcile:
+  fold ghost rc entries into the stable narrative they belong to, or
+  drop them. No retroactive CHANGELOG rewrite is required for already-
+  shipped versions, but new entries from this date forward follow Rule
+  5.
+- Tentacle briefs: before writing a CHANGELOG section for an rc bump,
+  confirm the publisher will `npm publish --tag rc` for that bump (or
+  is the publish at-stable-promotion-only). If the rc won't publish,
+  no entry.
+
+**Status:** doc-only refresh. No code-side behavior change; the
+shift is in how tentacles + team-lead write CHANGELOG entries going
+forward.
+
+---
+
 ## 2026-05-15 — governance.md gains Rule 4 (PR cadence)
 
 **Change:** [`governance.md`](../patterns/governance.md) extended from

--- a/patterns/auth-stack.md
+++ b/patterns/auth-stack.md
@@ -1,0 +1,173 @@
+# Auth stack — umbrella
+
+> Signpost across the auth-cluster pattern docs. **If you're trying to
+> X, read Y.** This file links — it doesn't duplicate. The
+> authoritative shape for each piece lives in the linked doc; if those
+> diverge from this one, the linked doc wins.
+
+## The stack at a glance
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Operator browser / agent / external surface (notes, etc.)   │
+└──────────────────────────────┬──────────────────────────────┘
+                               │
+                               │  OAuth code-flow (RFC 6749 + PKCE)
+                               │  or paste `pvt_*` PAT
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│  hub (the OAuth issuer for the whole ecosystem)              │
+│  • DCR (RFC 7591) — every public reg lands `pending`         │
+│  • /oauth/authorize, /oauth/token, JWKS                      │
+│  • Mints JWT access (15min) + refresh (30d, rotated)         │
+└──────────────────────────────┬──────────────────────────────┘
+                               │
+                               │  Bearer JWT with scopes
+                               │  `vault:<name>:<verb>` etc.
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│  resource server (vault / agent / scribe — today only vault) │
+│  • Validates JWT vs hub JWKS, checks `aud` + `iss`           │
+│  • Per-token attributes: scoped_tags allowlist               │
+│  • Falls back to `pvt_*` (PAT) for direct-vault clients      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## If you're trying to…
+
+### Understand who issues tokens and why everything points at hub
+
+Read [`hub-as-issuer.md`](./hub-as-issuer.md). The single architectural
+fact this rests on: every auth-capable module advertises **the hub
+origin** as its `issuer`, regardless of where the module itself is
+hosted. Token `iss` claims, discovery documents, and the service
+catalog returned with the token all stem from one resolver so they
+can never disagree.
+
+### Pick a scope string for a new endpoint or capability
+
+Read [`oauth-scopes.md`](./oauth-scopes.md) — the scope vocabulary
+(`<service>[:<resource>]*:<action>`), the registered launch scopes
+(`vault:<name>:<verb>`, `scribe:*`, `agent:*`,
+`parachute:host:admin`), inheritance semantics (`admin ⊇ write ⊇
+read`), and the non-requestable-scope mechanism for operator-only
+capabilities.
+
+### Implement the consent dance for a new third-party client
+
+Read [`oauth-dcr-approval.md`](./oauth-dcr-approval.md). Dynamic
+Client Registration (RFC 7591) lands every public registration as
+`pending`. The four approval paths (CLI, browser inline button,
+same-origin auto-approve, hub admin UI). The state machine and the
+hub-side implementation pointers.
+
+### Mint a token a user pastes into a script or CLI
+
+Read [`token-auth.md`](./token-auth.md). The `pvt_*` PAT path —
+prefix, sha256-only storage, scoping, one-time reveal. This is the
+**user-facing** counterpart to OAuth bearers; same scope vocabulary,
+different lifetime + storage model. Live alongside hub-issued JWTs;
+both validate at the same vault entrypoint.
+
+### Narrow a token to a specific slice of a vault
+
+Read [`tag-scoped-tokens.md`](./tag-scoped-tokens.md). Tokens can
+declare a `scoped_tags` allowlist at mint time. The OAuth scope
+claim (`vault:<name>:<verb>`) stays clean; tag scoping is a
+**per-token vault-internal attribute**, not a scope-string
+extension. Hierarchy expansion via `tags.parent_names`,
+string-form fallback for orphan sub-tags, fail-closed delete-tag
+guards.
+
+### Wire one service to call another
+
+Read [`service-to-service-auth.md`](./service-to-service-auth.md).
+The validator-seam pattern: each callee runs incoming tokens
+through one `validateToken(token) → {valid, scopes}` function.
+Today's shared-secret implementation (CLI mints + writes to both
+ends) is the body of that function; the future hub-issued-JWT
+implementation is a body-swap. Callers and callees don't change.
+
+### Serve OAuth metadata for an issuer with a path component
+
+Read [`well-known-discovery-rfc.md`](./well-known-discovery-rfc.md).
+RFC 8414 §3.1 mandates path-insertion (`<origin>/.well-known/<type>/<path>`),
+not path-append. Vault serves both shapes; path-insertion is
+canonical. Strict clients (Claude Code's MCP SDK, RFC 8414-conformant
+libraries) **only** probe the canonical form.
+
+### Get industry-survey-level depth on the whole auth surface
+
+Read [`research/auth-architecture-shape.md`](../research/auth-architecture-shape.md).
+The 2026-05-09 working note that traces all five concurrent token
+shapes (`parachute_hub_session` cookie, hub-issued OAuth access JWT,
+hub-issued refresh JWT, `operator.token`, `pvt_*` PAT, plus the
+legacy `SCRIBE_AUTH_TOKEN` shared-secret on s2s), surveys how
+mature systems (Auth0, Clerk, Supabase, Cloudflare Access) shape
+the equivalent surface, and records the decision direction (hub as
+sole AS; vault/agent/scribe as RS) plus migration tracker
+[hub#212](https://github.com/ParachuteComputer/parachute-hub/issues/212).
+Research-tier — pattern docs are for resolved patterns; this is
+the longer arc still being worked through.
+
+## The two token paths
+
+Two paths reach the same resource server, with the same scope
+vocabulary:
+
+| Path | Issuer | Token shape | Storage | Audience | When to use |
+| --- | --- | --- | --- | --- | --- |
+| **OAuth bearer** | hub | JWT signed by hub JWKS | not stored; validated stateless | bound (`aud=vault.<name>` etc.) | agent-to-service, third-party SPA, programmatic API consumer |
+| **`pvt_*` PAT** | vault (or other RS) | random opaque token, `pvt_` prefix | sha256 hash in RS DB | implicit (per-row) | human pastes into CLI/script; standalone-vault deployments with no hub |
+
+The PAT path is **legacy and direct**: hub doesn't see it, no JWT
+involved, vault validates against its own `tokens` table. The OAuth
+path is **the canonical future**: hub validates the consent dance,
+mints the JWT, vault validates the JWT signature + claims. Both share
+the scope string and the same scope-inheritance rules; they diverge on
+storage, lifetime, and revocation.
+
+The migration arc is *not* "kill PATs." PATs solve a real ergonomic
+problem (pasted secrets in scripts, standalone-vault no-hub
+deployments). The arc is "make sure the PAT path doesn't accumulate
+its own DCR-substitute layer cake" — keep the OAuth path as the rich
+one, keep PATs as the deliberate-flat-secret escape hatch.
+
+## How the cluster composes
+
+Every PR that touches auth typically touches more than one of these
+files because the underlying concepts compose:
+
+- A new resource server adopts `hub-as-issuer` + `oauth-scopes` +
+  `well-known-discovery-rfc` together. None of those make sense
+  alone.
+- A new capability registers a scope (`oauth-scopes`), might add a
+  per-token attribute (`tag-scoped-tokens` shape), and gets enforced
+  at request time on the RS.
+- A new client either goes through DCR (`oauth-dcr-approval`) and
+  consents (hub-side) or asks the operator to paste a PAT
+  (`token-auth`).
+- A new inter-service edge either inherits the validator seam
+  (`service-to-service-auth`) on a shared-secret basis or upgrades
+  to hub-issued JWTs (Phase B2 cutover).
+
+Each PR's `## Patterns check` per [`governance.md`](./governance.md)
+Rule 3 should name which auth-cluster docs the change touches.
+
+## Cross-links
+
+- [`hub-as-issuer.md`](./hub-as-issuer.md) — the issuer architecture
+- [`oauth-scopes.md`](./oauth-scopes.md) — the scope vocabulary
+- [`oauth-dcr-approval.md`](./oauth-dcr-approval.md) — DCR + consent
+- [`token-auth.md`](./token-auth.md) — `pvt_*` PAT path
+- [`tag-scoped-tokens.md`](./tag-scoped-tokens.md) — sub-vault scope
+- [`service-to-service-auth.md`](./service-to-service-auth.md) —
+  inter-service edges
+- [`well-known-discovery-rfc.md`](./well-known-discovery-rfc.md) —
+  metadata URLs
+- [`research/auth-architecture-shape.md`](../research/auth-architecture-shape.md)
+  — full survey + decision direction
+- [`guides/multi-writer-workspace.md`](../guides/multi-writer-workspace.md)
+  §2 — operator-facing scoped-token worked example
+- [`governance.md`](./governance.md) Rule 3 — patterns-check
+  discipline

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -1,7 +1,7 @@
 # Governance: PR review, RC versioning, patterns alignment
 
 > One short doc covering how Parachute repos ship code post-launch (v0.x,
-> April 2026 onward). Four rules, one shared shape.
+> April 2026 onward). Five rules, one shared shape.
 
 ## Rule 1 — No auto-merge
 
@@ -127,6 +127,38 @@ The two are independent axes:
 Most session-shaped work satisfies both: one bundle PR (granularity),
 landed before the next session begins (serial).
 
+## Rule 5 — CHANGELOG discipline: match the release log to the npm record
+
+The CHANGELOG serves two readers: consumers want "what's in this
+release" (canonical, aligned 1:1 with npm `@latest`); developers want
+per-bump archaeology. Both deserve space.
+
+The shape:
+
+- **Stable section per published `@latest` version.** Headline
+  narrative rolling up the rc chain. Migration risks + breaking
+  changes in the TL;DR. This is what upgrade docs (e.g.
+  `UPGRADING.md`) and external readers parse.
+- **RC section per rc-bump-that-actually-publishes-to-`@rc`.** Per-PR
+  development log. Stays as historical detail; not retroactively
+  edited.
+
+**An rc bump that doesn't `npm publish --tag rc` gets NO CHANGELOG
+section.** This is the discipline gap that produced ~28 ghost-version
+entries in the `vault@0.3.6-rc.X` chain (rc.1 then rc.30–rc.39 in
+CHANGELOG; only `0.3.0-rc.1`, `0.3.0`, `0.3.1`, `0.3.3` on npm).
+Don't write CHANGELOG entries for versions that don't exist in the
+world.
+
+At stable promotion: the rc-chain entries stay below the new stable
+section. The stable section's narrative is the headline; the rc
+entries are the citations.
+
+**Why this is its own rule.** Rule 2 (RC versioning) covers the
+publish discipline; this rule covers the CHANGELOG discipline that
+has to ride alongside it. Skipping either produces drift: publish
+without entry = silent; entry without publish = fiction.
+
 ## Why these rules
 
 The first two months of post-launch shipping (April 2026 → ?) are the period
@@ -139,11 +171,14 @@ of most rapid change. In that window:
 - Every undocumented pattern becomes harder to retrofit later.
 - Every fragmented PR set is a click-cost that scales with the wrong axis
   (issues touched), not the right one (sessions of work).
+- Every CHANGELOG entry for a version that never reached npm becomes
+  a footgun for the consumer reader who's trying to decide what to
+  install.
 
 The cost of these rules is small (one extra click for merge, one extra
 command for promotion, one extra paragraph in review, one extra
-discipline on bundling). The benefit is durable alignment across modules
-and humans.
+discipline on bundling, one extra check before writing a CHANGELOG
+section). The benefit is durable alignment across modules and humans.
 
 ## Open questions
 

--- a/patterns/module-discovery.md
+++ b/patterns/module-discovery.md
@@ -85,7 +85,21 @@ same one-source-two-surfaces pattern.
 
 ## Worked example: vault declares itself
 
-The canonical end-to-end:
+> **Note.** This example shows the full-complement *target* shape — the
+> fields a future vault would emit once `hasAuth`, `init`, and
+> `urlForEntry.perConsumer` flow through `module.json` end-to-end
+> (today some of those declarations still live in hub's transitional
+> `FIRST_PARTY_FALLBACKS` per
+> [`module-json-extensibility.md`](./module-json-extensibility.md)).
+> Vault's currently-shipped
+> [`.parachute/module.json`](https://github.com/ParachuteComputer/parachute-vault/blob/main/.parachute/module.json)
+> is simpler: `name`, `manifestName`, `displayName`, `tagline`,
+> `kind`, `port`, `paths`, `health`, `managementUrl`, `startCmd`, and
+> a `scopes` object with a `defines` array. For the canonical field
+> catalog see
+> [`module-json-extensibility.md`](./module-json-extensibility.md).
+
+The canonical end-to-end (target shape):
 
 **1. `parachute-vault/.parachute/module.json`** declares the module:
 
@@ -107,16 +121,17 @@ The canonical end-to-end:
       "claude.ai": { "appendPath": "/mcp" }
     }
   },
-  "managementUrl": "/admin",
-  "scopes": ["vault:<name>:read", "vault:<name>:write", "vault:<name>:admin"]
+  "managementUrl": "/admin/",
+  "scopes": { "defines": ["vault:<name>:read", "vault:<name>:write", "vault:<name>:admin"] }
 }
 ```
 
 The field catalog is in
 [`module-json-extensibility.md`](./module-json-extensibility.md);
 `managementUrl` is the relative-resolves-against-module shape per
-the same doc; `init` carries a safety constraint that `command[0]`
-must equal a bin from the installed npm package.
+the same doc (trailing slash deliberate per its fragment-token-SPA
+section); `init` carries a safety constraint that `command[0]` must
+equal a bin from the installed npm package.
 
 **2. `parachute install @openparachute/vault`** populates
 `~/.parachute/services.json` with the entry, runs `init.command`,
@@ -143,7 +158,7 @@ first real tool call.
 
 **5. An OAuth-capable client** discovers the AS via
 `/.well-known/oauth-authorization-server/vault/<name>` per
-[`well-known-discovery-rfc.md`](../patterns/well-known-discovery-rfc.md),
+[`well-known-discovery-rfc.md`](./well-known-discovery-rfc.md),
 sees the hub origin in `issuer` per
 [`hub-as-issuer.md`](./hub-as-issuer.md), and runs the full DCR +
 consent dance with the auth cluster's

--- a/patterns/module-discovery.md
+++ b/patterns/module-discovery.md
@@ -1,0 +1,184 @@
+# Module discovery — umbrella
+
+> Signpost across the module-cluster pattern docs. **If you're trying
+> to X, read Y.** This file links — it doesn't duplicate. The
+> authoritative shape for each piece lives in the linked doc; if those
+> diverge from this one, the linked doc wins.
+
+## The lifecycle at a glance
+
+```
+                  Author publishes npm package with
+                  .parachute/module.json shipped inside
+                                  │
+                                  ▼
+   ┌──────────────────────────────────────────────────────────┐
+   │  `parachute install <pkg>`                                │
+   │  • CLI reads module.json                                   │
+   │  • Writes ~/.parachute/services.json entry                 │
+   │  • Runs `init.command` (one-shot, safety-checked)          │
+   └──────────────────────────────┬───────────────────────────┘
+                                  │
+                                  ▼
+   ┌──────────────────────────────────────────────────────────┐
+   │  Hub serves /.well-known/parachute.json                   │
+   │  • Aggregates services.json + each module's well-known   │
+   │  • Renders discovery tiles per module's `uiUrl`           │
+   │  • Renders "Manage" links per module's `managementUrl`    │
+   └──────────────────────────────┬───────────────────────────┘
+                                  │
+                                  ▼
+   ┌──────────────────────────────────────────────────────────┐
+   │  Clients discover module capability                       │
+   │  • MCP clients hit <module-url>/mcp (Streamable HTTP)     │
+   │  • Vault MCP returns the projection brief at initialize   │
+   │  • OAuth-aware clients discover AS via well-known         │
+   └──────────────────────────────────────────────────────────┘
+```
+
+## If you're trying to…
+
+### Understand the three-layer module contract (services.json, well-known, module.json)
+
+Read [`module-protocol.md`](./module-protocol.md). The primary
+reference: storage layer (`~/.parachute/services.json`), discovery
+layer (`/.well-known/parachute.json`), declaration layer
+(`.parachute/module.json` shipped in the npm package). Every other
+file in this cluster is a refinement of one slot in that protocol.
+
+### Declare a new module (third-party or first-party)
+
+Read [`module-json-extensibility.md`](./module-json-extensibility.md).
+The full `module.json` field catalog — `name`, `manifestName`,
+`displayName`, `tagline`, `kind`, `port`, `paths`, `health`,
+`startCmd`, `scopes`, `dependencies`, plus the extensibility fields
+(`hasAuth`, `init`, `urlForEntry`, `managementUrl`, `uiUrl`). No
+`@openparachute/` scope or `parachute-*` prefix required; the
+contract is what makes a module a module.
+
+### Render your module in the hub's discovery section
+
+Read [`module-ui-declaration.md`](./module-ui-declaration.md).
+Declare `uiUrl` in `module.json` and hub renders one tile per
+service that declares it. Path form resolves against hub's origin
+(distinct from `managementUrl`'s relative form, which resolves
+against the module's own well-known origin). Absent = no tile.
+
+### Expose MCP tools from your module
+
+Read [`mcp-transport.md`](./mcp-transport.md). Streamable HTTP at
+`<base>/mcp` + `Authorization: Bearer <token>`. Both OAuth bearers
+and `pvt_*` PATs validate the same way. Discovery via RFC 8414
+metadata — links into the auth cluster
+([`well-known-discovery-rfc.md`](./well-known-discovery-rfc.md),
+[`hub-as-issuer.md`](./hub-as-issuer.md)).
+
+### Surface a rich projection of your module's shape at MCP `initialize`
+
+Read [`vault-mcp-discovery.md`](./vault-mcp-discovery.md). Vault's
+reference implementation: one source (`buildVaultProjection`), two
+surfaces (markdown brief in `initialize` response + JSON via the
+`vault-info` tool), scope-filtered symmetrically. Tags +
+inheritance + effective_fields + indexed_fields + query_hints +
+optional stats. Other modules with non-trivial shape can adopt the
+same one-source-two-surfaces pattern.
+
+## Worked example: vault declares itself
+
+The canonical end-to-end:
+
+**1. `parachute-vault/.parachute/module.json`** declares the module:
+
+```json
+{
+  "name": "parachute-vault",
+  "manifestName": "@openparachute/vault",
+  "displayName": "Vault",
+  "tagline": "Personal knowledge graph",
+  "kind": "api",
+  "port": 1940,
+  "paths": ["/vault/:name"],
+  "health": "/vault/:name/health",
+  "startCmd": ["parachute-vault", "serve"],
+  "hasAuth": true,
+  "init": { "command": ["parachute-vault", "init"] },
+  "urlForEntry": {
+    "perConsumer": {
+      "claude.ai": { "appendPath": "/mcp" }
+    }
+  },
+  "managementUrl": "/admin",
+  "scopes": ["vault:<name>:read", "vault:<name>:write", "vault:<name>:admin"]
+}
+```
+
+The field catalog is in
+[`module-json-extensibility.md`](./module-json-extensibility.md);
+`managementUrl` is the relative-resolves-against-module shape per
+the same doc; `init` carries a safety constraint that `command[0]`
+must equal a bin from the installed npm package.
+
+**2. `parachute install @openparachute/vault`** populates
+`~/.parachute/services.json` with the entry, runs `init.command`,
+and starts the service.
+[`module-protocol.md`](./module-protocol.md) §1-2.
+
+**3. Hub serves the well-known aggregate** at
+`/.well-known/parachute.json`. Each vault entry includes its
+`uiUrl` (intentionally omitted in vault's case — vault content is
+browsed via Notes, see
+[`module-ui-declaration.md`](./module-ui-declaration.md)'s adoption
+note) and `managementUrl` so hub's admin page renders a "Manage
+Vault `<name>`" link.
+[`module-protocol.md`](./module-protocol.md) §2.
+
+**4. An MCP client connects** to `<vault-url>/mcp` over Streamable
+HTTP. The `initialize` response includes a markdown
+`serverInstructions` payload — the vault projection brief — built
+from `buildVaultProjection`. The client gets the vault's shape
+(tags, schemas, indexed fields, query hints) before issuing its
+first real tool call.
+[`mcp-transport.md`](./mcp-transport.md) +
+[`vault-mcp-discovery.md`](./vault-mcp-discovery.md).
+
+**5. An OAuth-capable client** discovers the AS via
+`/.well-known/oauth-authorization-server/vault/<name>` per
+[`well-known-discovery-rfc.md`](../patterns/well-known-discovery-rfc.md),
+sees the hub origin in `issuer` per
+[`hub-as-issuer.md`](./hub-as-issuer.md), and runs the full DCR +
+consent dance with the auth cluster's
+[`auth-stack.md`](./auth-stack.md) shapes.
+
+## How the cluster composes with the auth cluster
+
+The module-discovery cluster and the auth cluster overlap at two
+seams:
+
+- **`hasAuth: true`** in `module.json` signals the module is an
+  OAuth resource server. Hub keys its publicExposure derivation off
+  this; the resource server itself adopts
+  [`auth-stack.md`](./auth-stack.md) wholesale.
+- **`urlForEntry.perConsumer`** declarations describe per-consumer
+  URL adjustments for clients that read the well-known aggregate.
+  Today's only case: claude.ai appends `/mcp` to vault entries.
+
+For everything else, the two clusters are orthogonal: module
+discovery answers "where does this thing live and what does it
+expose"; auth answers "who's allowed to talk to it."
+
+## Cross-links
+
+- [`module-protocol.md`](./module-protocol.md) — three-layer
+  protocol (storage / discovery / declaration)
+- [`module-json-extensibility.md`](./module-json-extensibility.md)
+  — full `module.json` field catalog
+- [`module-ui-declaration.md`](./module-ui-declaration.md) — `uiUrl`
+  + hub discovery tiles
+- [`mcp-transport.md`](./mcp-transport.md) — Streamable HTTP at
+  `<base>/mcp`
+- [`vault-mcp-discovery.md`](./vault-mcp-discovery.md) — vault's
+  one-source-two-surfaces projection pattern
+- [`auth-stack.md`](./auth-stack.md) — the auth cluster, hooked in
+  at `hasAuth: true`
+- [`governance.md`](./governance.md) Rule 3 — patterns-check
+  discipline

--- a/patterns/module-json-extensibility.md
+++ b/patterns/module-json-extensibility.md
@@ -277,6 +277,20 @@ for vault's SPA). The hub doesn't proxy module internals or sniff auth
 headers; it links out and the module's own SPA boots up under its
 origin and runs its own OAuth dance against the hub if it needs one.
 
+**Trailing slash for fragment-token SPAs.** For SPA-style admin UIs
+that receive auth tokens via URL fragment (e.g., `#token=…`), the
+`managementUrl` SHOULD end with `/`. Browsers drop URL fragments
+through 301 redirects (RFC 7231 SHOULD-preserves, but
+Chrome/Firefox/Safari behave inconsistently — most drop). If the
+module's server canonicalizes bare → trailing-slash form via 301,
+the fragment is silently lost and the SPA receives no token. By
+emitting the canonical trailing-slash form directly from
+`managementUrl`, the redirect never fires and the token survives.
+Real-world example: vault#252 added a 301 from `/vault/<name>/admin`
+→ `/vault/<name>/admin/`; vault#255 fixed token loss by changing
+`managementUrl: "/admin"` → `"/admin/"`. Modules with non-SPA
+admin UIs, or SPAs that don't use fragment-tokens, don't need this.
+
 **Backwards-compatible.** Absent field = no link rendered. Modules that
 manage purely via CLI, or have no admin surface at all, simply omit the
 field. Same rule as `hasAuth` / `init` / `urlForEntry`.

--- a/research/format-aware-notes.md
+++ b/research/format-aware-notes.md
@@ -1,0 +1,220 @@
+# Format-aware notes — research
+
+**Status:** research-tier. Real open design questions remain; not yet
+a pattern.
+**Date:** 2026-05-17
+**Companion to:** `patterns/module-discovery.md` (umbrella),
+`research/parachute-surface-direction.md` (surfaces atop vault),
+`guides/building-a-surface.md` (builder companion)
+**Tracker:** [parachute-patterns#65](https://github.com/ParachuteComputer/parachute-patterns/issues/65)
+
+## Why this is research and not yet a pattern
+
+Vault 0.4.5 introduced an `extension` column + sidecar metadata for
+non-markdown notes
+([vault#328](https://github.com/ParachuteComputer/parachute-vault/issues/328);
+shipped at vault 0.4.5). The PWA-side counterpart — format-aware
+rendering dispatch in
+[notes#138](https://github.com/ParachuteComputer/parachute-notes/issues/138)
+— is deferred for v0.5 but already partially scoped.
+
+Two surfaces are already implementing pieces of an emerging pattern:
+**surfaces consume vault's `extension` field to dispatch renderers.**
+But the pattern isn't yet resolved across enough open questions to
+write it down as a pattern doc per `CLAUDE.md`'s "document what's
+real" rule. This file collects the context so the eventual pattern
+doc has a starting point.
+
+## What's shipped (vault side, 0.4.5)
+
+Three things are real today:
+
+1. **`extension` column** on `notes` (TEXT NOT NULL DEFAULT 'md').
+   Schema migration v17 → v18. Every existing note auto-defaults to
+   `'md'`; no data migration needed beyond ALTER TABLE.
+
+2. **Sidecar metadata files** at `.parachute/notes-meta/<note-id>.yaml`
+   for extensions that can't carry inline frontmatter. The predicate
+   `supportsInlineFrontmatter(extension)` splits the world:
+   - frontmatter-compatible: `.md`, `.mdx`, future `.org`
+   - sidecar-required: `.csv`, `.yaml`, `.json`, `.txt`, etc.
+
+   Sidecar contents are identical in shape to inline frontmatter,
+   lifted into a separate file. The note's content file holds raw
+   bytes of the declared format.
+
+3. **API surface carries `extension`** on create/update/query. Notes
+   created without an explicit extension default to `md`; explicit
+   value pinned at create time and editable via update.
+
+What this isn't yet: a substrate-level commitment to *validating*
+the content matches the declared extension. Vault stores bytes;
+extension is a declared label, not an enforced constraint.
+
+## What's emerging (notes side, vault clients side)
+
+Surfaces consume `extension` to pick a renderer. Notes#138 sketches
+the dispatch as:
+
+```ts
+function pickRenderer(note: Note): Renderer {
+  switch (note.extension) {
+    case "md":   return MarkdownView;
+    case "mdx":  return MdxView;       // bundle-weight concern; v3 axis
+    case "csv":  return CsvTableView;  // PapaParse, read-only first pass
+    case "yaml":
+    case "json": return CodeMirrorView; // mode-pick on extension
+    case "txt":  return PlaintextView;
+    default:     return PlaintextView;
+  }
+}
+```
+
+The dispatcher lives in the surface, not in vault. Vault's job is to
+say "this is a CSV"; the surface's job is to render it as a CSV.
+
+If multiple surfaces (Notes, eventual third-party surfaces, agent-side
+preview cards) all consume the same `extension` field but each dispatches
+to its own renderer fleet, the pattern is: **vault declares; surface
+dispatches**. The two sides agree on the vocabulary; nothing else
+constrains them.
+
+## Open questions
+
+These are the questions the future pattern doc has to answer. They're
+open today.
+
+### Q1 — Where does format validation live?
+
+When a note's content doesn't match its declared extension, who
+catches it?
+
+- **Vault validates at write time.** Pro: bytes-in-the-DB are
+  always coherent with the label. Con: vault gains a per-extension
+  parser dependency (CSV, YAML, JSON parsers in the substrate);
+  the substrate becomes opinionated about format rules.
+- **Surface validates at read time.** Pro: vault stays
+  parser-agnostic; new extensions can be added without substrate
+  changes. Con: malformed content sits in vault until something
+  tries to render it; corruption is detected late.
+- **Both.** Vault does a fast-path syntactic check at write (parse
+  ok / not ok, no schema awareness); surface does a richer
+  semantic check at read (required columns, type coercion). Pro:
+  layered defense. Con: same parser dependency lives in two
+  places; the "which check is authoritative" boundary is fuzzy.
+
+Aaron flagged in conversation 2026-05-16 that he leans toward
+**surface validates** for the v0.5 cut, then revisit if real
+corruption shows up. No commitment yet.
+
+### Q2 — How do third-party surfaces declare renderer capabilities?
+
+A first-party surface (Notes) can hardcode its switch statement.
+A third-party surface (eventual community-built surface on top of
+vault) needs to advertise which extensions it can render so
+clients picking a surface know what they're getting.
+
+Candidate shapes:
+
+- **`module.json` field** — `surfaces.extensions: ["md", "csv",
+  "yaml"]`. Pros: lands cleanly in the module-discovery cluster
+  (per [`module-discovery.md`](../patterns/module-discovery.md)).
+  Cons: static declaration drifts from real renderer fleet over
+  time.
+- **Runtime endpoint** — `<surface>/capabilities/extensions`
+  returns the live list. Pros: always-fresh. Cons: one more
+  endpoint to spec; one more hop to render the discovery UI.
+- **No declaration; fall through to plaintext** for unknown
+  extensions. Pros: zero coordination. Cons: poor discoverability;
+  user picks a surface without knowing if their CSVs will render.
+
+The umbrella doc for module discovery already exists; this is a
+candidate addition once Q1 + Q2 land together.
+
+### Q3 — Sidecar lifecycle across multi-writer edits
+
+A CSV note has a sidecar at `.parachute/notes-meta/<id>.yaml`. Two
+writers each edit the CSV (the content file) without touching the
+sidecar. What's the OC token shape?
+
+- **Single `updated_at`** covering both content + sidecar. Simplest
+  if both files always write together. Sidecar-only edits (e.g.
+  tag change) still bump the content's `updated_at`.
+- **Separate `updated_at`** per axis (content vs metadata). Two
+  conflict-detection clocks; richer concurrency but more surface
+  area.
+
+Today's
+[`optimistic-concurrency.md`](../patterns/optimistic-concurrency.md)
+pattern only addresses single-resource writes. Multi-file notes
+need either an "atomic pair" semantics or a separate clock per
+file. Vault#328 ships with single-clock; whether that's
+enough-for-v0.5 or needs an upgrade-path doc is open.
+
+### Q4 — MDX bundle weight
+
+MDX requires a JSX runtime + compiler bundle. The PWA's current
+bundle is ~600KB gz; adding MDX support pushes that past 1MB. The
+trade is rich-document features vs initial-load time.
+
+Three paths:
+
+- **Bundle MDX in the PWA.** Worst case for first paint; best UX
+  for MDX users.
+- **Render-on-server.** Push MDX through a hub-side or vault-side
+  compiler endpoint, return HTML. Pros: keeps the PWA bundle
+  small. Cons: introduces a server-side rendering surface; auth
+  story for the compile endpoint.
+- **Defer MDX support.** Render MDX as plaintext for v0.5; revisit
+  when there's demand. Aaron's 2026-05-16 call.
+
+Q4 is closer to a product question than an architecture question;
+the pattern doc can capture the *trade* without picking a winner.
+
+### Q5 — What does "extension" mean for binary attachments?
+
+Vault distinguishes notes (text with extension) from attachments
+(blobs under `.parachute/attachments/<id>/<filename>`). An image,
+PDF, or audio file is an attachment, not a note with `extension:
+png`. The line is currently drawn at "can it be text?"
+
+If a third-party surface wants to render images inline as
+note-like cards, the question becomes: are images notes with
+binary content, or are they always attachments? Current answer:
+attachments. The pattern doc should make this explicit so the
+boundary doesn't drift.
+
+## Cross-links
+
+- [vault#328](https://github.com/ParachuteComputer/parachute-vault/issues/328)
+  — vault-side: extension column + sidecar metadata
+- [notes#138](https://github.com/ParachuteComputer/parachute-notes/issues/138)
+  — notes-side: Phase 2 PWA rendering dispatch
+- [`patterns/module-discovery.md`](../patterns/module-discovery.md)
+  — module cluster umbrella (Q2 lands here when resolved)
+- [`patterns/optimistic-concurrency.md`](../patterns/optimistic-concurrency.md)
+  — single-clock OC pattern (Q3 may extend)
+- [`research/parachute-surface-direction.md`](./parachute-surface-direction.md)
+  — surfaces as a category (where third-party renderer-fleet
+  discovery lives)
+- [`guides/building-a-surface.md`](../guides/building-a-surface.md)
+  — builder companion (will gain a "format-aware rendering" section
+  once Q1+Q2 resolve)
+
+## When this becomes a pattern doc
+
+When Q1 + Q2 are resolved across vault + notes implementation. The
+pattern would name:
+
+- the substrate contract (vault declares `extension`, doesn't
+  validate beyond syntactic-parse-ok),
+- the surface contract (consume `extension`, dispatch renderer,
+  validate semantically per surface's rules),
+- the multi-writer-edit model for sidecars (Q3),
+- the third-party-surface capability-declaration mechanism (Q2),
+- the binary-attachments boundary (Q5).
+
+Promote at that point per [`CLAUDE.md`](../CLAUDE.md) — remove the
+research-tier prefix, move to `patterns/format-aware-notes.md`, file
+adoption-notes entry, drop a tracking link from the
+module-discovery umbrella's cross-links section.


### PR DESCRIPTION
## Summary

Post-0.4.5 patterns refresh bundling four concerns:

1. **Rule 5 — CHANGELOG discipline** in `governance.md`. The release log has to match the npm record; rc bumps that don't `npm publish --tag rc` get no CHANGELOG entry. Motivating incident: vault@0.3.6-rc.X accumulated ~28 ghost-version entries.
2. **`auth-stack.md` umbrella** signposting the 7-file auth cluster (hub-as-issuer, oauth-scopes, oauth-dcr-approval, token-auth, tag-scoped-tokens, service-to-service-auth, well-known-discovery-rfc + research/auth-architecture-shape). Includes stack diagram, two-token-paths table, cluster-composition cheatsheet.
3. **`module-discovery.md` umbrella** signposting the 5-file module cluster (module-protocol, module-json-extensibility, module-ui-declaration, vault-mcp-discovery, mcp-transport). Includes lifecycle diagram + worked end-to-end example (vault declaring itself).
4. **`research/format-aware-notes.md`** — new research-tier doc covering the vault#328 + notes#138 design space. Five open questions captured; promotion tracker filed at patterns#65.
5. **Stale-issue triage** — six 12-14-day-stale issues triaged. Four close as already-fixed (#27, #34, #38) or deferred (#25); one folds into this PR as a small inline addition (#35 — trailing-slash recommendation appended to managementUrl semantics); one stays open with priority comment (#37 — R1-R15 tag-scoped-tokens-survey triage, queued next session).

Five commits, reviewer reads commit-by-commit:

- `f7370e0` — Rule 5 + bump "Four rules" → "Five rules" + adoption note
- `f3746e0` — auth-stack umbrella
- `92003d9` — module-discovery umbrella
- `b08bced` — format-aware-notes research + tracker issue (patterns#65)
- `a534f83` — stale-issue triage + module-json fragment-slash recommendation

## Patterns check

This PR is patterns-only, so the Rule 3 question collapses to: *does it conform to its own meta-rules?* Audit:

- **One pattern per file** (`CLAUDE.md`) — Both umbrellas are explicitly *umbrellas* (signposts, not new patterns); they link rather than duplicate. The seven auth-cluster and five module-cluster files each retain their independent scope. ✅
- **Document what's real** — `research/format-aware-notes.md` is research-tier because Q1–Q5 are unresolved; it does not pretend to be a pattern. ✅
- **Migration notes touched** — Adoption-notes entries added for all four substantive landings (governance Rule 5, auth-stack, module-discovery, format-aware-notes). ✅
- **Governance Rule 4 (bundle by session/theme)** — Single PR, 5 commits, each one logical change. Theme: post-0.4.5 patterns refresh. ✅
- **Governance Rule 5 (just added)** — Doc-only, no version bump, no CHANGELOG entry — this repo doesn't publish to npm. N/A. ✅

## Issues closed

- Closes #25 (deferred past v0.5)
- Closes #27 (already-fixed)
- Closes #34 (already-fixed)
- Closes #35 (folded into this PR)
- Closes #38 (already-fixed)

#37 stays open with a sequencing comment (R1-R15 triage queued for next session).

#65 opened as the promotion tracker for `research/format-aware-notes.md` → eventual `patterns/format-aware-notes.md`.

## Test plan

- [x] Verify governance.md "Four rules" → "Five rules" header bump consistent throughout
- [x] Verify auth-stack umbrella links resolve to all 7 underlying files + research doc
- [x] Verify module-discovery umbrella links resolve to all 5 underlying files
- [x] Verify format-aware-notes.md cross-links resolve (parachute-surface-direction, building-a-surface, module-discovery, optimistic-concurrency)
- [x] Verify five issue-close comments rendered with anchors
- [x] Verify patterns#65 (promotion tracker) open
- [x] Verify patterns#37 stays open with priority comment