### PR TITLE
docs(patterns): canonicalize four post-launch patterns (self-register, ssrf-safe-fetch, bootstrap, dev-mode-sse)

### DIFF
--- a/patterns/bootstrap-on-first-boot.md
+++ b/patterns/bootstrap-on-first-boot.md
@@ -143,6 +143,10 @@ migrate. The behavior is the same on every cold start.
 
 ## Failure modes
 
+**Note**: `<things>` in the table below is the array key for the
+module's default units, e.g. `apps` for parachute-app, `jobs` for
+a future parachute-jobs.
+
 | Condition | Behavior |
 | --- | --- |
 | `enabled: false` | Whole pass skipped, logged as `skipReason: "config.bootstrap_default_apps.enabled is false"`. |

--- a/patterns/bootstrap-on-first-boot.md
+++ b/patterns/bootstrap-on-first-boot.md
@@ -1,0 +1,173 @@
+# Bootstrap on first boot
+
+> A host module that mounts user-installable units (UIs, jobs, plugins)
+> auto-installs configured defaults the first time it starts against an
+> empty state — so a fresh install runs something useful out of the
+> box, not an empty dashboard. After that, the operator owns the state
+> and the bootstrap stays out of the way.
+
+## The principle
+
+The friend-deploy story for a host module is "`parachute install
+<module>` → `parachute start <module>` → open the URL and see
+something". If the second click lands on a blank "no <thing> installed
+yet" page, the operator has to know which package to install next and
+how to install it before the module justifies its presence. That's a
+discovery cliff at the worst possible moment.
+
+Bootstrap-on-first-boot closes the gap. The module ships with a
+*default* set of units it knows are the right starting point; on first
+boot, if the operator hasn't curated their own set, it installs them
+via the same code path the admin "add" verb uses. After that, the
+operator's state takes over — the bootstrap is a one-shot, not a
+running default.
+
+## When to use
+
+- **Host modules that mount user-installable units.** Apps host UIs;
+  a hypothetical runner could host default jobs; an MCP-server host
+  could ship default tools. The module's value is "host these things"
+  and the empty-state default is "host nothing," which obscures the
+  module's job.
+- **Friend-deploy / fresh-install scenarios.** Self-hosters spinning up
+  the ecosystem from `parachute install` should hit a working surface
+  on the first page load. Bootstrap removes the "now go install Notes"
+  step.
+- **When the default is clearly the right starting point.** For apps,
+  Notes is the canonical first UI — every Parachute install benefits
+  from it. The bootstrap codifies that recommendation as behavior.
+
+## When NOT to use
+
+- **The empty state is meaningful.** Vault should NOT auto-create a
+  vault on first boot — operators may want zero vaults, or want to
+  create the first one with specific naming. Empty-state-is-the-point
+  modules don't bootstrap.
+- **The default install has cost.** A multi-hundred-MB download, a
+  config that touches operator infrastructure, anything destructive on
+  failure — these are deliberate operator decisions, not defaults.
+- **The expected first-boot is "configure from scratch."** Modules
+  whose primary surface is operator-authored content (e.g. a notes
+  editor with no built-in defaults) shouldn't seed a placeholder.
+
+## The contract
+
+The shape is the same across host modules:
+
+```jsonc
+// <module>/config.json
+{
+  "bootstrap_default_<things>": {
+    "enabled": true,
+    "<things>": ["@openparachute/notes-ui"]
+  }
+}
+```
+
+- **`enabled: boolean`** — operator kill-switch. Defaults to `true`.
+  Setting `false` is the "I'll curate this myself" knob.
+- **`<things>: string[]`** — the canonical defaults the module ships
+  with. For apps, this is `["@openparachute/notes-ui"]`; future
+  committed-core UIs may join. The list is operator-overridable so
+  forks / private deployments can swap in their own defaults.
+
+**First-boot detection is state-based, not config-based.** The trigger
+is "the target install dir is empty," not "a `first_boot_done` flag
+hasn't fired yet." Reasoning: a flag-based trigger has subtle modes
+the operator can't recover from — they install the default, delete
+it deliberately, and on next restart the bootstrap re-fires (flag
+already cleared) or doesn't (flag stuck), neither of which matches
+intent. State-based is honest: "empty → bootstrap, non-empty →
+operator owns it."
+
+**Failures are best-effort.** Network down, package unpublished,
+malformed bundle — each per-unit failure logs a warning and the rest
+proceed. A failed bootstrap does NOT block daemon startup: the daemon's
+primary job is "host whatever's in the install dir already," and the
+empty-dir case degrades to "host nothing," which is the same state
+the operator would see without the bootstrap feature at all.
+
+## Reference implementation
+
+[`parachute-app/packages/app-host/src/bootstrap.ts`](https://github.com/ParachuteComputer/parachute-app/blob/main/packages/app-host/src/bootstrap.ts):
+
+```ts
+export type BootstrapOpts = {
+  config: AppConfig;
+  uisDir: string;
+  add: BootstrapAddFn;          // closure over the admin add path
+  npmFetch?: typeof fetchNpmPackage;
+  logger?: Pick<Console, "log" | "warn" | "error">;
+};
+
+export type BootstrapResult = {
+  bootstrapped: string[];                          // npm specs added
+  skipped: Array<{ pkg: string; reason: string }>;
+  failed: Array<{ pkg: string; error: string }>;
+  skipReason?: string;                             // whole-pass skip
+};
+
+export async function maybeBootstrapDefaultApps(
+  opts: BootstrapOpts,
+): Promise<BootstrapResult>;
+```
+
+Three load-bearing properties:
+
+- **Pure function.** Takes config + dir + an `add` closure; the closure
+  is the seam that decouples bootstrap from the admin handler's mutable
+  state. Tests inject a fake `add`; production wires it to
+  `addUiInternal`.
+- **Per-spec independence.** The loop catches each `add` rejection,
+  records it in `failed`, and continues. One bad package can't take
+  down the rest.
+- **Returns a summary, doesn't throw.** The caller logs
+  `bootstrapped.length` defaults installed and moves on. The summary
+  shape supports tests asserting on the post-bootstrap state without
+  having to read the filesystem.
+
+Wired in [`index.ts`](https://github.com/ParachuteComputer/parachute-app/blob/main/packages/app-host/src/index.ts)
+under `serve()` *after* HTTP starts listening and self-register has
+stamped its row — bootstrap is fire-and-forget; daemon serves whatever
+exists today while the bootstrap installs whatever should exist
+tomorrow, then the admin `add` flow's in-place state-swap picks up
+the new UIs without a restart.
+
+## Idempotency
+
+Re-running `serve` doesn't re-bootstrap, because the directory is no
+longer empty. The only way to re-trigger is for the operator to remove
+every installed unit (`rm -rf uis/*`) and restart — which is exactly
+when re-bootstrapping is desired. No flag to clear, no state to
+migrate. The behavior is the same on every cold start.
+
+## Failure modes
+
+| Condition | Behavior |
+| --- | --- |
+| `enabled: false` | Whole pass skipped, logged as `skipReason: "config.bootstrap_default_apps.enabled is false"`. |
+| `<things>: []` | Whole pass skipped, logged as `skipReason: "<things> is empty"`. |
+| Install dir non-empty | Whole pass skipped, logged as `skipReason: "uisDir is non-empty"`. |
+| Network down / registry timeout | Per-spec `failed` entry with the underlying error; rest of list continues. |
+| Package not on registry (404) | Per-spec `failed` entry with `not_found`; rest continues. |
+| Package malformed (no `dist/`, missing manifest) | Per-spec `failed` with the validator's reason; rest continues. |
+
+The visible symptom of a fully-failed bootstrap is "I see an empty
+dashboard on first boot." The operator's recovery is the explicit
+admin verb (`parachute-app add @openparachute/notes-ui` or the SPA
+"add" button) — same code path the bootstrap was trying to run, so
+the manual retry surfaces the same error in the operator's terminal.
+
+## Cross-references
+
+- Shipped in
+  [parachute-app#7](https://github.com/ParachuteComputer/parachute-app/pull/7)
+  (Phase 2.1) on 2026-05-22, alongside the auto-provision-schema work
+  that makes Notes' DCR-required schema appear in the vault on the
+  same first boot.
+- See [`module-self-registration.md`](./module-self-registration.md) —
+  bootstrap runs *after* self-register, so the services.json row exists
+  before the bootstrap stamps the post-bootstrap `uis` map.
+- See [`module-protocol.md`](./module-protocol.md) — the "host module"
+  shape (storage / runtime / discovery contracts) is the precondition
+  for this pattern; bootstrap layers on top.

--- a/patterns/dev-mode-sse-live-reload.md
+++ b/patterns/dev-mode-sse-live-reload.md
@@ -1,6 +1,6 @@
 # Dev-mode SSE live-reload
 
-> Hosted UIs in a supervisor module ship a dev mode that automatically
+> Hosted UIs in a host module ship a dev mode that automatically
 > reloads the browser when their source changes. The shape: a file
 > watcher (or manual trigger) broadcasts a `reload` event over an SSE
 > stream; an injected `<script>` in the served HTML listens via
@@ -10,7 +10,7 @@
 
 ## The principle
 
-UIs hosted inside a supervisor module (apps host UIs; a hypothetical
+UIs hosted inside a host module (apps host UIs; a hypothetical
 runner could host job dashboards) don't get the dev affordances a
 standalone Vite dev server gives them — they're served by the host as
 static bundles. Without a deliberate dev mode the iteration loop is:
@@ -167,10 +167,12 @@ Per-module knobs in the module config:
 - **`dev_watch_dir` is validated relative.** An absolute path in
   the manifest would let a malformed UI ask the host to watch
   `/Users/<op>/.ssh/`. Schema rejects absolute paths at meta-load.
-- **CORS / cross-origin:** SSE stream uses standard CORS, not
-  credentialed — a third-party origin can connect (and observe a
-  noisy "the operator reloaded their dev tab" signal), but can't
-  trigger a reload (no auth means no `/dev/trigger`).
+- **CORS / cross-origin:** The endpoint sets no CORS headers;
+  browsers block cross-origin EventSource connections by default
+  (same-origin policy). The default 127.0.0.1 bind further limits
+  reach. The intent: the SSE endpoint is intentionally unauthenticated
+  for dev-mode simplicity — a local same-origin tab observes reload
+  events without a token.
 
 ## Cross-references
 

--- a/patterns/dev-mode-sse-live-reload.md
+++ b/patterns/dev-mode-sse-live-reload.md
@@ -1,0 +1,191 @@
+# Dev-mode SSE live-reload
+
+> Hosted UIs in a supervisor module ship a dev mode that automatically
+> reloads the browser when their source changes. The shape: a file
+> watcher (or manual trigger) broadcasts a `reload` event over an SSE
+> stream; an injected `<script>` in the served HTML listens via
+> `EventSource` and calls `window.location.reload()`. Iteration cost
+> for a UI under bun-link drops from "rebuild + manual reload + maybe
+> service-worker dance" to "edit + tab refreshes itself."
+
+## The principle
+
+UIs hosted inside a supervisor module (apps host UIs; a hypothetical
+runner could host job dashboards) don't get the dev affordances a
+standalone Vite dev server gives them — they're served by the host as
+static bundles. Without a deliberate dev mode the iteration loop is:
+
+  edit → `bun run build` → switch to browser tab → reload → service
+  worker cached the old bundle, hard-reload → still cached, devtools
+  cache-disable + reload → finally see the new code.
+
+Multiply by ten edits per minute during a polish session and the
+friction dominates. The dev-mode pattern moves the loop to: edit →
+tab refreshes itself.
+
+## The architecture
+
+Three thin layers, all per-UI (a UI can be in dev mode without others
+being affected):
+
+1. **Server side — SSE endpoint.** `GET /<mount>/<name>/_dev/reload`
+   returns a `text/event-stream` response. Each connected browser is a
+   subscriber held in an in-process `Map<name, Set<subscriber>>`.
+   Disconnect handler reaps the entry. Unauthenticated (browser
+   `EventSource` can't add `Authorization` headers; the affordance is
+   meant for the dev path, not a production protected surface).
+
+2. **Inject script — browser side.** When dev mode is on AND the
+   response body is HTML for that UI, the host parses the HTML and
+   injects a `<script id="parachute-app-dev-reload">` just before
+   `</head>`. The script opens an `EventSource` against the relative
+   endpoint, listens for `reload` events, and calls
+   `window.location.reload()` (200ms grace to coalesce duplicate
+   events). Idempotent: marker `id` is checked before injection so
+   re-serves don't duplicate the tag.
+
+3. **Trigger — file watcher OR manual.** Default trigger is a
+   recursive `fs.watch` on the UI's source dir (debounced 250ms).
+   Operators can also fire a manual broadcast via `POST
+   /<mount>/<name>/dev/trigger` (the CLI's `--trigger` flag); useful
+   when the source is on a remote filesystem the watcher can't see, or
+   for testing the reload path itself.
+
+## The flow
+
+1. Operator runs `<module> dev <ui>` → POSTs to the host's
+   `/dev/enable` route. In-memory state flips for that UI; file watcher
+   starts on the UI's `dev_watch_dir`.
+2. Source change → FSWatcher fires → debounced callback waits the
+   quiet-window out (250ms default; floor 50ms).
+3. (Optional) operator-declared `dev_build_cmd` runs via `Bun.spawn` —
+   60s timeout, single-flight per UI (a fresh batch arriving during a
+   build is coalesced into "re-run on completion").
+4. Build success (exit 0) → `broadcastReload(name)` pushes an
+   `event: reload\ndata: {"timestamp":...}\n\n` to every subscriber.
+   Build failure → log stdout/stderr (truncated), no broadcast,
+   watcher stays armed.
+5. Each connected browser's `EventSource` dispatches; injected script
+   calls `window.location.reload()`. The next request for the
+   bundle is served fresh (dev mode also overrides cache headers, see
+   below). New code visible.
+
+Total wall-clock from "save" to "browser refreshed": debounce +
+build-time + ~10ms broadcast + ~50ms reload + bundle reparse.
+For a small UI with no build cmd, it's ~300ms end-to-end.
+
+## Cache strategy interaction
+
+A dev mode that fires reload events while service workers serve stale
+bundles is worse than no dev mode at all. The host enforces a hard
+override:
+
+- **In dev mode:** every response from that UI's mount gets
+  `Cache-Control: no-cache, no-store, must-revalidate`, overriding the
+  production smart-cache headers (hashed assets get `immutable`,
+  unhashed get `max-age=3600`). HTML especially: the browser must
+  re-fetch the document for the inject script to find a fresh
+  `EventSource` endpoint.
+- **PWA service workers:** UIs that ship a service worker get the same
+  no-cache treatment on the SW file itself, but ultimately the UI
+  owns its SW lifecycle. Best-practice for UIs that want clean dev:
+  detect dev mode (e.g. presence of the inject script) and call
+  `registration.unregister()` to drop the SW entirely while iterating.
+  (parachute-notes#151 tracks Notes adopting this pattern.)
+- **On `dev disable`:** cache headers revert to the production shape;
+  SSE subscribers are closed; the browser's next request fetches via
+  the production cache plan. No daemon restart needed.
+
+## Reference implementation
+
+In [`parachute-app`](https://github.com/ParachuteComputer/parachute-app):
+
+- [`dev-mode.ts`](https://github.com/ParachuteComputer/parachute-app/blob/main/packages/app-host/src/dev-mode.ts)
+  — per-UI state (`Map<name, DevModeState>` + `Map<name,
+  Set<subscriber>>`). `enableDevMode` / `disableDevMode` /
+  `broadcastReload` / `addSubscriber` / `removeSubscriber`.
+- [`dev-watcher.ts`](https://github.com/ParachuteComputer/parachute-app/blob/main/packages/app-host/src/dev-watcher.ts)
+  — `fs.watch(..., { recursive: true })` per UI; debounce + ignore
+  `dist/` + `node_modules/` + `.git/`; optional build via `Bun.spawn`
+  with `AbortController` timeout; single-flight + rerun-pending guard.
+- [`dev-injection.ts`](https://github.com/ParachuteComputer/parachute-app/blob/main/packages/app-host/src/dev-injection.ts)
+  — regex-based HTML insertion before `</head>` (fallbacks: before
+  first `<script>`, after `<body>`, append). Idempotent via
+  `id="parachute-app-dev-reload"` marker check. Deliberately NOT
+  cheerio — a 500KB HTML-parser dep for one insertion is wrong-shaped.
+- [`dev-routes.ts`](https://github.com/ParachuteComputer/parachute-app/blob/main/packages/app-host/src/dev-routes.ts)
+  — `GET /_dev/reload` SSE; `POST /dev/enable`, `/dev/disable`,
+  `/dev/trigger`; `GET /dev/list`, `GET /dev`.
+
+## Configuration
+
+Per-UI knobs live in the UI's manifest (apps reads them from
+`meta.json`):
+
+- **`dev_watch_dir: string`** — source dir to watch, relative to UI
+  root. Validated as relative (no absolute-path escape). Defaults to
+  the UI root itself (filter handles `dist/` + `node_modules/`).
+- **`dev_build_cmd: string`** — optional shell command run before
+  broadcast (e.g. `"bun run build"`). cwd is UI root. Spawned via `sh
+  -c`. Skipped when undefined.
+- **`dev_debounce_ms: number`** — debounce window. Default `250`,
+  floor `50` (clamped).
+
+Per-module knobs in the module config:
+
+- **`dev_mode_allowed: boolean`** — operator kill-switch. Default
+  `true`. Setting `false` makes `/dev/enable` return `409
+  dev_mode_disabled` — useful for production deployments where dev
+  mode shouldn't be reachable even with admin scope.
+
+## Failure modes
+
+| Condition | Behavior |
+| --- | --- |
+| `dev_build_cmd` exits non-zero | Log truncated stdout + stderr; no reload broadcast; watcher stays armed; next edit retries. |
+| `dev_build_cmd` hangs > 60s | `AbortController.abort()` kills the process; watcher continues. |
+| Build-output-loop (build writes to `dist/`) | Watcher filter drops `dist/` + `node_modules/` + `.git/` paths before debounce; loop never starts. |
+| FSWatcher error (rare; platform quirks) | Logged; watcher slot may fall back to non-recursive on the same dir; pattern degrades to "watches root only". |
+| Recursive watch unsupported on platform | Logged warning; falls back to `fs.watch` without `recursive: true`. |
+| SSE client disconnect | `cancel` hook fires; subscriber removed from set; no leak. |
+| Build in flight when next batch lands | Single-flight guard; `rerunPending = true`; runs once current build settles. |
+| `dev_mode_allowed: false` | `enable` returns `409 dev_mode_disabled`. |
+
+## Security
+
+- **SSE endpoint is unauthenticated.** Browser `EventSource` doesn't
+  support custom headers; an OAuth-bearer flow on the dev stream
+  would require a token-in-query-string shim. The endpoint reveals
+  reload events for one named UI; the surface is small and the impact
+  is "a third-party tab gets told to reload, which it has no reason
+  to listen for." For deployments where this is unacceptable, the
+  `dev_mode_allowed: false` config disables the whole subsystem.
+- **`dev_build_cmd` is shell-spawned.** That's operator-authored
+  config under the operator's own UID — same trust level as the
+  `startCmd` in the module's `.parachute/module.json`. Not user
+  input, not callable from a third party.
+- **`dev_watch_dir` is validated relative.** An absolute path in
+  the manifest would let a malformed UI ask the host to watch
+  `/Users/<op>/.ssh/`. Schema rejects absolute paths at meta-load.
+- **CORS / cross-origin:** SSE stream uses standard CORS, not
+  credentialed — a third-party origin can connect (and observe a
+  noisy "the operator reloaded their dev tab" signal), but can't
+  trigger a reload (no auth means no `/dev/trigger`).
+
+## Cross-references
+
+- Shipped in
+  [parachute-app#3](https://github.com/ParachuteComputer/parachute-app/pull/3)
+  (Phase 1.3 — dev mode + SSE + inject) and
+  [parachute-app#8](https://github.com/ParachuteComputer/parachute-app/pull/8)
+  (Phase 3.0 — file watcher + auto-rebuild) on 2026-05-22.
+- Closes the iteration friction tracked in
+  [parachute-notes#151](https://github.com/ParachuteComputer/parachute-notes/issues/151)
+  ("dev mode: trigger SW unregister on rebuild so bun-link source
+  edits propagate") — the SW-unregister piece still belongs to Notes,
+  but the broadcast-on-rebuild affordance the issue was working
+  around now ships at the platform level.
+- See [`module-self-registration.md`](./module-self-registration.md) —
+  dev-mode state is process-local + ephemeral by design; it doesn't
+  ride along in services.json. A daemon restart returns every UI to
+  production cache headers.

--- a/patterns/module-self-registration.md
+++ b/patterns/module-self-registration.md
@@ -183,7 +183,9 @@ The pattern shipped across three modules on 2026-05-21:
   `FIRST_PARTY_FALLBACKS[vault]`.
 - **runner#3** — Phase 1.3, modeled on the agent + scribe shape (which
   predate the vault POC by a few weeks but weren't formalized as a
-  pattern yet).
+  pattern yet). (Note: parachute-runner is currently exploration-tier;
+  cited as a faithful implementation of the same pattern as vault/scribe,
+  not as a canonical committed-core module.)
 - **scribe#50** — converged on the runner shape; module.json is now the
   single source of truth for paths/health/displayName/tagline.
 

--- a/patterns/module-self-registration.md
+++ b/patterns/module-self-registration.md
@@ -1,0 +1,210 @@
+# Module self-registration
+
+> Every Parachute module owns its own row in
+> `~/.parachute/services.json`. On `serve` startup it reads its own
+> `.parachute/module.json`, computes its `installDir`, and atomically
+> upserts the row. Hub reads the file as the canonical source of truth.
+
+## The principle
+
+Hub-as-supervisor (v0.6) reads `~/.parachute/services.json` to know which
+modules exist on the host. A module that doesn't self-register is
+invisible to `parachute status`, `parachute restart`, the admin SPA
+module catalog, and the live `/.well-known/parachute.json` builder.
+
+**The module is the authority on its own row.** Hub's vendored
+`FIRST_PARTY_FALLBACKS` table in
+[`parachute-hub/src/service-spec.ts`](https://github.com/ParachuteComputer/parachute-hub/blob/main/src/service-spec.ts)
+is a transitional shim — one entry per module that hasn't yet shipped
+its own `.parachute/module.json` or self-register path. The endgame is
+every committed-core module self-registers reliably and the fallback
+table retires (tracked at
+[parachute-hub#301](https://github.com/ParachuteComputer/parachute-hub/issues/301)).
+
+## The contract
+
+A self-registering module:
+
+1. **Ships `.parachute/module.json`** with the required fields (see
+   [`module-json-extensibility.md`](./module-json-extensibility.md)):
+   `name`, `manifestName`, `displayName`, `tagline`, `kind`, `port`,
+   `paths`, `health`, `startCmd`, `scopes`.
+2. **Exposes a `selfRegister(opts) → result` function** that reads the
+   manifest, atomically upserts the services.json row, and returns
+   structured success/failure (never throws).
+3. **Calls it from `serve` startup AFTER the HTTP server starts
+   listening**, fire-and-forget. Best-effort: failures log + the daemon
+   continues serving.
+
+## The reference shape
+
+Canonical types — runner's version is the cleanest reference:
+
+```ts
+// parachute-runner/src/self-register.ts
+export type SelfRegisterOpts = {
+  /** The port we just bound — first-run fallback only. */
+  boundPort: number;
+  /** Absolute path to the package root (where `.parachute/` + `package.json` live). */
+  installDir: string;
+  /** Override services.json location (tests). */
+  manifestPath?: string;
+  /** Logger override; default console. */
+  logger?: Pick<Console, "log" | "warn" | "error">;
+};
+
+export type SelfRegisterResult = {
+  ok: boolean;
+  manifestPath: string;
+  hadExistingEntry: boolean;
+  portWritten: number;
+  /** Set when ok=false — the error swallowed by the caller. */
+  error?: Error;
+};
+```
+
+And the services.json helpers (mirror these per module — same shape
+across vault, scribe, runner, agent):
+
+```ts
+// parachute-runner/src/services-manifest.ts
+export function resolveManifestPath(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const base = env.PARACHUTE_HOME ?? join(env.HOME ?? os.homedir(), ".parachute");
+  return join(base, "services.json");
+}
+
+export function readServiceEntry(name: string, path = resolveManifestPath()): ServiceEntry | undefined;
+
+export function upsertService(entry: ServiceEntry, path = resolveManifestPath()): void {
+  // Merge into existing row (preserves hub-stamped fields). Atomic write:
+  // stage to `<path>.tmp-<pid>-<now>`, rename over target.
+}
+```
+
+Three load-bearing details:
+
+- **`upsertService` merges, doesn't replace** — `entry` spreads last so
+  the module wins on its own fields; hub-stamped fields the module
+  doesn't author (`installDir`, future `uiUrl` / `managementUrl`) ride
+  through.
+- **Atomic write** — stage to a per-pid tmp file, then rename. A crash
+  mid-write leaves the prior file intact rather than corrupting it.
+- **`PARACHUTE_HOME` is resolved per-call** — honored at runtime so
+  Docker / sandbox / test setups can redirect without import-boundary
+  flakiness.
+
+## What gets preserved across re-registrations
+
+| Field | Authority | Behavior |
+| --- | --- | --- |
+| `port` | Operator (or hub) at install time | If a row exists with a `port`, the module **preserves** it on subsequent boots. First-boot writes the bound port. |
+| `installDir` | The module on boot | Module **re-stamps** `installDir` from its own package root so a `git pull` that moves the checkout is reflected. Hub-stamped value from `parachute install` is overwritten by the module's own resolution (they should agree). |
+| `paths` / `health` / `displayName` / `tagline` / `stripPrefix` / `version` | Module's `.parachute/module.json` + `package.json` | Re-stamped every boot from the manifest. |
+| Hub-stamped extras (`uiUrl`, `managementUrl`, future fields) | Hub at install/upgrade time | Preserved via the merge in `upsertService`. |
+| Other modules' rows | Other modules | Never touched. The upsert keys on `name`. |
+
+Port-preservation matters: an operator who set `scribe.port = 1947` in
+services.json (or hub picked it during port-collision resolution) stays
+at 1947 across restarts. Scribe pinned this in `scribe#40` /
+`paraclaw#145` — earlier scribe versions silently overwrote the
+operator's port with the env-derived default on every boot.
+
+## Failure modes (graceful)
+
+Every read or write boundary returns `{ok: false, error}` rather than
+throwing. The caller logs a single `[<module>] skipped self-register:
+<reason>` line and continues:
+
+- **`PARACHUTE_HOME` unset and `$HOME` unresolvable** → skip, log.
+- **`.parachute/module.json` absent** → skip, log ("legacy install or
+  dev tree").
+- **`services.json` malformed** → skip, log. (The next operator-driven
+  fix-up surfaces the error.)
+- **`services.json` unwritable** (permissions, disk full, concurrent
+  writer) → skip, log.
+
+The running module is more valuable than the discoverability
+bookkeeping. The visible symptom of failure is "module doesn't appear
+on hub discovery / admin SPA"; the fix is to restart the module or run
+`parachute install <name>` to re-stamp via the hub-side path.
+
+## Trust boundary
+
+Filesystem-direct writes mean the module process has write access to
+hub's `~/.parachute/` directory. That's appropriate for the v0.6
+owner-operated single-container deployment (see
+[`trust-gradient-isolation.md`](./trust-gradient-isolation.md)) — hub
+and module share a filesystem, share an operator, share a trust
+gradient.
+
+For v0.7 multi-container cloud, the seam is swappable: the
+`selfRegister` function is the single call site that would change from
+"write to filesystem" to "POST to `hub/api/modules/self-register`". The
+caller — `serve` startup — doesn't know or care which transport ran.
+Vault's `self-register.ts` docstring captures the forward-compatibility
+explicitly.
+
+## What about frontend modules (notes)?
+
+Notes is a static bundle served by hub's `notes-serve.ts` shim, not a
+daemon with a `serve` startup. The self-registration pattern doesn't
+directly apply — notes is registered by whatever installs it (hub's
+install flow + the `NOTES_FALLBACK` vendored manifest in
+`service-spec.ts`). When notes ships its own `.parachute/module.json`
+and hub's install path reads it, `NOTES_FALLBACK` retires the same way
+the others do — but the call site for the row stamp lives in hub's
+install command rather than in notes itself.
+
+## Why filesystem-direct, not HTTP
+
+HTTP would be a cleaner trust boundary — the module wouldn't need write
+access to hub's home directory — but it costs:
+
+- **Hub-side endpoint.** `POST /api/modules/self-register` with auth
+  (the module needs the operator's bearer to register).
+- **Bootstrap ordering.** If hub is supervising every module and the
+  module self-registers via HTTP-to-hub, hub has to be up first; today
+  modules can boot independently and hub picks them up on next read.
+- **Auth complexity.** Modules don't currently hold an operator-bearer
+  on cold-boot.
+
+Filesystem-direct works in v0.6 single-container, where hub and modules
+share both filesystem and operator. Defer HTTP to v0.7 when the trust
+gradient genuinely steepens (cross-container, multi-tenant) and the
+isolation cost is load-bearing rather than ceremonial.
+
+## History
+
+The pattern shipped across three modules on 2026-05-21:
+
+- **vault#356** — first implementer; POC for retiring hub's
+  `FIRST_PARTY_FALLBACKS[vault]`.
+- **runner#3** — Phase 1.3, modeled on the agent + scribe shape (which
+  predate the vault POC by a few weeks but weren't formalized as a
+  pattern yet).
+- **scribe#50** — converged on the runner shape; module.json is now the
+  single source of truth for paths/health/displayName/tagline.
+
+Agent's `services-manifest.ts` (now deprecated alongside the module
+itself, see `parachute-agent/DEPRECATED.md`) was the original
+implementation that runner + scribe mirrored. The pattern's
+"manifest-sourced metadata, not hardcoded in the call site" property is
+the load-bearing piece that makes the FALLBACK retirement possible —
+once all four committed-core modules self-register from their own
+manifest, hub no longer needs vendored copies.
+
+## Related patterns
+
+- [`module-protocol.md`](./module-protocol.md) — the three contracts
+  every module implements (storage / runtime / discovery).
+  Self-registration is how a module gets its row into the storage
+  layer.
+- [`module-json-extensibility.md`](./module-json-extensibility.md) —
+  the manifest shape self-registration reads from.
+- [`trust-gradient-isolation.md`](./trust-gradient-isolation.md) —
+  why filesystem-direct writes are appropriate for v0.6 owner-operated
+  and the seam where v0.7 multi-tenant would swap to HTTP.
+- [`canonical-ports.md`](./canonical-ports.md) — what the `port` field
+  the module re-stamps is bounded by.

--- a/patterns/ssrf-safe-fetch.md
+++ b/patterns/ssrf-safe-fetch.md
@@ -1,0 +1,224 @@
+# SSRF-safe URL fetching
+
+> Any Parachute module that fetches user-supplied URLs must defend
+> against Server-Side Request Forgery — preventing the server from
+> being weaponized to reach internal services, cloud metadata
+> endpoints, link-local addresses, or private networks.
+
+## The principle
+
+Once a module accepts a URL from a caller (a `transcribe-url` payload,
+a webhook target, a notification destination, an arbitrary "import this
+file" tool), it stops being a passive responder and starts being a
+client. Without explicit defenses, the module's network position
+becomes the caller's network position: requests originate from inside
+the Parachute deployment's trust boundary, which often reaches surfaces
+the caller cannot — Tailscale-internal vaults, AWS instance metadata,
+loopback admin SPAs, private RFC 1918 ranges, CG-NAT tailnet IPs.
+
+The defense is a **single hardened fetch primitive** every consumer
+goes through. No ad-hoc `fetch()` against caller-supplied URLs anywhere
+in the module — exactly one chokepoint, every layer enforced before any
+audio data flows.
+
+## The 7-layer defense
+
+Implemented in
+[`parachute-scribe/src/url-fetch.ts`](https://github.com/ParachuteComputer/parachute-scribe/blob/main/src/url-fetch.ts):
+
+| # | Layer | Enforcement | Failure code |
+| --- | --- | --- | --- |
+| 1 | **Scheme allowlist** | `http:` / `https:` only. Reject `file:`, `data:`, `gopher:`, `ftp:`, `javascript:`, anything else. | `400 unsupported_scheme` |
+| 2 | **Hostname blocklist** | Literal IPs in private / loopback / link-local / CG-NAT / multicast / reserved ranges (see below); `localhost` and `*.localhost`. | `400 blocked_host` |
+| 3 | **DNS resolve + re-check** | `dns.lookup(hostname)` → re-run the resolved IP through the blocklist. Catches DNS rebinding (`169-254-169-254.example.com` → `169.254.169.254`). | `400 blocked_host` / `400 dns_failed` |
+| 4 | **Redirect revalidation** | `redirect: "manual"`. Every `3xx Location` re-runs layers 1–3 before following. Max 5 hops. | `400` per layer / `502 fetch_failed` ("too many redirects") |
+| 5 | **Size cap** | Explicit byte limit (scribe: 100 MiB). Checked via `Content-Length` AND mid-stream during body read — chunked-transfer can't bypass. | `413 too_large` |
+| 6 | **Timeout** | `AbortController` wrapping the whole fetch (DNS + connect + body read). Scribe: 5 min. | `504 timeout` |
+| 7 | **Content-Type sniff** | Permissive but typed gate. Reject responses that aren't plausibly the expected content (scribe: `audio/*`, select `video/*` containers, `application/octet-stream` with audio extension). | `415 not_audio` (or domain-equivalent) |
+
+The blocklist for layer 2 + 3, conservative:
+
+```
+IPv4:
+  0.0.0.0/8        reserved
+  10.0.0.0/8       private (RFC 1918)
+  127.0.0.0/8      loopback
+  169.254.0.0/16   link-local (AWS metadata: 169.254.169.254)
+  172.16.0.0/12    private (RFC 1918)
+  192.0.0.0/24     IETF protocol assignments
+  192.168.0.0/16   private (RFC 1918)
+  100.64.0.0/10    CG-NAT (RFC 6598; tailnet space)
+  224.0.0.0/4      multicast
+  240.0.0.0/4      reserved
+  255.255.255.255  broadcast
+
+IPv6:
+  ::               unspecified
+  ::1              loopback
+  fc00::/7         unique-local
+  fe80::/10        link-local
+  ff00::/8         multicast
+  ::ffff:a.b.c.d   IPv4-mapped (dotted form — defer to v4 blocklist)
+  ::ffff:HHHH:HHHH IPv4-mapped (hex form — what Bun emits; decode + defer to v4)
+```
+
+## The Bun normalization gap
+
+Bun's URL parser normalizes `[::ffff:127.0.0.1]` (dotted IPv4-mapped
+IPv6) into `[::ffff:7f00:1]` (hex IPv4-mapped) before handing the
+hostname back to the caller. A blocklist that only matches the dotted
+form misses the hex form and allows the loopback hop.
+
+The blocklist must handle **both** representations:
+
+```ts
+// parachute-scribe/src/url-fetch.ts isBlockedV6
+const mappedDotted = lower.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+if (mappedDotted) return isBlockedV4(mappedDotted[1]!);
+
+const mappedHex = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+if (mappedHex) {
+  const hi = parseInt(mappedHex[1]!, 16);
+  const lo = parseInt(mappedHex[2]!, 16);
+  // Decode `hi:lo` into `a.b.c.d` and defer to v4.
+  return isBlockedV4(`${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`);
+}
+```
+
+Pin this in tests with both literal forms of `::ffff:127.0.0.1`.
+
+## Test-only escape
+
+Real tests need to exercise the fetcher against a local server. The
+escape is an env var **read per-call** (not module-scope), so it can't
+accidentally persist across an import boundary and leak into
+non-test code paths:
+
+```ts
+function loopbackBypassFor(hostname: string): boolean {
+  if (process.env.PARACHUTE_SCRIBE_URL_FETCH_ALLOW_LOOPBACK !== "1") return false;
+  if (hostname === "::1") return true;
+  if (!hostname.includes(".")) return false;
+  return hostname.startsWith("127."); // IPv4 loopback only.
+}
+```
+
+Three properties make this safe:
+
+- Per-call read — flipping the env after a test sets up the fetcher
+  doesn't persist.
+- Loopback only — bypass is the narrowest possible: `127.0.0.0/8` +
+  `::1`. Other private ranges stay blocked.
+- Hard-coded module-scoped name — the env var is module-prefixed
+  (`PARACHUTE_SCRIBE_*`); a hypothetical second consumer doesn't share
+  the bypass.
+
+## What's not enough
+
+- **`new URL()` parsing alone** — accepts the URL as well-formed but
+  doesn't validate the host against private networks. The whole point
+  is the URL is syntactically fine.
+- **DNS lookup alone** — without re-checking the resolved IP and
+  pinning it for the connect, a malicious DNS server can return a
+  public IP for the check and a private IP for the actual fetch
+  (DNS rebinding). Layer 2 + 3 work together.
+- **User-Agent / Referer / origin header checks** — trivially
+  bypassable by any caller. They're for telemetry, not defense.
+- **Blocking by hostname string** — `localhost.evil.example.com`
+  resolves to a public IP that lies inside one of the blocklisted
+  ranges; only the post-resolve re-check catches it.
+- **Trusting `Content-Length` for the size cap** — chunked-transfer
+  responses can omit it. The streaming check (layer 5, second half) is
+  the load-bearing piece.
+
+## Reference implementation
+
+See [`parachute-scribe/src/url-fetch.ts`](https://github.com/ParachuteComputer/parachute-scribe/blob/main/src/url-fetch.ts):
+
+- `parseAndValidateUrl(input)` — layers 1 + 2.
+- `resolveAndCheck(hostname)` — layer 3 (DNS + re-check).
+- `fetchAudioFromUrl(input)` — wires layers 4 + 5 + 6 + 7 around the
+  `fetch` call, with `redirect: "manual"` driving the per-hop
+  revalidation loop and `AbortController` driving the timeout.
+- `isBlockedAddress(ip, family)` / `isBlockedV4` / `isBlockedV6` — the
+  blocklist primitives, plus the Bun normalization handling.
+
+Tests in
+[`parachute-scribe/src/url-fetch.test.ts`](https://github.com/ParachuteComputer/parachute-scribe/blob/main/src/url-fetch.test.ts)
+(34 cases) cover: scheme rejection, the full IP-literal blocklist (v4 +
+v6 + IPv4-mapped-v6 dotted + Bun-normalized hex), DNS resolution +
+re-check, redirect revalidation across every layer, mid-stream size
+cap, non-audio content-type rejection, the audio-ish fallback for
+generic `application/octet-stream`.
+
+## Rules
+
+- **One chokepoint per module.** All caller-URL-bearing routes call
+  the same fetcher function. Don't sprinkle `fetch()` into route
+  handlers — the route handler accepts the URL string and hands it to
+  the fetcher.
+- **Reject early.** Layers 1 + 2 fire before any DNS or network
+  traffic. A bad scheme or IP literal shouldn't cost a DNS lookup.
+- **Pin the resolved IP — or accept the cost of resolving twice.**
+  Resolving for the check then handing the hostname back to `fetch`
+  lets the OS resolve again under the attacker's nose. Either pin
+  (via undici dispatcher) or accept that the second resolve hits the
+  OS cache and re-checks per layer 3.
+- **Manual redirects, full re-validation per hop.** A 302 to
+  `http://127.0.0.1:1939/admin` is the canonical attack — every
+  Location runs the full gauntlet.
+- **Streaming size enforcement.** `Content-Length` is a hint, not a
+  contract. The mid-stream accumulation check is the binding one.
+- **Test-only bypasses are env-gated and per-call.** Module-scope
+  bypasses persist across imports and accidentally enable in
+  production.
+
+## When this applies
+
+Today, scribe's `POST /v1/audio/transcriptions-url` and the
+`transcribe-url` MCP tool. The pattern extends to any future
+caller-URL surface:
+
+- Webhook fan-out modules (channel-style) that POST to caller-supplied
+  callback URLs.
+- Notification senders that GET caller-supplied avatar URLs.
+- Import-from-URL flows in vault (markdown / Obsidian / attachment
+  imports).
+- Module-to-module HTTP calls where the destination is operator-config
+  rather than module-hardcoded (the destination is still operator-
+  trusted, but defense in depth costs little).
+
+Each new consumer should reuse the same fetcher (factored into a
+shared library when scribe + a second module both need it) rather
+than reimplementing the 7 layers. The blocklist is the kind of code
+that's only correct on the third or fourth pass; sharing the
+implementation amortizes the audit cost.
+
+## History
+
+Shipped in
+[`scribe#48`](https://github.com/ParachuteComputer/parachute-scribe/pull/48)
+on 2026-05-21 alongside the URL transcription endpoint and the MCP
+server. 34 tests across the 7 layers pin the defense; reviewer dispatch
+verified the IPv4-mapped IPv6 dual-form handling and the
+mid-stream size cap as the two highest-leverage layers.
+
+YouTube + general-purpose video extraction was punted from the same PR
+— `yt-dlp` is a heavy runtime dep (~50MB Python + ffmpeg) AND a much
+bigger SSRF surface (libcurl + every protocol handler yt-dlp speaks).
+Direct-URL only is the narrow primitive; callers who want YouTube
+extract audio outside scribe and POST the URL.
+
+## Related patterns
+
+- [`service-to-service-auth.md`](./service-to-service-auth.md) — the
+  same "one validator function, one chokepoint" discipline applied to
+  bearer tokens. SSRF-safe-fetch is its egress-side cousin.
+- [`trust-gradient-isolation.md`](./trust-gradient-isolation.md) —
+  why even owner-operated modules defend against SSRF: the trust
+  gradient runs caller → module, and the caller authoring a
+  URL is closer to a third party than to the operator.
+- [`module-protocol.md`](./module-protocol.md) — modules accept
+  caller input on their `/.parachute/*` and module-specific routes;
+  caller-supplied URLs are a specific shape of caller input that needs
+  this defense.

--- a/patterns/trust-gradient-isolation.md
+++ b/patterns/trust-gradient-isolation.md
@@ -163,6 +163,13 @@ from "name the audience first" instead of "build the safest thing."
   trust axis between Parachute services. Today flat (loopback +
   shared secret); tomorrow JWT-mediated, but still distinct from
   user-prompt trust. Different gradients, different mechanisms.
+- [`module-self-registration.md`](./module-self-registration.md) —
+  why modules in the owner-operated trust gradient self-register via
+  filesystem writes to hub's `~/.parachute/services.json`: hub and
+  module share a filesystem, share an operator. Multi-tenant cloud
+  (v0.7+) is the seam where the same `selfRegister` function would
+  swap from filesystem-direct to HTTP-to-hub; same shape, different
+  transport, different gradient.
 - [`governance.md`](./governance.md) — the rules these patterns live
   inside. Naming the audience belongs to the same family of
   decisions as RC-versioning and the patterns check.


### PR DESCRIPTION
## Summary

Canonicalizes four patterns that shipped across the ecosystem 2026-05-21 / 2026-05-22 as ecosystem-wide conventions.

### Already on this PR (2026-05-21)

**`module-self-registration.md`** (210 LOC) — every Parachute module owns its own row in `~/.parachute/services.json`, reading its own `.parachute/module.json` on `serve` startup and atomically upserting via filesystem-direct writes. Hub reads the file as the canonical source of truth. References vault#356, runner#3, scribe#50.

**`ssrf-safe-fetch.md`** (224 LOC) — the 7-layer SSRF defense shipped in scribe#48 for `transcribe-url`: scheme allowlist, hostname blocklist (full IPv4/IPv6 + IPv4-mapped-IPv6 dotted AND hex — Bun normalization gap), DNS resolve + re-check (rebinding), manual-redirect revalidation, dual Content-Length + mid-stream size cap, AbortController timeout, content-type sniff.

### Added 2026-05-22

**`bootstrap-on-first-boot.md`** (173 LOC) — host modules that mount user-installable units auto-install configured defaults on empty state; first-boot detection is directory-empty (not a flag), per-unit best-effort failure, idempotent. Reference: parachute-app#7 (Phase 2.1).

**`dev-mode-sse-live-reload.md`** (191 LOC) — hosted UIs gain SSE live-reload via three layers (SSE endpoint + inject script + file-watcher trigger with optional build cmd); cache-override contract + failure-mode table + security notes on the unauthenticated stream and shell-spawn build cmd. Reference: parachute-app#3 (Phase 1.3) + parachute-app#8 (Phase 3.0); closes the iteration friction tracked in parachute-notes#151.

## Cross-references

- `trust-gradient-isolation.md` gets a new Related-patterns entry pointing at `module-self-registration.md`.
- `bootstrap-on-first-boot.md` and `dev-mode-sse-live-reload.md` cross-link to `module-self-registration.md`, `module-protocol.md`, `canonical-ports.md` where appropriate.
- Both new docs deliberately do NOT add code; CLAUDE.md "no code" rule preserved.

## Commits

1. `docs(patterns): add module-self-registration pattern` — new doc + trust-gradient cross-reference.
2. `docs(patterns): add ssrf-safe-fetch pattern` — new doc.
3. `docs(patterns): add bootstrap-on-first-boot pattern` — new doc.
4. `docs(patterns): add dev-mode-sse-live-reload pattern` — new doc.

## Test plan

- [ ] Reviewer dispatch — verify each doc matches the codebase reality (selfRegister shape, 7-layer SSRF impl, bootstrap.ts shape, dev-mode triad shape).
- [ ] Confirm cross-references resolve to existing files.
- [ ] Confirm no code added (CLAUDE.md rule).

Doc-only — no rc bump (governance rule 2 exemption).