### PR TITLE
docs(patterns): refresh module references for app architecture (Notes-as-app + agent retired)

### DIFF
--- a/guides/multi-writer-workspace.md
+++ b/guides/multi-writer-workspace.md
@@ -75,8 +75,8 @@ The committed-core that this guide leans on:
 | **parachute-vault** | The knowledge graph + MCP. Notes, tags, links, schemas. |
 | **parachute-hub** | The portal + Authorization Server. Token issuance, identity, service catalog. |
 | **parachute-scribe** | Transcription daemon. Picks up audio attachments + writes transcripts back. |
-| **parachute-agent** | (Optional) Container-hosted Claude distribution for automation. |
-| **parachute-notes** | (Optional) Frontend PWA for human authoring. |
+| **parachute-runner** | (Optional) Background job runner; spawns `claude -p` against vault jobs. |
+| **parachute-app** | (Optional) UI host module; ships Notes as canonical first app. |
 
 Each is its own repo with its own conventions. Vault is the one this guide is centered on; the others appear where they matter.
 

--- a/patterns/canonical-ports.md
+++ b/patterns/canonical-ports.md
@@ -25,20 +25,24 @@ this doc's reservations get enforced through.
 |---|---|---|---|---|
 | 1939 | `parachute-hub` | committed core | assigned | CLI-managed; static + reverse-proxy front door, fronts every service for `parachute expose`. |
 | 1940 | `parachute-vault` | committed core | assigned | REST + MCP at `/vault/<name>/`. |
-| 1942 | `parachute-notes` | committed core | assigned | Static server over the PWA bundle. |
+| 1942 | `parachute-notes` | committed core | deprecating (Phase 2 — see notes#154) | Static server over the PWA bundle. Standalone notes-daemon is deprecating; Notes ships as the canonical first app under `parachute-app` (1946) going forward. |
 | 1943 | `parachute-scribe` | committed core | assigned | Whisper-compatible transcription API at root. |
-| 1944 | `parachute-agent` | committed core | assigned | Web UI + agent runtime. De facto since launch; formally assigned 2026-05-08 to reflect agent's compiled-in default and `module.json` services.json seed. |
+| 1944 | `parachute-agent` | committed core | retired | Web UI + agent runtime. Retired 2026-05-20 (see `parachute-agent/DEPRECATED.md`); slot held for historical reference. |
 | 1941 | `parachute-channel` | working module | assigned | Daemon. Exploratory; may retire — not part of the committed ecosystem. |
-| 1945 | unassigned | — | reserved | |
-| 1946 | unassigned | — | reserved | |
+| 1945 | `parachute-runner` | exploration | assigned | Background job runner; spawns `claude -p` against vault jobs. Phase 1 complete; exploration-tier (not committed-core). |
+| 1946 | `parachute-app` | committed core | assigned | UI host module; ships Notes as canonical first app. |
 | 1947 | unassigned | — | reserved | |
 | 1948 | unassigned | — | reserved | |
 | 1949 | unassigned | — | reserved | |
 
 The **committed core** is the set of modules the Parachute ecosystem
-commits to maintaining: hub, vault, notes, scribe, agent. **Working
-modules** like channel exist and run, but the ecosystem does not
-commit to them as long-term first-party citizens.
+commits to maintaining: hub, vault, app, scribe. (The standalone
+notes-daemon is deprecating into `parachute-app`; `parachute-agent`
+retired 2026-05-20.) **Working modules** like channel exist and run,
+but the ecosystem does not commit to them as long-term first-party
+citizens. **Exploration-tier** modules like `parachute-runner` claim
+a slot in the range while they prove out, without a committed-core
+maintenance commitment.
 
 ## Why a fixed range
 

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -10,12 +10,15 @@ open PRs and report status; team-lead reviews and writes a verification
 summary; the repo owner (currently Aaron) clicks merge.
 
 - All Parachute repos with code or content (`parachute-hub`, `parachute-vault`,
-  `parachute-notes`, `parachute-scribe`, `parachute-agent`,
-  `parachute.computer`, `parachute-patterns`) have **branch protection on
-  `main`**: no force-push, no branch deletion, PR-required for changes.
-  `parachute-agent` joined this set on its committed-core promotion
-  (2026-05-05) and is subject to the same review-discipline / RC-versioning /
-  patterns-check rules as the original five.
+  `parachute-app`, `parachute-notes`, `parachute-runner`, `parachute-scribe`,
+  `parachute-agent` (retired), `parachute.computer`, `parachute-patterns`)
+  have **branch protection on `main`**: no force-push, no branch deletion,
+  PR-required for changes. `parachute-agent` joined this set on its
+  committed-core promotion (2026-05-05) and retains branch protection through
+  retirement (2026-05-20) for historical preservation. `parachute-notes`
+  stays protected through the Phase 2-3 deprecation arc; archive happens at
+  Phase 4 (see notes#154). Same review-discipline / RC-versioning /
+  patterns-check rules apply to every protected repo.
 - **Required-review count is calibrated to team size**:
   - **Solo human team (today):** required approvals = `0`. The single human
     *is* both reviewer and merger; a separate "approve" click before "merge"


### PR DESCRIPTION
## Summary

Sweep stale references to the pre-app architecture across three pattern docs. An audit found that committed-core lists, branch-protection lists, and the multi-writer workspace example all still framed Notes as a committed-core daemon and Agent as alive. Notes is now an app under `parachute-app` (the new UI host module); Agent retired 2026-05-20. Aaron hit one of these (hub setup wizard) directly — fixed in hub#324. These three patterns docs are the remaining repo-side stale refs.

## Files changed

- **`patterns/canonical-ports.md`** — mark 1942 `parachute-notes` as `deprecating (Phase 2 — see notes#154)`; mark 1944 `parachute-agent` as `retired`; add 1945 `parachute-runner` (exploration-tier) and 1946 `parachute-app` (committed-core); refresh body text on what committed-core covers (hub, vault, app, scribe) and add a sentence on the exploration tier.
- **`patterns/governance.md`** — add `parachute-app` + `parachute-runner` to the branch-protected list; mark `parachute-agent` parenthetically retired; note that `parachute-notes` stays branch-protected through the Phase 2-3 deprecation arc with archive at Phase 4.
- **`guides/multi-writer-workspace.md`** — replace the optional `parachute-agent` row and the optional `parachute-notes` row in the "Three modules, one workspace" table with `parachute-runner` (job runner) and `parachute-app` (UI host).

Structural shape of each pattern is unchanged; only the module reference set is refreshed.

## Cross-refs

- hub#324 — wizard fix that surfaced this audit
- `parachute-app` (design doc + module)
- notes#154 — Notes deprecation arc
- `parachute-agent/DEPRECATED.md` — retirement note

## Versioning

Doc-only — no rc bump per governance rule 2.

## Test plan

- [ ] Read each section in context; tone matches existing patterns voice
- [ ] No broken cross-references introduced
- [ ] Cross-doc consistency between canonical-ports / governance / multi-writer-workspace on which modules are committed-core
- [ ] Reviewer subagent dispatched (orchestrator)