### PR TITLE
docs(patterns): bun-container-deploy — proxy-header-forwarding pitfall (hub#358)

### DIFF
--- a/patterns/bun-container-deploy.md
+++ b/patterns/bun-container-deploy.md
@@ -104,6 +104,61 @@ Diagnostic when this is the bug: container logs show
 `error: Failed to start server. Is port <N> in use? EADDRINUSE`
 where `<N>` is the platform's PORT injection (typically hub's port).
 
+## Pitfall: reverse-proxy hops drop X-Forwarded-* headers
+
+Once supervised modules start running, the next reachable bug: hub
+reverse-proxies HTTP requests to children at loopback. The children
+need to know the public origin to construct OAuth discovery metadata,
+redirect URIs, and similar public-facing URLs. Without forwarded
+headers, they fall back to `req.url.origin` which is the internal
+loopback URL.
+
+Concrete failure mode: a client hits
+`https://parachute-hub.onrender.com/vault/default/.well-known/oauth-authorization-server`.
+Hub proxies to `http://127.0.0.1:1940/.well-known/...`. Vault returns:
+
+```json
+{
+  "issuer": "http://127.0.0.1:1940/vault/default",
+  "authorization_endpoint": "http://127.0.0.1:1940/vault/default/oauth/authorize",
+  ...
+}
+```
+
+…not what the client can use. Any OAuth flow that touches the metadata
+redirects to an internal address.
+
+The fix has two sides:
+
+1. **The reverse proxy MUST forward `X-Forwarded-Host` and
+   `X-Forwarded-Proto`** to upstream services. Capture the public
+   `Host` header BEFORE deleting it (the upstream wants its own
+   loopback host); set `X-Forwarded-Host`. Synthesize
+   `X-Forwarded-Proto` from the request URL scheme if the edge didn't
+   already set it. Preserve already-set forwarded headers (nested
+   proxy chains).
+
+2. **Each supervised module's `getBaseUrl` MUST honor those
+   headers** when constructing public-facing URLs. Vault already did
+   this correctly via `oauth.ts:getBaseUrl`; the gap was hub not
+   forwarding them.
+
+```typescript
+// In hub's proxyRequest (or any reverse proxy)
+const publicHost = req.headers.get("host");
+headers.delete("host");
+if (publicHost && !headers.has("x-forwarded-host")) {
+  headers.set("x-forwarded-host", publicHost);
+}
+if (!headers.has("x-forwarded-proto")) {
+  headers.set("x-forwarded-proto", isHttpsRequest(req) ? "https" : "http");
+}
+```
+
+This was hub#358. Diagnostic: curl any supervised module's discovery
+endpoint via the public URL and inspect the `issuer` claim. If it
+shows the internal loopback address, the proxy isn't forwarding.
+
 ## Diagnosis flow when an install fails
 
 1. `bun add -g --verbose <package>` from a shell on the container —

--- a/patterns/bun-container-deploy.md
+++ b/patterns/bun-container-deploy.md
@@ -241,7 +241,7 @@ parent owned by root, not bun.
 - [`parachute-hub/docker-entrypoint.sh`](https://github.com/ParachuteComputer/parachute-hub/blob/main/docker-entrypoint.sh)
   — the entrypoint chown pattern.
 - [hub#349](https://github.com/ParachuteComputer/parachute-hub/pull/349)
-  — the issue trail; chain of seven PRs to land the full fix:
+  — the issue trail; chain of nine PRs to land the full fix:
   - #349 — opening issue
   - #350 — entrypoint chown stub
   - #351 — `TMPDIR` on persistent disk
@@ -253,25 +253,48 @@ parent owned by root, not bun.
     completes for the first time)
   - #356 — platform-injected `PORT` clobbers child ports (third load-
     bearing fix; vault + scribe finally start cleanly after install)
+  - #357 — `bootSupervisedModules` was a third PORT-spawn site missed
+    by #356 (fourth load-bearing fix; auto-spawn on hub boot now sets
+    PORT for each child too)
+  - #358 — reverse proxy must forward `X-Forwarded-Host` + `X-Forwarded-
+    Proto` to supervised modules (fifth load-bearing fix; OAuth metadata
+    now publishes the public origin instead of internal loopback)
 - [hub#352](https://github.com/ParachuteComputer/parachute-hub/pull/352)
   — the `Bun.spawn { env: process.env }` fix specifically.
 - [hub#355](https://github.com/ParachuteComputer/parachute-hub/pull/355)
   — the mkdir-as-root pitfall fix; diagnosed via live SSH into a fresh
   Render deploy.
 - [hub#356](https://github.com/ParachuteComputer/parachute-hub/pull/356)
-  — the platform-PORT pitfall fix; surfaced one PR later when vault
-  could finally try to start.
+  — the platform-PORT pitfall fix (install + lifecycle paths).
+- [hub#357](https://github.com/ParachuteComputer/parachute-hub/pull/357)
+  — the PORT-fix-for-boot-path follow-up; symmetric fix in the third
+  spawn site (`bootSupervisedModules`).
+- [hub#358](https://github.com/ParachuteComputer/parachute-hub/pull/358)
+  — the X-Forwarded-* proxy pitfall fix; surfaced after vault + scribe
+  started cleanly and OAuth flows were first exercised via the public URL.
 - [patterns#85](https://github.com/ParachuteComputer/parachute-patterns/issues/85)
   — open audit: verify `Bun.spawn` passes `env: process.env` across
   vault / scribe / app / runner.
 
+## Security note on X-Forwarded-Host
+
+Modules that honor `X-Forwarded-Host` for public-URL construction (e.g.
+vault's `getBaseUrl` for OAuth metadata) are trusting that header — a
+malicious client that can reach the module DIRECTLY (bypassing hub)
+could send `X-Forwarded-Host: evil.com` and poison the published OAuth
+metadata, enabling redirect-URI attacks. Defense: each module should
+bind loopback-only (`127.0.0.1`) so the only way in is through hub's
+reverse proxy, which is a trusted forwarder. Direct internet exposure
+of supervised modules is out of scope for this pattern.
+
 ## History
 
 - **2026-05-23 → 2026-05-24** — bugs discovered + fixed across
-  hub#349-#356. The pattern of "each fix unblocks the next reachable
-  bug" repeated three times: env-var chain → mkdir-as-root → platform-
-  injected PORT. Local docker-volume repro caught most but missed both
-  load-bearing bugs that required live SSH into a fresh Render deploy.
+  hub#349-#358. The pattern of "each fix unblocks the next reachable
+  bug" repeated five times: env-var chain → mkdir-as-root → platform-
+  injected PORT (install path) → PORT (boot path) → X-Forwarded-*
+  forwarding. Local docker-volume repro caught the first; live SSH
+  into a fresh Render deploy was load-bearing for the rest.
 - **2026-05-24** — pattern doc landed so the next module deployed to
   a container + persistent disk doesn't walk the same path. Updated
   same day with the mkdir-as-root + platform-PORT pitfall callouts.


### PR DESCRIPTION
## Summary

Doc-only update following hub#358 — the eighth load-bearing bug in the bun-container-deploy chain. After PORT chain (#356, #357) unblocked vault, E2E testing showed vault published `http://127.0.0.1:1940/...` as its OAuth issuer when accessed via the hub-proxied URL. Root cause: hub's reverse proxy deleted the Host header (correct) but never set X-Forwarded-Host, so vault fell back to req.url.origin which was the internal loopback.

Verified post-fix: vault now publishes `https://parachute-hub.onrender.com/vault/default` as issuer via the hub-proxied URL.

## Changes

New "Pitfall: reverse-proxy hops drop X-Forwarded-* headers" section between the platform-PORT pitfall and the diagnosis flow. Documents:
- The failure mode + diagnostic (issuer = loopback URL)
- Two-sided fix: proxy MUST forward + module MUST honor
- Concrete TypeScript snippet of the proxy-side fix
- "Preserve already-set forwarded headers" semantics for nested chains

## Test plan

- [x] Markdown only — no code change
- [x] Doc-only PR; skips rc per governance

🤖 Generated with [Claude Code](https://claude.com/claude-code)