### PR TITLE
docs(patterns): rename parachute-jobs → parachute-runner (#71)

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,29 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-05-21 — trust-gradient-isolation.md: parachute-jobs → parachute-runner
+
+**Change:** rename references to the lightweight owner-operated job-substrate
+module from `parachute-jobs` to `parachute-runner` in
+[`trust-gradient-isolation.md`](../patterns/trust-gradient-isolation.md).
+Naming was settled 2026-05-21 with the runner design doc
+([`parachute.computer/design/2026-05-21-parachute-runner-design.md`](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-parachute-runner-design.md));
+the module shipped through Phase 1.2 at
+[`github.com/ParachuteComputer/parachute-runner`](https://github.com/ParachuteComputer/parachute-runner).
+Worked-examples and History sections updated; `(TBD)` markers dropped
+because the module exists.
+
+**Affected:**
+
+- `parachute-patterns` — pattern doc updated (this PR).
+- No downstream code changes; the prior entries in this migration-notes
+  log retain their historical `parachute-jobs` wording on purpose
+  (running log, not retroactive rewrite).
+
+**Status:** doc-only. Tracked in patterns#71.
+
+---
+
 ## 2026-05-20 — trust-gradient-isolation.md introduced
 
 **Change:** new pattern

--- a/patterns/trust-gradient-isolation.md
+++ b/patterns/trust-gradient-isolation.md
@@ -62,7 +62,7 @@ with `--mode lightweight` vs `--mode container` becomes two codebases
 glued together at the CLI. The operational surfaces diverge fast: logs,
 restart semantics, lifecycle hooks, secret handling, debugging stories.
 Better to ship two narrower modules that each do their job well
-(`parachute-jobs` for owner-operated, `parachute-cloud` for hosted)
+(`parachute-runner` for owner-operated, `parachute-cloud` for hosted)
 than one wide module that does both poorly.
 
 **Default to the lightest viable primitive.** For owner-operated
@@ -84,9 +84,9 @@ discipline, the whole architecture). Don't half-isolate.
 
 ## Worked examples
 
-### parachute-jobs (lightweight, owner-operated) — TBD
+### parachute-runner (lightweight, owner-operated)
 
-The future home of the Gitcoin-Brain-style runner. Trust gradient: flat.
+The home of the Gitcoin-Brain-style runner. Trust gradient: flat.
 The operator wrote the prompts, owns the vault, runs the cron entry on
 their own host. Architecture:
 
@@ -114,7 +114,7 @@ this audience*:
 - Resource limits enforced at the container layer, not by the
   application.
 
-The same container mechanics that are overhead for parachute-jobs are
+The same container mechanics that are overhead for parachute-runner are
 load-bearing here.
 
 ### parachute-agent (deprecated 2026-05-20)
@@ -182,10 +182,12 @@ the audience actually using it.
 captures the per-module narrative; this pattern doc captures the
 generalizable lesson so the next runtime primitive doesn't repeat it.
 
-**Future.** `parachute-jobs` (TBD) implements the lightweight
-primitive for owner-operated automation — the Gitcoin Brain shape
-graduated into a committed module. `parachute-cloud` (TBD) handles
-the hosted-multi-tenant case if and when that demand materializes,
-reusing the container-isolation ideas where they're load-bearing.
+**Future.** [`parachute-runner`](https://github.com/ParachuteComputer/parachute-runner)
+implements the lightweight primitive for owner-operated automation — the
+Gitcoin Brain shape graduated into a committed module (design doc:
+[`parachute.computer/design/2026-05-21-parachute-runner-design.md`](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-parachute-runner-design.md)).
+`parachute-cloud` (TBD) handles the hosted-multi-tenant case if and when
+that demand materializes, reusing the container-isolation ideas where
+they're load-bearing.
 Two modules, two audiences, two clearly-distinct trust gradients —
 which is the whole point.


### PR DESCRIPTION
## Summary

Naming was settled 2026-05-21: the lightweight owner-operated job-substrate module is `parachute-runner`, not `parachute-jobs`. The module shipped through Phase 1.2 at [`github.com/ParachuteComputer/parachute-runner`](https://github.com/ParachuteComputer/parachute-runner) (design doc: [`parachute.computer/design/2026-05-21-parachute-runner-design.md`](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-parachute-runner-design.md)). Updating `trust-gradient-isolation.md` to reflect the real name.

- 4 renames in `patterns/trust-gradient-isolation.md` (worked-examples + history + two contextual mentions); `(TBD)` markers dropped because the module exists
- Cross-links added to the runner repo + design doc in the History section
- New `2026-05-21` entry in `adoption/migration-notes.md` logging the rename; prior `2026-05-20` entry left as-is (running log, not retroactive rewrite)

Doc-only — no rc bump per governance rule 2.

Closes #71.

## Test plan

- [x] grep `patterns/trust-gradient-isolation.md` for `parachute-jobs` returns nothing
- [x] occurrences of `job` as concept ("do their job well", "job notes") preserved
- [x] new migration-notes entry renders cleanly with working links

🤖 Generated with [Claude Code](https://claude.com/claude-code)