### PR TITLE
docs(patterns): services-json row conventions + audit script extension (closes duplicate-port bug shape)

### DIFF
--- a/migrations/2026-05-21-notes-as-app.md
+++ b/migrations/2026-05-21-notes-as-app.md
@@ -95,6 +95,10 @@ Locations that consumed the old "Notes-as-module-installed-via-install-Notes" sh
 - [x] `guides/multi-writer-workspace.md` — "Three modules, one workspace" table refreshed: `parachute-agent` and old `parachute-notes` rows replaced with `parachute-runner` + `parachute-app`. (patterns#75)
 - [x] `migrations/` directory + this file + README + audit script. (patterns#76 — this PR)
 - [x] `guides/multi-writer-workspace.md` §8 — "parachute-agent vs your own cron" retargeted to parachute-runner. (patterns#76 — this PR)
+- [x] `patterns/services-json-row-conventions.md` — canonicalized the row-naming rule that the duplicate-port bug revealed (patterns#77 — this PR)
+- [x] `scripts/audit-canonical-refs.sh` — `self-register row name` block added to catch the bug shape going forward (patterns#77 — this PR)
+- [x] `parachute-app#13` — app self-register row key fix (`name: "app"` → `name: ROW_NAME` derived from `manifestName`)
+- [x] `parachute-runner#4` — runner self-register row key fix (mirror of app#13)
 
 ### parachute.computer (public site)
 

--- a/patterns/services-json-row-conventions.md
+++ b/patterns/services-json-row-conventions.md
@@ -1,0 +1,123 @@
+# services.json row conventions
+
+> Each module's row in `~/.parachute/services.json` is keyed by
+> `manifestName` (e.g. `"parachute-vault"`) — NOT the short name
+> (`"vault"`). Self-register writes and hub install writes must agree on
+> the key, or you get duplicate rows fighting over the same port.
+
+## The convention (TL;DR)
+
+When a module self-registers via the canonical pattern (see
+[`module-self-registration.md`](./module-self-registration.md)), the
+`ServiceEntry` written to `~/.parachute/services.json` MUST use the
+module's `manifestName` as the row's `name`:
+
+```ts
+const entry: ServiceEntry = {
+  name: manifest.manifestName,  // "parachute-<short>", NOT "<short>"
+  port: ...,
+  paths: ...,
+  // ... etc
+};
+```
+
+Hub looks up rows by `manifestName`. Hub's install path writes new rows
+keyed on `manifestName`. If self-register writes the short name and
+install writes the manifestName, hub sees two rows — and the next
+services.json read fails with `duplicate port <N> — claimed by both
+"<short>" and "parachute-<short>"`.
+
+## Why — the constraint that produced it
+
+Hub's install path
+([`parachute-hub/src/api-modules-ops.ts`](https://github.com/ParachuteComputer/parachute-hub/blob/main/src/api-modules-ops.ts))
+uses `findService(spec.manifestName)` to detect existing rows and
+writes new rows with `name: spec.manifestName`. Examples from that
+file:
+
+```ts
+const existing = findService(spec.manifestName, deps.manifestPath);
+// ...
+const entry = { manifestName: spec.manifestName, /* ... */ };
+```
+
+The CLI surface (`parachute install <short>`) accepts the short name
+from operators, but internally resolves to `manifestName` for every
+services.json operation. The split is intentional — short is
+human-friendly, `manifestName` is the canonical key.
+
+If a module's self-register writes a row with the short name and the
+install path later writes the same module's row keyed on
+`manifestName`, you end up with two rows pointing at the same daemon
+on the same port. services.json readers that enforce port-uniqueness
+(hub's port-collision check, the admin SPA catalog) reject the file
+with a duplicate-port error. The daemon won't start until the
+duplicate row is removed by hand.
+
+## Examples (canonical implementations)
+
+- vault: [`parachute-vault/src/self-register.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/self-register.ts) — `name: manifest.manifestName`
+- scribe: [`parachute-scribe/src/self-register.ts`](https://github.com/ParachuteComputer/parachute-scribe/blob/main/src/self-register.ts) — `name: module.manifestName`
+- app: [`parachute-app/packages/app-host/src/self-register.ts`](https://github.com/ParachuteComputer/parachute-app/blob/main/packages/app-host/src/self-register.ts) — `name: ROW_NAME` (pre-resolved from `module.json`'s `manifestName` at module scope)
+- runner: [`parachute-runner/src/self-register.ts`](https://github.com/ParachuteComputer/parachute-runner/blob/main/src/self-register.ts) — same pattern as app
+
+The `ROW_NAME` const variant (app + runner) is slightly safer than the
+inline `manifest.manifestName` variant (vault + scribe): the row name
+is resolved once at module load, used for both `readServiceEntry` and
+the entry write, so the read and write keys are guaranteed identical.
+Both shapes are correct — the load-bearing rule is that the key
+matches `manifestName`.
+
+## The CLI surface uses the short name; everything else uses manifestName
+
+| Surface | Identifier shape | Example |
+| --- | --- | --- |
+| Operator CLI (`parachute install`, `parachute restart`) | short | `parachute install app` |
+| services.json row `name` field | manifestName | `"parachute-app"` |
+| Hub `findService` lookups | manifestName | `findService("parachute-app")` |
+| Module-discovery URL paths | short or per-paths from `module.json` | `/app/...` |
+| npm package name | scoped manifestName | `@openparachute/app` |
+
+The CLI translates short → `manifestName` at the boundary; downstream
+code never sees the short name. The two namespaces share a stem
+(`<short>` ⇄ `parachute-<short>`) but they're separate identifier
+spaces — don't conflate.
+
+## Future-proofing — checklist for a new module
+
+When writing a new module's self-register:
+
+1. Set `manifestName` in `.parachute/module.json` to the npm package
+   slug (e.g. `@openparachute/<name>` → `manifestName:
+   "parachute-<name>"`).
+2. In self-register, set `name: manifest.manifestName` — or hoist to a
+   `ROW_NAME` const at module scope (app/runner style) and reference
+   that same const in every services.json read/write call.
+3. Run [`scripts/audit-canonical-refs.sh`](../scripts/audit-canonical-refs.sh)
+   from the workspace root; the
+   `self-register row name` block will flag any literal short-name
+   write.
+
+## History
+
+- **2026-05-22**: Aaron hit a `duplicate port 1946 — claimed by both
+  "parachute-app" and "app"` error walking a fresh install. Root cause:
+  parachute-app's self-register wrote `name: "app"` while hub's install
+  path had earlier stamped `name: "parachute-app"`. Same shape latent
+  in parachute-runner (`name: "runner"`). Fixed inline in
+  [parachute-app#13](https://github.com/ParachuteComputer/parachute-app/pull/13)
+  and
+  [parachute-runner#4](https://github.com/ParachuteComputer/parachute-runner/pull/4).
+  Pattern doc landed same day to prevent recurrence; audit script
+  extended to catch the bug shape going forward.
+
+## Related patterns
+
+- [`module-self-registration.md`](./module-self-registration.md) — the
+  broader self-register pattern this convention lives within. Row
+  identity is the single load-bearing field self-register has to get
+  right.
+- [`canonical-ports.md`](./canonical-ports.md) — the port-uniqueness
+  invariant that duplicate-rows-with-same-port violate.
+- [`module-json-extensibility.md`](./module-json-extensibility.md) —
+  where `manifestName` lives and what shape it takes.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,7 +23,7 @@ When adding one:
 
 ## Adding a new audit class to `audit-canonical-refs.sh`
 
-Each architectural shift produces a new class of stale-reference pattern. When you spot one (during a migration, or via a bug report like hub#323 → hub#324), add a grep block to the script:
+Each architectural shift produces a new class of stale-reference pattern. When you spot one (during a migration, or via a bug report like hub#323 → hub#324, or via a bug-shape like the parachute-app#13 / parachute-runner#4 duplicate-port-row regression), add a grep block to the script:
 
 ```bash
 echo "--- '<pattern description>' ---"
@@ -40,5 +40,10 @@ Keep the script honest:
 - Exclude `CHANGELOG`, `migrations/`, `_site`, `node_modules`, `.git/`, `DEPRECATED`, `BLOG-OUTLINE` by default (already in `$EXCLUDES`). Workspace-root draft docs (`BLOG-OUTLINE-*.md`, etc.) are expected noise — they legitimately quote stale framing as historical narration; add new filename fragments to `LINE_EXCLUDES` (in the script) the same way `BLOG-OUTLINE` was added if a future draft class leaks through.
 - Cite the migration that introduced the shift in the block's intro echo.
 - Cap each block at `head -20` so output stays readable.
+
+Not every block has to fit the `--include='*.md'` shape. The `self-register row name` block, for example, walks a discovered list of `self-register.ts` files (under `parachute-*/src` and `parachute-*/packages/*/src`) and runs a focused regex per-file rather than a workspace-wide grep. Use whichever shape gives the cleanest signal:
+
+- **Workspace-wide grep** when the stale ref is text that could appear anywhere (doc copy, comments, hardcoded ports).
+- **Discover-then-check** when the bug shape is structural — a specific kind of file where a specific line shape is wrong (the convention violation in [`patterns/services-json-row-conventions.md`](../patterns/services-json-row-conventions.md), wrong import path, missing required field). Cite the pattern doc that establishes the convention.
 
 The script is not exhaustive — it catches known stale patterns, not unknown ones. Real audits still rely on a human reading the changes against the migration doc. The script is the safety net for the patterns we've already seen drift.

--- a/scripts/audit-canonical-refs.sh
+++ b/scripts/audit-canonical-refs.sh
@@ -89,6 +89,25 @@ echo "(operator-facing docs should reference parachute-runner; agent retired)"
     | head -20; } || true
 echo ""
 
+echo "--- self-register row name written as literal short name ---"
+echo "(should be \`name: manifest.manifestName\` or \`name: ROW_NAME\` per services-json-row-conventions; literal short names create duplicate-port rows)"
+{
+  # Discover self-register.ts under any first-party package layout (src/ or
+  # packages/*/src/). Sort + uniq so the broad glob doesn't re-list the
+  # explicit set above. Quiet `find` so missing dirs don't noise the output.
+  find "$WORKSPACE"/parachute-*/src \
+       "$WORKSPACE"/parachute-*/packages/*/src \
+       -maxdepth 1 -name self-register.ts -type f 2>/dev/null \
+    | sort -u
+} | while read -r f; do
+  hits=$(grep -nE "^\s+name:\s*\"[a-z][a-z-]+\"" "$f" 2>/dev/null || true)
+  if [[ -n "$hits" ]]; then
+    echo "$hits"
+    echo "  ^ $f writes a literal short name as services.json row identity — should be manifestName"
+  fi
+done
+echo ""
+
 echo "=== Done. Review findings; cross-check against migrations/*.md. ==="
 echo ""
 echo "Notes:"


### PR DESCRIPTION
## Summary

- **New pattern**: [`patterns/services-json-row-conventions.md`](./patterns/services-json-row-conventions.md) canonicalizes the rule that each module's services.json row is keyed by `manifestName` (e.g. `"parachute-vault"`), NOT the short name (`"vault"`). Hub looks up rows by manifestName, and hub's install path writes rows keyed on manifestName, so self-register has to agree or you get duplicate rows fighting over the same port.
- **Audit script extension**: `scripts/audit-canonical-refs.sh` gets a new `self-register row name` block that walks every `parachute-*/{src,packages/*/src}/self-register.ts` and flags any `name: "<short>"` literal — the exact bug shape that produced Aaron's `duplicate port 1946 — claimed by both "parachute-app" and "app"` error.
- **Migration doc updated**: the Notes-as-app migration's parachute-patterns checklist records both the pattern doc and the audit block as shipped under this PR; also records parachute-app#13 + parachute-runner#4 as the originating bug fixes that surfaced the convention.

## Originating bug

2026-05-22: Aaron walked a fresh install and hit `duplicate port 1946 — claimed by both "parachute-app" and "app"`. Root cause: parachute-app's self-register wrote `name: "app"` while hub's install path had earlier stamped `name: "parachute-app"`. Same shape latent in parachute-runner (`name: "runner"`).

Fixed inline:
- **parachute-app#13** — `name: "app"` → `name: ROW_NAME` (resolved from `module.json`'s `manifestName`)
- **parachute-runner#4** — mirror of app#13

This PR canonicalizes the convention so the next module author can't repeat it.

## Why a pattern doc + audit block instead of just the inline fixes

The two repos are fixed. The convention isn't documented anywhere — and the bug shape is silent (no test catches it; the error only surfaces when an operator runs `parachute install <module>` after the module's own boot has written a row). New modules will hit it the same way unless we name the rule and give the audit script a chance to spot it.

## Verification

Audit script output against the current workspace (no findings — all four current self-register sites use the canonical pattern):

```
--- self-register row name written as literal short name ---
(should be `name: manifest.manifestName` or `name: ROW_NAME` per services-json-row-conventions; literal short names create duplicate-port rows)
```

Verified it fires when broken: temporarily edited `parachute-app/packages/app-host/src/self-register.ts` `name: ROW_NAME` → `name: "app"` and re-ran:

```
139:    name: "app",
  ^ /Users/parachute/ParachuteComputer/parachute-app/packages/app-host/src/self-register.ts writes a literal short name as services.json row identity — should be manifestName
```

App file restored before commit; no working-tree changes outside the patterns repo.

## Patterns check

- Establishes a new pattern (`services-json-row-conventions.md`). Sibling pattern (`module-self-registration.md`) cross-references it; the new doc is the narrower convention living inside that broader pattern.
- Doc-only — no rc bump per governance rule 2.
- Reviewer dispatch + Aaron's merge per governance rule 1.

## Test plan

- [ ] Reviewer reads `patterns/services-json-row-conventions.md` end-to-end for clarity.
- [ ] Reviewer runs `bash scripts/audit-canonical-refs.sh` against `~/ParachuteComputer` and confirms the new block reports zero findings.
- [ ] Reviewer verifies the migration doc entry under "parachute-patterns" lists the new pattern doc + audit block under this PR.