### PR TITLE
docs(patterns): migration discipline + retroactive Notes-as-app entry + audit script + multi-writer §8 cleanup

### DIFF
--- a/guides/multi-writer-workspace.md
+++ b/guides/multi-writer-workspace.md
@@ -501,26 +501,28 @@ await fetch(`${VAULT_URL}/api/notes/${note.id}/attachments`, {
 // 3. Done. Scribe takes over. The note's content updates async when transcription lands.
 ```
 
-Scribe is vault-level, not Notes-PWA-level — configure scribe once against the vault and every client (Telegram bot, Notes PWA, future agents) gets transcripts as a free service. The Notes UI doesn't need to know transcription is configured; that's vault's concern.
+Scribe is vault-level, not app-UI-level — configure scribe once against the vault and every client (Telegram bot, the Notes app under parachute-app, future custom apps and agents) gets transcripts as a free service. None of the consuming UIs needs to know transcription is configured; that's vault's concern.
 
 ---
 
 ## 8. Agent-as-writer patterns
 
-### parachute-agent vs your own cron
+### parachute-runner vs your own cron
 
 Two paths for agent-driven writes:
 
 **Plain script + cron.** A small Bun/Python/node script that reads its source, talks to vault's REST API or MCP with a long-lived token, runs on a system cron. Lowest-friction shape for one or two scheduled jobs.
 
-**parachute-agent.** A distribution of Claude that runs in containers, with named agent groups, scheduled or webhook-triggered execution, hub-issued auto-rotated tokens, a UI to monitor runs, and first-class vault writes attributable to the agent identity.
+**parachute-runner.** The lightweight successor to the retired parachute-agent (see [`patterns/trust-gradient-isolation.md`](../patterns/trust-gradient-isolation.md) for the architectural reasoning). Runner uses vault itself as the job substrate — operators create notes tagged `#job` with a prompt and a schedule; runner watches for those notes and spawns `claude -p` against each one. Same `claude -p` substrate the operator runs by hand, but supervised and scheduled. Writes are attributable to the runner's hub-minted identity.
 
 Rule of thumb:
 
-- **1–2 scheduled jobs:** plain script + cron. The token-rotation and monitor-UI overhead of parachute-agent doesn't earn its weight yet.
-- **3+ agent groups with distinct scopes + schedules:** parachute-agent. Token rotation handled for you; restart/reconfigure without redeploying scripts; the agent's writes are attributable to its identity in the (forthcoming) per-identity attribution columns.
+- **1–2 scheduled jobs:** plain script + cron. The hub-token + vault-job-substrate overhead of parachute-runner doesn't earn its weight yet.
+- **3+ scheduled jobs with distinct scopes + schedules:** parachute-runner. Vault is already the substrate where jobs are authored; runner reads the job notes, schedules them, and writes results back into vault. No separate orchestration store. Token issuance is hub's job; rotation comes for free.
 
-You can start with a script and migrate to parachute-agent later. The vault doesn't care which is doing the writing; the writes look the same.
+You can start with a script and migrate to parachute-runner later. The vault doesn't care which is doing the writing; the writes look the same.
+
+> Historical note: **parachute-agent** (a containerized Claude distribution) shipped as committed-core 2026-05-05 and retired 2026-05-20. The Gitcoin Brain pattern proved the "Claude in containers" architecture was overengineered for the owner-operated, trusted-vault audience this guide is centered on. parachute-runner is the lightweight primitive that absorbed the use case; parachute-cloud (TBD) will handle multi-tenant container isolation when that demand materializes.
 
 ### Hub-issued scoped tokens for agents
 

--- a/guides/multi-writer-workspace.md
+++ b/guides/multi-writer-workspace.md
@@ -537,7 +537,7 @@ hub tokens mint --identity nightly-source-scraper \
 Two design notes:
 
 1. **Don't use a single service token for many agents.** Each agent gets its own identity, so the attribution columns (when they land — vault#298) tell you which agent did what.
-2. **Token rotation is hub's job.** With parachute-agent, rotation is automatic. With your own scripts, rotate manually via `hub tokens rotate <id>` and update the script's secret store.
+2. **Token rotation is hub's job.** With parachute-runner, rotation is automatic. With your own scripts, rotate manually via `hub tokens rotate <id>` and update the script's secret store.
 
 ### Writing back to the vault from agents
 

--- a/migrations/2026-05-21-notes-as-app.md
+++ b/migrations/2026-05-21-notes-as-app.md
@@ -1,0 +1,159 @@
+---
+title: Notes-as-app migration
+date: 2026-05-21
+status: active
+originating-pr: parachute.computer#54 (parachute-app design doc §16)
+---
+
+# Notes-as-app migration
+
+The first migration tracked under this discipline (and the one that motivated it). Notes was always — conceptually — an "app that consumes a vault," not a backend service. parachute-app shipped 2026-05-21 with auto-bootstrap of `@openparachute/notes-ui`, which collapsed notes-daemon's role to a static-serve wrapper. The architectural shift: **the committed-core line moves from `vault + notes + scribe + hub` to `vault + app + scribe + hub`**, with Notes living as the canonical first app inside parachute-app.
+
+This file is the propagation checklist. It is retroactive — written after the cleanup wave so future contributors see what "fully propagated" looks like for a real shift. The intent is to seed the migrations discipline with an exemplar.
+
+## Why the shift
+
+- **Notes was already a UI bundle.** notes-daemon was a thin Bun static server in front of the Vite build. The "module" in `parachute-notes` was the static server; the *product* was the React app.
+- **Custom UIs needed a home.** Gitcoin Brain (and now Unforced Brain) were external UIs operators wanted hosted under their hub. The choices were: (1) every UI graduates to its own module, or (2) one supervisor hosts N UIs. (2) is parachute-app.
+- **Once parachute-app existed, Notes had to be the first app.** If the canonical first-party UI — the one with deepest cross-cutting integration, longest history as own-module, highest bar to clear — didn't migrate, the architecture wasn't real. Notes-as-first-app is the proof-of-pattern.
+- **The dev-rebuild caching frustration** ([notes#151](https://github.com/ParachuteComputer/parachute-notes/issues/151)) recurred enough that solving it at the platform level (smart cache headers, opt-in PWA, SSE live-reload) was worth the lift. parachute-app made the right default automatic.
+
+Full architectural reasoning: [`parachute.computer/design/2026-05-21-parachute-apps-design.md`](../../parachute.computer/design/2026-05-21-parachute-apps-design.md) — specifically §16 (Notes migration) and §17 (phasing).
+
+## Phase timeline
+
+The shift unfolds across four phases. Phases 1 and 2 are landed; 3 and 4 are scheduled.
+
+### Phase 1 — parachute-app v0.7 MVP (landed 2026-05-21)
+
+- parachute-app ships as a new module: supervisor + per-UI meta.json + DCR-on-add + admin SPA at `/app/admin/`.
+- `@openparachute/notes-ui` published alongside `@openparachute/notes` as a parallel build target — same source, no daemon, just the bundle + meta.json.
+- `parachute-app add @openparachute/notes-ui` works alongside the existing `parachute install notes`. Operators can run either; cloud (TBD) will default to app.
+- Originating PRs: app#1 (Phase 1.1 core hosting), app#2 (Phase 1.2 admin endpoints + DCR + admin SPA), app#3 (Phase 1.3 dev mode with SSE live-reload), app#4 (Phase 2.0 monorepo restructure + extract `@openparachute/app-client` + `required_schema`), app#7 (Phase 2.1 bootstrap-default-apps — auto-install notes-ui on first boot), app#8 (Phase 3.0 file-watcher + auto-rebuild), notes#152 (dual-publish notes-ui), notes#153 (notes-ui adopts `@openparachute/app-client`), notes#155 (notes-ui subclasses app-client VaultClient).
+
+### Phase 2 — notes-daemon deprecation (landed 2026-05-22)
+
+- notes-daemon marked deprecated: DEPRECATED.md, npm `deprecated` field, README banner.
+- hub adds `/notes/*` → `/app/notes/*` 301 redirect so operator bookmarks keep working.
+- hub wizard tile switches from "Install Notes" to "Install App." Curated-modules list keeps notes installable for backwards compatibility but recommends app.
+- Originating PRs: notes#154 (deprecate notes-daemon), hub#316 (redirect), hub#324 (wizard fix), patterns#75 (refresh canonical-ports + governance + multi-writer-workspace).
+
+### Phase 3 — notes-daemon retirement (~Q3 2026)
+
+- notes-daemon `package.json` removed; `@openparachute/notes` (module package) ships its final RC chain.
+- `parachute install notes` removed from hub's install path.
+- Hub's `/notes/*` → `/app/notes/*` redirect runs for one more release window, then retires.
+- Port 1942 reclaimed; reassignable to the next module needing a slot.
+
+### Phase 4 — repo archive (post-1.0)
+
+- Legacy redirect retired entirely.
+- parachute-notes repo either archived (if it has no remaining role) or refactored to be the UI-bundle-only repo (`@openparachute/notes-ui` becomes its sole npm publish).
+- Operators on legacy installs get a one-time migration notice on hub upgrade.
+
+## Code references
+
+Locations that consumed the old "Notes-as-module-installed-via-install-Notes" shape, and which needed updating as the shift propagated. Items are marked `[x]` when landed; `[ ]` when planned/pending.
+
+### parachute-hub
+
+- [x] `src/setup-wizard.ts` `INSTALL_TILE_PROPS` — first tile flipped from `notes` to `app`, with tagline "Host module for Parachute UIs — auto-installs Notes on first boot." (hub#324)
+- [x] `src/api-modules.ts` `CURATED_MODULES` — list reshaped to `["vault", "app", "notes", "scribe", "runner"]`; `notes` retained as back-compat install path. (hub#324)
+- [x] `src/service-spec.ts` `KNOWN_MODULES["app"]` — added with `package: "@openparachute/app"`, `canonicalPort: 1946`, `kind: "frontend"`, `canonicalPaths: ["/app", "/.parachute"]`, `extras.hasAuth: true`. (hub#324)
+- [x] `src/service-spec.ts` `PORT_RESERVATIONS` — `1946 → parachute-app` added with status `assigned`. (hub#324)
+- [x] `src/commands/setup.ts` `BLURBS` — `app` + `runner` entries added; `notes` blurb suffixed `(notes-daemon; superseded by app)`. (hub#324)
+- [x] Hub `/notes/*` → `/app/notes/*` 301 redirect added in `hub-server.ts` with opt-out flag `hub_settings.notes_redirect_disabled`. (hub#316)
+- [x] `web/ui` admin SPA install + upgrade UI surfaces `app` correctly. (hub#304, verified by hub#324 wizard test pass)
+- [x] `src/services-manifest.ts` ServiceEntry hierarchical `uis` schema extension — sub-units under app's row carry per-UI displayName/iconUrl/path. (hub#315)
+- [ ] Hub README port table — already updated to reflect 1942 deprecating + 1946 app committed-core. (landed in hub README at the time of hub#324; no separate PR needed)
+
+### parachute-app
+
+- [x] `parachute-app` module exists, ships `@openparachute/app`, registers `installDir` via standard module-protocol self-registration. (app#1, app#2)
+- [x] `bootstrap-default-apps` step auto-installs `@openparachute/notes-ui` under `/app/notes` on first boot. (app#7)
+- [x] `@openparachute/app-client` extracted as standalone npm package, carrying `VaultClient` + OAuth helpers. (app#4)
+- [x] `meta.json` schema includes `required_schema` for app-side schema-ensure on first install. (app#4)
+- [x] Phase 3.0 file-watcher + auto-rebuild for dev mode. (app#8)
+
+### parachute-notes
+
+- [x] `packages/notes-ui` build target added; publishes as `@openparachute/notes-ui`. (notes#152)
+- [x] notes-ui adopts `@openparachute/app-client` (drops in-repo OAuth/vault code). (notes#153)
+- [x] notes-ui `VaultClient` subclasses app-client's. (notes#155)
+- [x] `packages/notes-daemon/DEPRECATED.md` lands with phased migration steps. (notes#154)
+- [x] `packages/notes-daemon/package.json` carries npm `deprecated` field. (notes#154)
+- [x] `packages/notes-daemon/README.md` carries deprecation banner. (notes#154)
+- [x] Workspace + daemon `CHANGELOG.md` records the deprecation event. (notes#154)
+- [ ] Phase 3: remove `packages/notes-daemon/` from the workspace; final RC chain for `@openparachute/notes` ships. (planned)
+- [ ] Phase 4: archive repo or refactor to UI-only. (planned)
+
+### parachute-patterns
+
+- [x] `patterns/canonical-ports.md` — 1942 marked `deprecating`; 1944 (agent) marked `retired`; 1945 (runner) + 1946 (app) added; body updated to name vault/app/scribe/hub as committed-core. (patterns#75)
+- [x] `patterns/governance.md` — `parachute-app` + `parachute-runner` added to branch-protected list; `parachute-notes` noted as protected through Phase 2-3 then archive at Phase 4. (patterns#75)
+- [x] `guides/multi-writer-workspace.md` — "Three modules, one workspace" table refreshed: `parachute-agent` and old `parachute-notes` rows replaced with `parachute-runner` + `parachute-app`. (patterns#75)
+- [x] `migrations/` directory + this file + README + audit script. (patterns#NN — this PR)
+- [x] `guides/multi-writer-workspace.md` §8 — "parachute-agent vs your own cron" retargeted to parachute-runner. (patterns#NN — this PR)
+
+### parachute.computer (public site)
+
+- [x] `install.njk` — Step 3 ("Want a UI for your notes?") rewritten: `parachute install app`; Notes auto-bootstrapped under `/app/notes/`. Multi-app context added (drop additional SPAs under same host).
+- [x] `index.njk` aside — "Parachute App — the UI host module. Notes (now part of App) ships as the first canonical app… Install more custom UIs — Gitcoin Brain, Unforced Brain, your own — under the same host." Install snippet: `parachute install app`.
+- [x] `deploy/render.njk` — "App (the UI host module, with Notes auto-bootstrapped as the first hosted app)" wording; admin-modules walkthrough mentions installing App auto-bootstraps Notes-UI.
+- [x] `blog/2026-04-23-parachute-is-here.md` — 2026-05-22 update banner pointing to `parachute-app` design doc + noting consolidation to four committed-core modules. Historical install commands preserved verbatim; pointer to live install guide.
+- [x] `design/2026-05-21-parachute-apps-design.md` — the design doc itself; the source of architectural truth.
+- [ ] `since-launch.njk` — review for Notes-PWA framing; existing copy ("Notes header layout," "Per-vault hint") doesn't quote "Notes-the-daemon" so likely fine, but worth a pass when next updating. (planned, low priority — copy was about UX work, not architecture)
+
+### Workspace docs
+
+- [x] Workspace [`CLAUDE.md`](../../../CLAUDE.md) — committed-core table reshaped (vault/app/scribe/hub); `parachute-notes` row moved to deprecating; "Note on parachute-notes migration" paragraph added; "Note on FIRST_PARTY_FALLBACKS" updated to reflect self-registration + KNOWN_MODULES split. (local edit — workspace root is not a git repo)
+- [x] Workspace `CLAUDE.md` — "When making architectural shifts" section pointing at this discipline. (this PR — local edit alongside the patterns commits)
+
+## Doc references
+
+Patterns + guides that quoted the old committed-core list or named notes-as-module.
+
+- [x] `parachute-patterns/patterns/canonical-ports.md` — see Code references. (patterns#75)
+- [x] `parachute-patterns/patterns/governance.md` — see Code references. (patterns#75)
+- [x] `parachute-patterns/patterns/module-self-registration.md` — pre-existing reference says "all four committed-core modules self-register from their own…"; the count is still 4 post-shift (vault/app/scribe/hub), so the sentence remains accurate. Verified during audit; no edit needed.
+- [x] `parachute-patterns/guides/multi-writer-workspace.md` — "Three modules, one workspace" table. (patterns#75)
+- [x] `parachute-patterns/guides/multi-writer-workspace.md` §8 — "parachute-agent vs your own cron" → "parachute-runner vs your own cron." (this PR)
+- [ ] `parachute-patterns/research/parachute-surface-direction.md` — references "Notes PWA" as the active-surface exemplar. Still accurate (Notes-as-app IS the active surface); no edit needed unless framing tightens up later. (no action)
+
+## Operator-facing references
+
+Public-facing surfaces operators read first.
+
+- [x] `parachute.computer/install.njk` — see Code references. (committed in parachute.computer alongside the wider site refresh)
+- [x] `parachute.computer/blog/2026-04-23-parachute-is-here.md` — banner update. (committed alongside the site refresh)
+- [x] `parachute.computer/deploy/render.njk` — see Code references.
+- [x] `parachute-hub/README.md` port table — refreshed to mark 1942 deprecating + 1946 app committed-core. (landed at the time of hub#324)
+- [x] `parachute-notes/packages/notes-daemon/README.md` banner. (notes#154)
+- [ ] `parachute.computer/roadmap.njk` — Notes line still says "Parachute Notes — browser-based companion for your vault. Installable PWA…" which remains accurate (Notes IS a PWA, it just runs under app's supervision now). No load-bearing change needed; small clarifying sentence could be added on next roadmap refresh. (low priority)
+- [ ] `parachute.computer/since-launch.njk` — see Code references. (low priority — copy is UX-focused, not architecture-quoting)
+
+## External references
+
+Offsite surfaces.
+
+- [x] npm `@openparachute/notes` — `deprecated` field set. (notes#154)
+- [x] npm `@openparachute/app` — published. (app#1+)
+- [x] npm `@openparachute/notes-ui` — published. (notes#152)
+- [x] npm `@openparachute/app-client` — published. (app#4)
+- [ ] GitHub repo description for `parachute-notes` — could add "(deprecating; merging into parachute-app)" suffix on the next pass. Not load-bearing. (low priority)
+- [ ] GitHub repo description for `parachute-app` — verify it names "UI host module" prominently. (low priority)
+
+## What the cleanup wave landed
+
+Three days of propagation work (2026-05-21 → 2026-05-22), four repos touched, ~12 PRs across the arc. Items still pending are low-priority cosmetics; the load-bearing surfaces (wizard, install guide, blog banner, patterns docs) all landed within 24 hours of the architectural shift becoming real with parachute-app's MVP ship.
+
+The bug that surfaced this discipline: hub#323 — Aaron walked the setup wizard on a fresh install and saw "Install Notes" instead of "Install App." The wizard tile was the last operator-facing surface still recommending notes-daemon. Fix landed as hub#324. The audit afterward found ~9 more stale references (the patterns docs, the multi-writer-workspace table) that hadn't been updated alongside the architectural design doc. None were operator-blocking; all were doc-quality issues. patterns#75 swept those.
+
+The lesson: an architectural-decision PR (the parachute-app design doc) names "the four committed-core modules become vault + app + scribe + hub" — but that single sentence is quoted (sometimes verbatim) across patterns, site, hub README, workspace CLAUDE.md. Without a propagation checklist in the originating PR, downstream surfaces drift. The migrations discipline closes that gap.
+
+## Cross-references
+
+- [`parachute.computer/design/2026-05-21-parachute-apps-design.md`](../../parachute.computer/design/2026-05-21-parachute-apps-design.md) — the architectural decision (especially §16, §17).
+- [`../patterns/governance.md`](../patterns/governance.md) — review discipline that surrounds migrations.
+- [`../scripts/audit-canonical-refs.sh`](../scripts/audit-canonical-refs.sh) — grep-based audit for the kinds of stale refs that motivated this migration doc.
+- [`parachute-agent/DEPRECATED.md`](https://github.com/ParachuteComputer/parachute-agent/blob/main/DEPRECATED.md) — the 2026-05-20 retirement precedent that informed notes-daemon's DEPRECATED.md shape.

--- a/migrations/2026-05-21-notes-as-app.md
+++ b/migrations/2026-05-21-notes-as-app.md
@@ -65,7 +65,8 @@ Locations that consumed the old "Notes-as-module-installed-via-install-Notes" sh
 - [x] Hub `/notes/*` → `/app/notes/*` 301 redirect added in `hub-server.ts` with opt-out flag `hub_settings.notes_redirect_disabled`. (hub#316)
 - [x] `web/ui` admin SPA install + upgrade UI surfaces `app` correctly. (hub#304, verified by hub#324 wizard test pass)
 - [x] `src/services-manifest.ts` ServiceEntry hierarchical `uis` schema extension — sub-units under app's row carry per-UI displayName/iconUrl/path. (hub#315)
-- [ ] Hub README port table — already updated to reflect 1942 deprecating + 1946 app committed-core. (landed in hub README at the time of hub#324; no separate PR needed)
+- [ ] `parachute-hub/README.md` — port table + module list line (hub#325 in flight)
+- [ ] `parachute-hub/src/service-spec.ts` — `notes` module tagline still reads `"Notes PWA backed by your vault."` (line ~296). Should reframe — notes-daemon is wrapper around notes-ui now. Caught by audit script post-cleanup.
 
 ### parachute-app
 
@@ -92,8 +93,8 @@ Locations that consumed the old "Notes-as-module-installed-via-install-Notes" sh
 - [x] `patterns/canonical-ports.md` — 1942 marked `deprecating`; 1944 (agent) marked `retired`; 1945 (runner) + 1946 (app) added; body updated to name vault/app/scribe/hub as committed-core. (patterns#75)
 - [x] `patterns/governance.md` — `parachute-app` + `parachute-runner` added to branch-protected list; `parachute-notes` noted as protected through Phase 2-3 then archive at Phase 4. (patterns#75)
 - [x] `guides/multi-writer-workspace.md` — "Three modules, one workspace" table refreshed: `parachute-agent` and old `parachute-notes` rows replaced with `parachute-runner` + `parachute-app`. (patterns#75)
-- [x] `migrations/` directory + this file + README + audit script. (patterns#NN — this PR)
-- [x] `guides/multi-writer-workspace.md` §8 — "parachute-agent vs your own cron" retargeted to parachute-runner. (patterns#NN — this PR)
+- [x] `migrations/` directory + this file + README + audit script. (patterns#76 — this PR)
+- [x] `guides/multi-writer-workspace.md` §8 — "parachute-agent vs your own cron" retargeted to parachute-runner. (patterns#76 — this PR)
 
 ### parachute.computer (public site)
 

--- a/migrations/2026-05-21-notes-as-app.md
+++ b/migrations/2026-05-21-notes-as-app.md
@@ -65,7 +65,7 @@ Locations that consumed the old "Notes-as-module-installed-via-install-Notes" sh
 - [x] Hub `/notes/*` → `/app/notes/*` 301 redirect added in `hub-server.ts` with opt-out flag `hub_settings.notes_redirect_disabled`. (hub#316)
 - [x] `web/ui` admin SPA install + upgrade UI surfaces `app` correctly. (hub#304, verified by hub#324 wizard test pass)
 - [x] `src/services-manifest.ts` ServiceEntry hierarchical `uis` schema extension — sub-units under app's row carry per-UI displayName/iconUrl/path. (hub#315)
-- [ ] `parachute-hub/README.md` — port table + module list line (hub#325 in flight)
+- [x] `parachute-hub/README.md` — port table + module list line (hub#325)
 - [ ] `parachute-hub/src/service-spec.ts` — `notes` module tagline still reads `"Notes PWA backed by your vault."` (line ~296). Should reframe — notes-daemon is wrapper around notes-ui now. Caught by audit script post-cleanup.
 
 ### parachute-app

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,53 @@
+# Migrations
+
+A `migration` here means: an architectural shift that changes the canonical shape of the ecosystem (which modules are committed-core, where Notes lives, what the install command is, etc.).
+
+Each architectural-decision PR ships with a corresponding `migrations/YYYY-MM-DD-<slug>.md` file that lists every code/doc location consumers need to update. Future propagation PRs check items off; the file gives a single place to look when you want to know "is this shift fully propagated?"
+
+## When to write one
+
+Make a migration doc when ANY of these are true:
+
+- A committed-core module changes (added, removed, role shifts).
+- The canonical install / setup path changes.
+- A pattern's reference implementation changes module.
+- A doc statement that's quoted elsewhere ("the four committed-core modules") changes.
+
+Skip for: bug fixes, additive features, refactors that don't change canonical shapes.
+
+## Format
+
+Frontmatter: `title`, `date`, `status` (`active` / `complete` / `abandoned`), `originating-pr`.
+
+Body: short context (why the shift), then sections:
+
+- **Code references** — checklist of code locations to update.
+- **Doc references** — checklist of doc locations to update.
+- **Operator-facing references** — public surfaces (READMEs, install guides, blog).
+- **External references** — anything offsite (npm package descriptions, GitHub repo descriptions).
+
+Each item is a checkbox + `repo:path` + (when in flight) the PR number that addresses it.
+
+## Maintenance
+
+- **Active migration:** keep updating as items land.
+- **Complete:** mark status `complete` + leave for historical reference.
+- **Abandoned:** mark status `abandoned` + note why.
+
+Don't delete migration files; they're the historical record.
+
+## Why this discipline exists
+
+The Notes-as-app shift (2026-05-21) caught us out: hub's setup wizard was still hardcoded to "install Notes" as the canonical first install, even though the architecture had shifted to "install App which auto-bootstraps notes-ui." An audit then found ~9 stale references scattered across patterns + site + workspace docs.
+
+Root cause: no discipline linking an architectural-decision PR to all the consumer code/docs that need updating. A migration file in the originating PR would have made the propagation obvious — every downstream surface a check-mark away from "done."
+
+## Example
+
+See [`2026-05-21-notes-as-app.md`](./2026-05-21-notes-as-app.md) for the canonical reference (retroactive — written after the shift to seed the discipline).
+
+## Related
+
+- [`../scripts/audit-canonical-refs.sh`](../scripts/audit-canonical-refs.sh) — grep-based audit script for known stale-reference patterns. Run it after architectural shifts (or before releases) to catch missed propagations.
+- [`../patterns/governance.md`](../patterns/governance.md) — review discipline that surrounds these migrations.
+- Workspace [`CLAUDE.md`](../../CLAUDE.md) — names this discipline as the expected workflow when shipping architectural shifts.

--- a/patterns/canonical-ports.md
+++ b/patterns/canonical-ports.md
@@ -19,7 +19,7 @@ chosen port into the service's `.env`. See
 assignment algorithm, idempotency rules, and the service-side contract
 this doc's reservations get enforced through.
 
-## Reservations (state of the world, 2026-05-08)
+## Reservations (state of the world, 2026-05-22)
 
 | Port | Service | Tier | Status | Notes |
 |---|---|---|---|---|

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,44 @@
+# scripts/
+
+Small operational scripts that help maintain the patterns + the ecosystem they describe. **No application code lives here** — this is a docs/conventions repo; scripts in this directory are tooling around the conventions, not implementations of them.
+
+## Current scripts
+
+- [`audit-canonical-refs.sh`](./audit-canonical-refs.sh) — grep-based audit for stale architectural references across the workspace. Run after architectural shifts (e.g. a new entry in [`../migrations/`](../migrations/)) or before releases to catch propagation misses.
+
+## Adding a script
+
+A script earns its place here when:
+
+- It supports a discipline already documented in `patterns/` or `guides/`.
+- It runs locally, against checked-out repos, with no production access.
+- It's a couple hundred lines or fewer. Larger tooling belongs in its own repo.
+
+When adding one:
+
+1. Drop it in this directory, executable bit set.
+2. Add a usage block at the top of the script (comment block above `set -uo pipefail` or equivalent).
+3. List it in the **Current scripts** section above with a one-line description.
+4. If it's tightly tied to a specific migration, cross-link from the migration doc.
+
+## Adding a new audit class to `audit-canonical-refs.sh`
+
+Each architectural shift produces a new class of stale-reference pattern. When you spot one (during a migration, or via a bug report like hub#323 → hub#324), add a grep block to the script:
+
+```bash
+echo "--- '<pattern description>' ---"
+echo "(<why this is now stale + which migration introduced the shift>)"
+grep -rn --include='*.md' --include='*.tsx' --include='*.ts' --include='*.njk' \
+    -E "<the grep regex>" \
+    "$WORKSPACE" 2>/dev/null | grep -v "$EXCLUDES" | head -20
+echo ""
+```
+
+Keep the script honest:
+
+- One grep block per class of stale ref.
+- Exclude `CHANGELOG`, `migrations/`, `_site`, `node_modules`, `.git/`, `DEPRECATED` by default (already in `$EXCLUDES`).
+- Cite the migration that introduced the shift in the block's intro echo.
+- Cap each block at `head -20` so output stays readable.
+
+The script is not exhaustive — it catches known stale patterns, not unknown ones. Real audits still rely on a human reading the changes against the migration doc. The script is the safety net for the patterns we've already seen drift.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,7 +37,7 @@ echo ""
 Keep the script honest:
 
 - One grep block per class of stale ref.
-- Exclude `CHANGELOG`, `migrations/`, `_site`, `node_modules`, `.git/`, `DEPRECATED` by default (already in `$EXCLUDES`).
+- Exclude `CHANGELOG`, `migrations/`, `_site`, `node_modules`, `.git/`, `DEPRECATED`, `BLOG-OUTLINE` by default (already in `$EXCLUDES`). Workspace-root draft docs (`BLOG-OUTLINE-*.md`, etc.) are expected noise — they legitimately quote stale framing as historical narration; add new filename fragments to `LINE_EXCLUDES` (in the script) the same way `BLOG-OUTLINE` was added if a future draft class leaks through.
 - Cite the migration that introduced the shift in the block's intro echo.
 - Cap each block at `head -20` so output stays readable.
 

--- a/scripts/audit-canonical-refs.sh
+++ b/scripts/audit-canonical-refs.sh
@@ -14,7 +14,7 @@
 # discipline is "one class of stale ref per block" — each block names
 # what it's looking for + cites which migration introduced the shift.
 
-set -uo pipefail
+set -euo pipefail
 
 WORKSPACE="${1:-$HOME/ParachuteComputer}"
 
@@ -38,53 +38,55 @@ GREP_DIR_EXCLUDES=(
 )
 
 # After grep finishes, line-level excludes for files we can't prune via
-# --exclude-dir (CHANGELOGs and DEPRECATED.md files are inside live repos).
-LINE_EXCLUDES='CHANGELOG\|DEPRECATED'
+# --exclude-dir (CHANGELOGs and DEPRECATED.md files are inside live repos;
+# BLOG-OUTLINE-*.md are workspace-root drafts that legitimately quote
+# stale framing as historical narration).
+LINE_EXCLUDES='CHANGELOG\|DEPRECATED\|BLOG-OUTLINE'
 
 echo "=== Auditing canonical-architecture references in $WORKSPACE ==="
 echo ""
 
 echo "--- 'install Notes' / 'parachute install notes' ---"
 echo "(should be 'install App' per Notes-as-app migration 2026-05-21)"
-grep -rn "${GREP_DIR_EXCLUDES[@]}" \
+{ grep -rn "${GREP_DIR_EXCLUDES[@]}" \
     --include='*.md' --include='*.tsx' --include='*.ts' --include='*.njk' \
     -E "parachute install notes|install Notes|Install Notes" \
-    "$WORKSPACE" 2>/dev/null | grep -v "$LINE_EXCLUDES" | head -20
+    "$WORKSPACE" 2>/dev/null | grep -v "$LINE_EXCLUDES" | head -20; } || true
 echo ""
 
 echo "--- 'four committed-core' / 'five committed-core' ---"
 echo "(post-Notes-as-app: four — vault/app/scribe/hub. Anything saying 'five' is stale)"
-grep -rn "${GREP_DIR_EXCLUDES[@]}" \
+{ grep -rn "${GREP_DIR_EXCLUDES[@]}" \
     --include='*.md' --include='*.njk' \
     -E "four committed.core|five committed.core" \
-    "$WORKSPACE" 2>/dev/null | grep -v "$LINE_EXCLUDES" | head -20
+    "$WORKSPACE" 2>/dev/null | grep -v "$LINE_EXCLUDES" | head -20; } || true
 echo ""
 
 echo "--- 'Notes — frontend PWA' / 'Notes PWA backed by' (legacy framing) ---"
 echo "(Notes is hosted by parachute-app now; 'Notes — frontend PWA' wording is stale)"
-grep -rn "${GREP_DIR_EXCLUDES[@]}" \
+{ grep -rn "${GREP_DIR_EXCLUDES[@]}" \
     --include='*.md' --include='*.tsx' --include='*.ts' --include='*.njk' \
     -E "Notes — frontend PWA|Notes PWA backed by" \
-    "$WORKSPACE" 2>/dev/null | grep -v "$LINE_EXCLUDES" | head -20
+    "$WORKSPACE" 2>/dev/null | grep -v "$LINE_EXCLUDES" | head -20; } || true
 echo ""
 
 echo "--- hardcoded port 1942 outside parachute-notes ---"
 echo "(1942 is the deprecating notes-daemon port; new operator-facing copy should point at /app/notes via hub)"
-grep -rn "${GREP_DIR_EXCLUDES[@]}" \
+{ grep -rn "${GREP_DIR_EXCLUDES[@]}" \
     --include='*.md' --include='*.tsx' --include='*.ts' --include='*.njk' \
     -E ":1942|port: 1942|port=1942" \
-    "$WORKSPACE" 2>/dev/null | grep -v "$LINE_EXCLUDES" | grep -v "parachute-notes\|canonical-ports\|service-spec" | head -20
+    "$WORKSPACE" 2>/dev/null | grep -v "$LINE_EXCLUDES" | grep -v "parachute-notes\|canonical-ports\|service-spec" | head -20; } || true
 echo ""
 
 echo "--- 'parachute-agent' (retired 2026-05-20) outside retirement/historical docs ---"
 echo "(operator-facing docs should reference parachute-runner; agent retired)"
-grep -rn "${GREP_DIR_EXCLUDES[@]}" \
+{ grep -rn "${GREP_DIR_EXCLUDES[@]}" \
     --include='*.md' --include='*.tsx' --include='*.ts' --include='*.njk' \
     -E "parachute-agent|parachute_agent" \
     "$WORKSPACE" 2>/dev/null \
     | grep -v "$LINE_EXCLUDES" \
     | grep -v "parachute-agent/\|trust-gradient\|retired\|governance\|FALLBACK\|service-spec\|loadAgents\|RELEASE-NOTES\|WAKE-UP\|BETA-EMAIL\|launch-day" \
-    | head -20
+    | head -20; } || true
 echo ""
 
 echo "=== Done. Review findings; cross-check against migrations/*.md. ==="

--- a/scripts/audit-canonical-refs.sh
+++ b/scripts/audit-canonical-refs.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Audit canonical-architecture references across the workspace.
+#
+# Run after architectural shifts, before releases, or whenever you suspect
+# stale refs. Output is grep results grouped by class of stale pattern —
+# review by hand, cross-check against the relevant migrations/*.md.
+#
+# Usage:
+#   ./scripts/audit-canonical-refs.sh [/path/to/workspace]
+#
+# Default workspace path: ~/ParachuteComputer
+#
+# Adding new patterns: drop a new "echo" + "grep" block below. The
+# discipline is "one class of stale ref per block" — each block names
+# what it's looking for + cites which migration introduced the shift.
+
+set -uo pipefail
+
+WORKSPACE="${1:-$HOME/ParachuteComputer}"
+
+if [[ ! -d "$WORKSPACE" ]]; then
+  echo "error: workspace dir not found: $WORKSPACE" >&2
+  exit 1
+fi
+
+# Shared grep args:
+#   --exclude-dir prunes vendor/build/git dirs from descent (the slow part).
+#   The migrations/ dir is excluded because it deliberately quotes stale patterns
+#   for historical reference.
+GREP_DIR_EXCLUDES=(
+  --exclude-dir=node_modules
+  --exclude-dir=_site
+  --exclude-dir=.git
+  --exclude-dir=dist
+  --exclude-dir=build
+  --exclude-dir=.next
+  --exclude-dir=migrations
+)
+
+# After grep finishes, line-level excludes for files we can't prune via
+# --exclude-dir (CHANGELOGs and DEPRECATED.md files are inside live repos).
+LINE_EXCLUDES='CHANGELOG\|DEPRECATED'
+
+echo "=== Auditing canonical-architecture references in $WORKSPACE ==="
+echo ""
+
+echo "--- 'install Notes' / 'parachute install notes' ---"
+echo "(should be 'install App' per Notes-as-app migration 2026-05-21)"
+grep -rn "${GREP_DIR_EXCLUDES[@]}" \
+    --include='*.md' --include='*.tsx' --include='*.ts' --include='*.njk' \
+    -E "parachute install notes|install Notes|Install Notes" \
+    "$WORKSPACE" 2>/dev/null | grep -v "$LINE_EXCLUDES" | head -20
+echo ""
+
+echo "--- 'four committed-core' / 'five committed-core' ---"
+echo "(post-Notes-as-app: four — vault/app/scribe/hub. Anything saying 'five' is stale)"
+grep -rn "${GREP_DIR_EXCLUDES[@]}" \
+    --include='*.md' --include='*.njk' \
+    -E "four committed.core|five committed.core" \
+    "$WORKSPACE" 2>/dev/null | grep -v "$LINE_EXCLUDES" | head -20
+echo ""
+
+echo "--- 'Notes — frontend PWA' / 'Notes PWA backed by' (legacy framing) ---"
+echo "(Notes is hosted by parachute-app now; 'Notes — frontend PWA' wording is stale)"
+grep -rn "${GREP_DIR_EXCLUDES[@]}" \
+    --include='*.md' --include='*.tsx' --include='*.ts' --include='*.njk' \
+    -E "Notes — frontend PWA|Notes PWA backed by" \
+    "$WORKSPACE" 2>/dev/null | grep -v "$LINE_EXCLUDES" | head -20
+echo ""
+
+echo "--- hardcoded port 1942 outside parachute-notes ---"
+echo "(1942 is the deprecating notes-daemon port; new operator-facing copy should point at /app/notes via hub)"
+grep -rn "${GREP_DIR_EXCLUDES[@]}" \
+    --include='*.md' --include='*.tsx' --include='*.ts' --include='*.njk' \
+    -E ":1942|port: 1942|port=1942" \
+    "$WORKSPACE" 2>/dev/null | grep -v "$LINE_EXCLUDES" | grep -v "parachute-notes\|canonical-ports\|service-spec" | head -20
+echo ""
+
+echo "--- 'parachute-agent' (retired 2026-05-20) outside retirement/historical docs ---"
+echo "(operator-facing docs should reference parachute-runner; agent retired)"
+grep -rn "${GREP_DIR_EXCLUDES[@]}" \
+    --include='*.md' --include='*.tsx' --include='*.ts' --include='*.njk' \
+    -E "parachute-agent|parachute_agent" \
+    "$WORKSPACE" 2>/dev/null \
+    | grep -v "$LINE_EXCLUDES" \
+    | grep -v "parachute-agent/\|trust-gradient\|retired\|governance\|FALLBACK\|service-spec\|loadAgents\|RELEASE-NOTES\|WAKE-UP\|BETA-EMAIL\|launch-day" \
+    | head -20
+echo ""
+
+echo "=== Done. Review findings; cross-check against migrations/*.md. ==="
+echo ""
+echo "Notes:"
+echo "  - Vendor/build dirs (node_modules, _site, dist, build, .next, .git, migrations) are pruned via --exclude-dir."
+echo "  - CHANGELOGs + DEPRECATED.md are excluded line-level (they're historical record)."
+echo "  - parachute-notes/canonical-ports.md/service-spec.ts are excluded from the port-1942 check (they're the canonical source)."
+echo "  - parachute-agent retirement docs + launch-day artifacts are excluded from the agent check."
+echo "  - Add new grep blocks above when you hit a new class of stale ref."


### PR DESCRIPTION
## Summary

Structural improvements to prevent stale-architecture-reference bugs like the recent
Notes-as-app wizard miss (hub#323 → hub#324). Aaron walked the setup wizard on a fresh
install and saw an "Install Notes" tile — the wizard was still recommending notes-daemon
as the canonical first install even though the architecture had shifted to "install App
which auto-bootstraps notes-ui." An audit afterward found ~9 more stale references
scattered across patterns + site + workspace docs. Root cause: no discipline linking an
architectural-decision PR to all the consumer code/docs that need updating.

This PR introduces three structural improvements:

1. **`migrations/` discipline** — architectural-decision PRs ship with a
   `migrations/YYYY-MM-DD-<slug>.md` propagation checklist in the same PR. Each
   downstream surface a check-mark away from "done."
2. **Retroactive Notes-as-app migration doc** — the canonical exemplar (since the
   shift is fresh and the cleanup work is recent). Captures the 4-phase arc with per-
   surface checkboxes: Phase 1 + 2 marked `[x]` with PR numbers (~12 PRs across
   app/notes/hub/patterns), Phase 3 + 4 marked `[ ]` as planned.
3. **`scripts/audit-canonical-refs.sh`** — grep-based safety net for known classes of
   stale refs. Output verified against the live workspace.

Plus a §8 + §7 cleanup in `guides/multi-writer-workspace.md` that the earlier audit
flagged: §8 still taught the retired `parachute-agent` pattern; updated to target
`parachute-runner` (the lightweight successor for owner-operated automation).

## Files

- **`migrations/README.md`** (new) — when to write a migration doc, the format
  (frontmatter + checkboxes by surface), maintenance discipline, why the practice
  exists.
- **`migrations/2026-05-21-notes-as-app.md`** (new) — retroactive exemplar. Frontmatter
  (active status, originating-pr); context paragraph (why the shift); 4-phase
  timeline; checkboxes across **Code references** (hub, parachute-app, parachute-notes,
  parachute-patterns), **Doc references**, **Operator-facing references**, **External
  references**. Cross-links to parachute-app design doc §16.
- **`scripts/audit-canonical-refs.sh`** (new, executable) — five audit blocks today:
  install-Notes wording, committed-core count (`four` vs `five`), "Notes — frontend
  PWA" / "Notes PWA backed by" framing, hardcoded port 1942 outside notes-daemon,
  parachute-agent references outside retirement/historical docs. `--exclude-dir`
  prunes node_modules/_site/dist/.git/migrations to stay fast.
- **`scripts/README.md`** (new) — what scripts/ is for + how to add new audit grep
  blocks.
- **`guides/multi-writer-workspace.md`** — §8 retitled "parachute-runner vs your own
  cron" with example rewritten around runner's vault-as-job-substrate shape;
  historical note appended on the agent → runner shift. §7 refreshed to "app-UI-level"
  framing with the consumer list updated (Notes app under parachute-app, future custom
  apps and agents).

Companion: a local edit to `~/ParachuteComputer/CLAUDE.md` (the workspace root, not a
git repo) adds a "When making architectural shifts" section pointing at this discipline
+ the audit script.

## Audit script — sample output

Run against the live workspace:

```
--- 'install Notes' / 'parachute install notes' ---
  ~18 hits — all legitimate: hub back-compat install path, notes-daemon README
  (deprecation banner + Phase 2-3 history), hub tests, launch-day historical
  artifacts. Research doc (`auth-architecture-shape.md`) discusses the install
  path in historical context.

--- 'four committed-core' / 'five committed-core' ---
  6 hits — five are current (post-Notes-as-app, the count IS four). One stale
  in `BLOG-OUTLINE-export-as-projection.md` ("five committed-core … with notes,
  hub, scribe, agent") which is a historical blog outline.

--- 'Notes PWA backed by your vault' ---
  3 hits in hub `service-spec.ts` + tests — the curated tagline for the notes
  install entry. Real signal: could be refreshed in a future hub pass when the
  curated entry's tagline gets a touch-up.

--- port 1942 outside parachute-notes ---
  18 hits — all hub tests + back-compat code (`/notes/*` redirect surfaces the
  port in test fixtures). Expected.

--- parachute-agent (retired 2026-05-20) outside retirement docs ---
  16 hits in parachute-patterns/research/ + a few patterns/ docs — all historical
  (auth-architecture-shape's §2.4 history, cli-as-port-authority's rename note,
  oauth-scopes' `agent:` scope registry, tag-data-model's per-module table).
  Reviewer can decide if a future pass refreshes any of them; none are
  operator-facing.
```

Findings cross-checked against `migrations/2026-05-21-notes-as-app.md` — the script
surfaces the same low-priority items the migration doc lists as `[ ]` pending.

## Cross-refs

- **hub#324** — wizard fix that surfaced this audit (the operator-facing miss).
- **hub#323** — the bug report.
- **parachute-app design doc §16** — architectural source for the Notes-as-app shift;
  retroactive migration doc cross-links throughout.
- **notes#154, #152, #153, #155; app#1–#8; hub#316, #324** — the cleanup-wave PRs that
  landed during the shift (all marked `[x]` with PR numbers in the migration doc).
- **patterns#75** — sibling sweep of patterns docs (canonical-ports, governance,
  multi-writer-workspace table); landed yesterday. This PR's §8 update is the
  remaining stale ref flagged in that audit.

## Patterns check

- **Touches** the docs-only PR pattern (RC bump skipped per governance rule 2).
- **Establishes** the migrations/ discipline as a new convention. Cross-referenced
  from `patterns/governance.md`'s review flow indirectly (via the workspace
  CLAUDE.md edit) and from the migrations README itself.
- **Conforms** to existing patterns repo conventions (one screen per file where
  possible; the migration doc is longer because it's load-bearing as the exemplar).

## Versioning

Doc-only — no rc bump per governance rule 2.

## Test plan

- [x] `migrations/README.md` reads cleanly
- [x] `migrations/2026-05-21-notes-as-app.md` reads cleanly; checkbox status verified
      against actual PRs that landed
- [x] `scripts/audit-canonical-refs.sh` is executable (`-rwxr-xr-x`); runs without
      error from any directory; uses `--exclude-dir` to skip node_modules/_site/etc.
      so it finishes in under a minute on the full workspace
- [x] `guides/multi-writer-workspace.md` §7 + §8 updates preserve the existing flow
- [ ] Reviewer subagent dispatch (orchestrator)