### PR TITLE
docs(patterns): runtime-tenancy-contract + app-bundle-shape v2 (mount-agnosticism)

### DIFF
--- a/patterns/app-bundle-shape.md
+++ b/patterns/app-bundle-shape.md
@@ -90,9 +90,11 @@ Specifically:
   [notes-ui#160](https://github.com/ParachuteComputer/parachute-notes/issues/160)
   for the reference implementation).
 
-The runtime mount is provided by the host via injected meta tag
-(`<meta name="parachute-mount" content="/app/<name>">`). Read it
-through `@openparachute/app-client`; don't regex-detect from
+The runtime mount is provided by the host via injected meta tags. The
+canonical set is `parachute-mount` (the mount path), `parachute-hub`
+(hub origin), `parachute-vault` (bound vault path, when applicable),
+`parachute-tenant-id` (tenant's logical name). Read them through
+`@openparachute/app-client`; don't regex-detect from
 `window.location.pathname` (that pattern was the interim during
 notes-ui's 0.1.1 rollout — phasing out as app-client lands).
 

--- a/patterns/app-bundle-shape.md
+++ b/patterns/app-bundle-shape.md
@@ -64,6 +64,42 @@ Vault hosts named vaults; app hosts named apps. Same shape, different
 content. The pattern doc canonicalizes the contract so future apps
 (and a future scaffolder) point at one source.
 
+## Mount-agnosticism
+
+An app bundle MUST work at any `/app/<name>/` mount where `<name>` is
+set by the operator at install time. Don't bake in a specific path.
+
+Specifically:
+
+- **Vite build with `base: ""`** — emits relative asset URLs that
+  work at any mount when paired with the host's `<base href>`
+  injection (see
+  [`runtime-tenancy-contract.md`](./runtime-tenancy-contract.md)).
+- **React Router `basename`** derived at runtime via
+  `@openparachute/app-client#getMountBase()`. Don't read
+  `import.meta.env.BASE_URL` for the basename.
+- **OAuth callback URLs** derived from the runtime mount. The DCR
+  (Dynamic Client Registration) flow registers redirect URIs that
+  match the actual mount.
+- **PWA manifest `start_url` / `scope`** are an acknowledged
+  limitation — PWA install requires a build-time-pinned base because
+  `manifest.webmanifest`'s URLs are static. Operators who want PWA at
+  non-default mounts must build with `VITE_BASE_PATH=/app/<name>/`.
+  The bundle should DETECT the mismatch and skip SW registration
+  gracefully (see
+  [notes-ui#160](https://github.com/ParachuteComputer/parachute-notes/issues/160)
+  for the reference implementation).
+
+The runtime mount is provided by the host via injected meta tag
+(`<meta name="parachute-mount" content="/app/<name>">`). Read it
+through `@openparachute/app-client`; don't regex-detect from
+`window.location.pathname` (that pattern was the interim during
+notes-ui's 0.1.1 rollout — phasing out as app-client lands).
+
+For the full host↔tenant runtime metadata contract — including
+`<base href>` injection, hub origin, and bound vault discovery — see
+[`runtime-tenancy-contract.md`](./runtime-tenancy-contract.md).
+
 ## The `meta.json` fields
 
 Quick reference. Canonical source:
@@ -232,6 +268,9 @@ These build on this pattern doc as the contract:
 - [`mount-path-convention.md`](./mount-path-convention.md) — how an
   SPA at `/app/<name>/` configures its routing (`base` / `basename` /
   internal routes).
+- [`runtime-tenancy-contract.md`](./runtime-tenancy-contract.md) — the
+  host↔tenant runtime metadata handshake that makes mount-agnostic
+  bundles possible.
 - [`canonical-ports.md`](./canonical-ports.md) — apps don't have
   ports; backend modules do. Reference for the other side.
 - [`oauth-scopes.md`](./oauth-scopes.md) — scope-string shape that
@@ -258,3 +297,11 @@ These build on this pattern doc as the contract:
   scaffolder) have a single source to point at. The Phase 2.0
   `required_schema`, Phase 3.0 `dev_*` knobs, PWA fields, and
   `public` are all live in `meta-schema.ts` as of this doc.
+- **2026-05-23 (v2)** — Mount-agnosticism section added. Aaron's
+  install loop revealed that bundles with `VITE_BASE_PATH` baked in
+  broke at operator-chosen mounts; notes-ui#159 shipped interim regex
+  detection, and the canonical answer became explicit host-injected
+  metadata — see
+  [`runtime-tenancy-contract.md`](./runtime-tenancy-contract.md).
+  Closes
+  [parachute-patterns#80](https://github.com/ParachuteComputer/parachute-patterns/issues/80).

--- a/patterns/module-surfaces.md
+++ b/patterns/module-surfaces.md
@@ -162,6 +162,10 @@ lighthouse — modules know which way they're heading.
   auth gradient every surface shares.
 - [`ssrf-safe-fetch.md`](./ssrf-safe-fetch.md) — for modules whose API
   surface fetches external URLs.
+- [`runtime-tenancy-contract.md`](./runtime-tenancy-contract.md) — the
+  third side of the contract triad: what hosts inject into tenants at
+  runtime, mirroring this doc (what modules expose) and
+  [`app-bundle-shape.md`](./app-bundle-shape.md) (what apps ship).
 
 ## History
 

--- a/patterns/mount-path-convention.md
+++ b/patterns/mount-path-convention.md
@@ -1,5 +1,20 @@
 # Mount-path convention
 
+> **⚠️ Superseded for parachute-app hosted UIs (2026-05-23).**
+> This doc describes the build-time-baked-mount pattern (Vite `base` +
+> `import.meta.env.BASE_URL`) that the notes-daemon era used. For app
+> bundles hosted under **parachute-app**, the canonical pattern is
+> **runtime mount detection** via `@openparachute/app-client` reading
+> host-injected metadata. See:
+>
+> - [`runtime-tenancy-contract.md`](./runtime-tenancy-contract.md) — what hosts inject
+> - [`app-bundle-shape.md`](./app-bundle-shape.md#mount-agnosticism) — mount-agnosticism requirement
+>
+> This doc remains accurate for the deprecating notes-daemon path and
+> as historical context. Don't follow its build-time-mount guidance for
+> new apps under parachute-app — they need to work at any operator-
+> chosen mount, which the old pattern can't support.
+
 ## Convention
 
 Every Parachute frontend module is served at a **subpath** under the

--- a/patterns/runtime-tenancy-contract.md
+++ b/patterns/runtime-tenancy-contract.md
@@ -1,0 +1,179 @@
+# Runtime tenancy contract
+
+> Hosts that serve tenants (parachute-app serving hosted UIs, future
+> tenancy contexts) inject structured environment metadata into the
+> tenant's runtime. Tenants READ from explicit metadata rather than
+> guessing from URL patterns or filesystem layout. Same architectural
+> shape across every host↔tenant relationship in Parachute. Third side
+> of the triad with [`module-surfaces.md`](./module-surfaces.md) (what
+> backend modules expose) and
+> [`app-bundle-shape.md`](./app-bundle-shape.md) (what frontend app
+> bundles ship).
+
+## The convention (TL;DR)
+
+The host injects, the tenant reads. For HTML tenants — the current
+canonical case, parachute-app serving SPA bundles — the contract is
+meta tags plus a `<base>` element in the served HTML:
+
+```html
+<head>
+  <base href="/app/<name>/">                              <!-- browser URL resolution -->
+  <meta name="parachute-mount" content="/app/<name>">     <!-- runtime code reads this -->
+  <meta name="parachute-hub" content="https://...">       <!-- hub origin for OAuth discovery -->
+  <meta name="parachute-vault" content="/vault/<name>">   <!-- when operator's session is vault-bound -->
+  <meta name="parachute-tenant-id" content="<name>">      <!-- tenant's logical name within this host -->
+</head>
+```
+
+Tenants consume via `@openparachute/app-client`:
+
+```ts
+import {
+  getMountBase,
+  getHubOrigin,
+  getVaultPath,
+  getTenantId,
+} from '@openparachute/app-client';
+```
+
+The helpers read the meta tags, return typed values, and throw clear
+errors when the host hasn't injected what the tenant expects.
+
+## Two-layer rationale
+
+Why both `<base href>` AND meta tags:
+
+- **`<base href>`** is load-bearing for the BROWSER's URL resolution.
+  Without it, relative paths (assets, manifest, service-worker scope)
+  resolve against the document's perceived directory, which fails for
+  SPAs mounted at non-trailing-slash URLs. This is the browser's
+  built-in mechanism; the host injects it so the bundle doesn't have
+  to know its own mount at build time.
+- **Meta tags** are for runtime CODE: React Router `basename`, OAuth
+  callback URL construction, vault API base URL, tenant-id-aware
+  storage keys. Strings the bundle reads at runtime; browser URL
+  resolution doesn't help here.
+
+Both layers serve the same architectural pattern at different
+concerns — DOM-level URL resolution vs. JavaScript-level configuration.
+
+## Why the contract exists — the constraint that produced it
+
+Implicit conventions don't generalize. Notes-ui learned this when
+shipped under parachute-app: initially the bundle had `/notes/` baked
+in via `VITE_BASE_PATH`, which broke when the operator chose a custom
+mount (`parachute-app add notes-ui --name my-notes` → `/app/my-notes/`).
+
+The first fix
+([notes#159](https://github.com/ParachuteComputer/parachute-notes/pull/159))
+was runtime mount detection via regex against `window.location.pathname`
+matching the KNOWN Parachute mount patterns (`/app/<name>` or `/notes`).
+That worked for the immediate ship but required the bundle to know
+Parachute's mount conventions — fragile, brittle to new conventions,
+and demanded a bundle update every time the convention shifted.
+
+Explicit metadata is the canonical answer: the host knows where it
+mounted the tenant; let it say so directly. The tenant reads what the
+host said, with no shared assumption about path shape.
+
+## Examples and reference implementations
+
+- **parachute-app → hosted UIs** — primary case.
+  [parachute-app#21](https://github.com/ParachuteComputer/parachute-app/issues/21)
+  implements the producer side (meta-tag + `<base>` injection in the
+  HTML response from the app-host HTTP server).
+  [parachute-app#22](https://github.com/ParachuteComputer/parachute-app/issues/22)
+  ships `@openparachute/app-client` — the consumer-side library with
+  typed helpers.
+- **parachute-notes / notes-ui** — first canonical consumer.
+  [notes#159](https://github.com/ParachuteComputer/parachute-notes/pull/159)
+  shipped the interim regex-based runtime detection; the next iteration
+  consumes `@openparachute/app-client` and reads the injected meta tags
+  directly. PWA service worker scope mismatch handling is tracked at
+  [notes#160](https://github.com/ParachuteComputer/parachute-notes/issues/160).
+
+## Future tenancy contexts (forward-looking)
+
+The same shape recurs across Parachute:
+
+- **Vault → MCP clients** — currently implicit via URL; could be
+  explicit via the well-known doc surface.
+- **Hub → modules** — already partially explicit via `parachute.json`
+  and `module.json` manifest fields.
+- **Future cloud platform → user-deployed workloads** — env vars,
+  init records, mount paths injected by the platform.
+
+When a new tenancy context emerges, follow this pattern: injection on
+the host side, reading on the tenant side, an abstraction library
+between them. The metadata mechanism varies (meta tags for HTML, env
+vars for processes, init records for isolates); the architectural
+shape is the same.
+
+## Anti-patterns
+
+- **Regex on `window.location.pathname`** to detect mount — works for
+  known patterns, breaks for arbitrary mounts. Pattern docs explicitly
+  DEPRECATE this for new code. The notes-ui regex was an interim
+  during the 0.1.1 ship; it phases out as `@openparachute/app-client`
+  lands.
+- **Bundling the mount at build time** — couples the bundle to one
+  mount, breaks the operator-chooses-mount design. Apps MUST be
+  mount-agnostic — see
+  [`app-bundle-shape.md`](./app-bundle-shape.md)'s Mount-agnosticism
+  section.
+- **Asking the host via a custom HTTP endpoint** — adds latency, breaks
+  offline-first SPAs, requires the tenant to be online to know its own
+  mount. The HTML-time injection is the right surface: the tenant has
+  what it needs the moment the document parses.
+
+## What this looks like for the operator
+
+A Parachute operator never thinks about this contract. They install an
+app via `parachute-app add @openparachute/notes-ui` (default mount
+`/app/notes/`) or `parachute-app add @openparachute/notes-ui --name
+my-notes` (custom mount `/app/my-notes/`). The app works at either
+mount with the same built bundle because the host injects mount-specific
+metadata at HTML-serve time.
+
+The contract is between the host and the tenant code; it's invisible to
+the operator and to the human user of the resulting UI.
+
+## Cross-references
+
+- [`module-surfaces.md`](./module-surfaces.md) — backend module
+  surfaces. The producer side of the host-as-module equation: every
+  host that injects tenant runtime metadata is itself a module
+  exposing the canonical surfaces.
+- [`app-bundle-shape.md`](./app-bundle-shape.md) — what app bundles
+  ship + the mount-agnosticism requirement that this contract makes
+  possible.
+- [`mount-path-convention.md`](./mount-path-convention.md) — sibling
+  discussion of single-source mount declarations from the bundle's
+  side.
+- [`module-protocol.md`](./module-protocol.md) — the runtime contracts
+  every backend module implements. Runtime-tenancy-contract is the
+  symmetric "what the host gives the tenant."
+- [`parachute-app/packages/app-host/src/http-server.ts`](https://github.com/ParachuteComputer/parachute-app/blob/main/packages/app-host/src/http-server.ts)
+  — where the host implements the injection (per
+  [parachute-app#21](https://github.com/ParachuteComputer/parachute-app/issues/21)).
+- `parachute-app/packages/app-client/src/mount.ts` (forthcoming) —
+  where the tenant-side helpers live (per
+  [parachute-app#22](https://github.com/ParachuteComputer/parachute-app/issues/22)).
+
+## History
+
+- **2026-05-23** — Aaron's install loop revealed implicit-convention
+  fragility; notes-ui shipped regex-based runtime detection as an
+  interim
+  ([notes#159](https://github.com/ParachuteComputer/parachute-notes/pull/159)).
+- **2026-05-23** — This pattern doc codifies the explicit-injection
+  contract.
+  [parachute-app#21](https://github.com/ParachuteComputer/parachute-app/issues/21)
+  and
+  [parachute-app#22](https://github.com/ParachuteComputer/parachute-app/issues/22)
+  implement the producer and consumer sides; closes
+  [parachute-patterns#81](https://github.com/ParachuteComputer/parachute-patterns/issues/81).
+- **Forthcoming** — Vault and Hub join the contract as their tenancy
+  surfaces formalize (no specific issues yet; the pattern doc is the
+  lighthouse).


### PR DESCRIPTION
## Summary

Ships two related pattern docs in one PR, completing a contract triad
about "what is a Parachute thing":

- **NEW** `patterns/runtime-tenancy-contract.md` — what hosts inject
  into tenants at runtime (meta tags + `<base href>` for HTML tenants;
  same architectural shape across every host-tenant relationship).
- **UPDATE** `patterns/app-bundle-shape.md` — adds a Mount-agnosticism
  section codifying the bundle-side constraint (Vite `base=""`,
  runtime React Router basename, OAuth callback derivation, PWA
  limitation + graceful SW skip). References the new contract doc.
- **UPDATE** `patterns/module-surfaces.md` — single-line cross-ref
  rounding out the triad (modules expose / apps ship / hosts inject).

## Why now

Aaron's install loop on parachute-app revealed that notes-ui needed
its mount path, hub origin, and bound vault at runtime. Without
explicit injection from the host, the bundle had to regex-guess from
URL patterns ([notes#159](https://github.com/ParachuteComputer/parachute-notes/pull/159)
shipped that as an interim). The pattern doc canonicalizes the
explicit-injection answer so future tenancy contexts (vault/MCP-clients,
hub/modules, future cloud platform) follow one shape.

## Triad framing

| Doc | Concern |
|---|---|
| `module-surfaces.md` | What backend modules EXPOSE (API, admin, MCP, health, self-reg) |
| `app-bundle-shape.md` | What frontend app bundles SHIP (dist + meta.json + mount-agnosticism) |
| `runtime-tenancy-contract.md` (new) | What hosts INJECT for tenants at runtime |

## Cross-refs

- Closes [#80](https://github.com/ParachuteComputer/parachute-patterns/issues/80) (app-bundle-shape v2: Mount-Agnosticism section)
- Closes [#81](https://github.com/ParachuteComputer/parachute-patterns/issues/81) (new runtime-tenancy-contract pattern doc)
- [parachute-app#21](https://github.com/ParachuteComputer/parachute-app/issues/21) — producer-side meta-tag + `<base>` injection
- [parachute-app#22](https://github.com/ParachuteComputer/parachute-app/issues/22) — `@openparachute/app-client` helpers
- [parachute-notes#159](https://github.com/ParachuteComputer/parachute-notes/pull/159) — interim regex-based runtime mount detection (merged)
- [parachute-notes#160](https://github.com/ParachuteComputer/parachute-notes/issues/160) — PWA service worker scope mismatch handling

## Patterns check

- Adds: `patterns/runtime-tenancy-contract.md` (new pattern)
- Touches (cross-ref only): `patterns/module-surfaces.md`,
  `patterns/app-bundle-shape.md`
- Conforms to CLAUDE.md: one pattern per file, short, no code, real
- Doc-only — no rc bump per governance rule 2 doc-only exemption

## Test plan

- [ ] Reviewer subagent confirms internal consistency across the three docs
- [ ] Cross-ref links resolve (audit-canonical-refs.sh shows no new dead refs)
- [ ] Mount-agnosticism section reads coherently in app-bundle-shape's flow