### PR TITLE
docs(patterns): release-ci.md + governance rule 2 update — tag-triggered CI

### DIFF
--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -41,24 +41,30 @@ dist-tag first; promotion to `@latest` is a deliberate, separate step.
 
 **Per PR:**
 
-- The PR bumps `package.json` to `0.X.Y-rc.N` (next patch + a fresh rc
-  number). Don't ship a "final" version straight from a feature PR.
-- After the human merge, the publisher runs `npm publish --tag rc` so the
-  build is reachable as `@openparachute/<pkg>@rc` (or
-  `@openparachute/<pkg>@0.X.Y-rc.N` directly) but **not** the default
-  `@latest` install for new users.
+- The PR bumps `package.json` to `0.X.Y-rc.N` (next rc number; the patch
+  number `Y` stays fixed across the rc chain until promotion). Don't
+  ship a "final" version straight from a feature PR.
+- After the human merge, push a matching git tag (`v0.X.Y-rc.N`). CI
+  publishes — see [`release-ci.md`](release-ci.md) for the workflow shape.
+  The tag is the canonical release marker; the publish is automated.
 
 **Promotion (a separate, deliberate action):**
 
-- Run `npm dist-tag add @openparachute/<pkg>@0.X.Y-rc.N latest` once the RC
-  has been validated (smoke install, manual demo, real-world feedback).
-- The same RC artifact becomes the `@latest`; no second build, no second
-  version. This keeps git history and npm versions aligned and keeps the
-  cadence fast.
+- Open a PR that drops the `-rc.N` suffix (e.g. `0.X.Y-rc.N` → `0.X.Y`).
+- Reviewer + merge.
+- Push the bare-version tag (`v0.X.Y`). CI publishes with `dist-tag=latest`
+  AND tags the container image as `:stable`.
+- Same source commit; no second build, no second version. Keeps git
+  history, npm versions, and container image tags aligned.
 
-**Doc-only / test-only PRs follow the same convention** for uniformity. Every
-PR that changes the published artifact bumps the version. The cost is one
-line in `package.json`; the benefit is no special-casing.
+**Doc-only PRs are EXEMPT from rc.N bumping** during an active rc chain —
+they merge without a version change and get picked up by the next
+code-touching PR's rc bump (or by the stable promotion, whichever lands
+first). Don't fragment a release into many patch bumps mid-validation.
+
+If a doc-only fix needs to ship outside an active rc chain (main is on a
+stable version with no rc in flight), bump the next patch
+(`0.X.Y` → `0.X.(Y+1)`), tag, ship.
 
 **At v1.0 and after**, switch to standard SemVer with `alpha` / `beta` / `rc`
 prerelease tags as feature stability warrants, and to a "release PR" pattern

--- a/patterns/release-ci.md
+++ b/patterns/release-ci.md
@@ -1,0 +1,175 @@
+# Release CI — tag-triggered publish to npm + ghcr.io
+
+> Pre-1.0 Parachute repos publish via GitHub Actions on git tag push,
+> not via manual `npm publish`. One workflow per repo, same shape
+> across all of them. Pilot in [parachute-hub#359](https://github.com/ParachuteComputer/parachute-hub/pull/359);
+> roll out to vault / scribe / app / runner follows.
+
+## The convention (TL;DR)
+
+Every committed-core Parachute repo has `.github/workflows/release.yml`
+that triggers on `v*` tag push. The workflow:
+
+1. **`test` job** — runs the repo's typecheck + test suite. Blocks publish.
+2. **`publish-npm` job** — publishes to npm with provenance attestation.
+   Dist-tag auto-detected from tag string: `-rc.` substring → `rc`,
+   else → `latest`.
+3. **`publish-image` job** (where applicable — modules that have a
+   container image artifact) — builds the Dockerfile, pushes to
+   `ghcr.io/parachutecomputer/<repo-name>` with tags `:rc` / `:stable` /
+   `:v<X>.<Y>.<Z>[-rc.<N>]`.
+
+Release flow becomes:
+
+```sh
+# 1. Code-touching PR merges to main with rc.N bump
+# 2. Operator pulls latest main, pushes a matching tag
+git pull --ff-only
+VERSION="v$(node -p "require('./package.json').version")"
+git tag "$VERSION" && git push origin "$VERSION"
+# CI takes over: tests → publishes
+```
+
+## Why tag-triggered (not push-to-main)
+
+- **Tag = explicit release signal.** Merges to main don't auto-publish;
+  the tag is the unambiguous "ship this" trigger.
+- **Tag itself is the audit trail.** What was released and when is
+  visible via `git tag` + GitHub's tag UI. No need to cross-reference
+  npm registry timestamps with git commits.
+- **Preserves a deliberate human gate** (you push the tag when you mean
+  to ship) **without the per-publish 2FA prompt** that gates remote
+  work. Operators can release from anywhere.
+- **Matches Render auto-deploy semantics:** Render watches main and
+  redeploys on every commit. CI release is independent — only fires
+  when a tag points at a commit.
+
+## Why ghcr.io alongside npm
+
+Image-based deploy targets (image-pinned `:stable` and `:rc` tags in a
+Render blueprint, future cloud offerings, etc.) need pre-built container
+images. ghcr.io is:
+
+- **Free for public images.**
+- **Integrated with GitHub Actions** — auth via the runner's
+  auto-provisioned `GITHUB_TOKEN`, no separate secret.
+- **Provenance-friendly** — image labels include source git ref + commit,
+  auditable supply chain.
+
+The image artifact exists even if no deploy target is currently using it.
+Lets future image-pinned `render.yaml` variants land as a doc/yaml
+change, not an infra change.
+
+## Operator one-time setup per repo
+
+1. **`NPM_TOKEN` secret.** npmjs.com → Access Tokens → New Token
+   (type: **Automation**) → scope `@openparachute/*`. Add as `NPM_TOKEN`
+   under GitHub repo Settings → Secrets and variables → Actions.
+
+2. **ghcr.io permissions.** No secret needed (the workflow uses
+   `GITHUB_TOKEN`), but the first push creates the package as **private
+   by default**. Toggle visibility to **Public** at
+   `https://github.com/orgs/ParachuteComputer/packages/container/<repo>/settings`
+   after first push — otherwise unauthenticated `docker pull` (Render,
+   etc.) 403s.
+
+## Workflow shape (canonical)
+
+The hub workflow is the reference. Other repos adapt:
+
+- **Test command** matches the repo's `package.json` test script.
+- **Build step.** If the package needs a build (e.g. hub builds the SPA
+  via `prepack`), the `prepack` hook in `package.json` handles it
+  automatically when `npm publish` runs — no explicit step in CI needed.
+- **Image job is omitted** for modules that don't ship a container
+  image (most don't — only hub does today, since it's the deploy
+  surface). Vault, scribe, app, runner publish to npm only.
+
+```yaml
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    # ... bun test ./src etc.
+
+  publish-npm:
+    needs: test
+    permissions:
+      contents: read
+      id-token: write   # provenance
+    steps:
+      # ... bun install, setup-node, version-vs-tag guard, npm publish
+
+  publish-image:   # hub only (for now)
+    needs: test
+    permissions:
+      contents: read
+      packages: write   # ghcr.io
+    # ... docker buildx + push with :rc / :stable tag derivation
+```
+
+## The version-vs-tag guard
+
+Every `publish-npm` job runs a guard before the publish step:
+
+```sh
+PKG_VERSION=$(node -p "require('./package.json').version")
+TAG_VERSION="${GITHUB_REF_NAME#v}"
+[ "$PKG_VERSION" = "$TAG_VERSION" ] || { echo "::error::drift" && exit 1; }
+```
+
+Prevents a "tagged `v0.5.13` but package.json still says `0.5.13-rc.32`"
+mistake from silently publishing under the wrong version.
+
+## Tag pattern details
+
+The `on.push.tags` filter accepts:
+
+- `v[0-9]+.[0-9]+.[0-9]+` — matches `v0.5.13`, `v1.0.0`, etc.
+- `v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+` — matches `v0.5.13-rc.32`, etc.
+
+The runtime bash check (`if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]`)
+disambiguates rc-vs-stable for the dist-tag and the image-tag derivation,
+not the workflow trigger.
+
+## Cross-references
+
+- [`parachute-hub/.github/workflows/release.yml`](https://github.com/ParachuteComputer/parachute-hub/blob/main/.github/workflows/release.yml)
+  — canonical reference implementation.
+- [`parachute-hub/RELEASING.md`](https://github.com/ParachuteComputer/parachute-hub/blob/main/RELEASING.md)
+  — operator-facing release flow doc (per-repo).
+- [`patterns/governance.md`](./governance.md) Rule 2 — the RC versioning
+  rule this workflow enforces.
+
+## Rollout plan
+
+Pilot: parachute-hub (landed 2026-05-24, hub#359).
+
+Per-repo rollout (separate PRs):
+
+- [ ] parachute-vault — same shape, no image job (npm only)
+- [ ] parachute-scribe — same shape, no image job
+- [ ] parachute-app — multi-package workspace; publish from
+  `packages/app-host`; no image job
+- [ ] parachute-runner — same shape, no image job
+
+Each rollout PR:
+1. Adds `.github/workflows/release.yml` (copied + adapted from hub)
+2. Adds `RELEASING.md` (copied + adapted)
+3. Bumps `rc.N` (the first tag CI can react to)
+
+Operator adds `NPM_TOKEN` secret to each repo before the first tag push.
+
+## History
+
+- **2026-05-24** — pilot landed in parachute-hub (hub#359). Rule 2
+  updated to describe tag-triggered release instead of manual
+  `npm publish`. Pattern doc landed alongside.

--- a/patterns/release-ci.md
+++ b/patterns/release-ci.md
@@ -8,14 +8,15 @@
 ## The convention (TL;DR)
 
 Every committed-core Parachute repo has `.github/workflows/release.yml`
-that triggers on `v*` tag push. The workflow:
+that triggers on `v*` tag push. Three jobs:
 
-1. **`test` job** — runs the repo's typecheck + test suite. Blocks publish.
-2. **`publish-npm` job** — publishes to npm with provenance attestation.
-   Dist-tag auto-detected from tag string: `-rc.` substring → `rc`,
-   else → `latest`.
-3. **`publish-image` job** (where applicable — modules that have a
-   container image artifact) — builds the Dockerfile, pushes to
+1. **`test`** — runs the repo's typecheck + test suite. Blocks publish.
+2. **`publish-npm`** (depends on `test`) — publishes to npm with
+   provenance attestation. Dist-tag auto-detected from tag string:
+   `-rc.` substring → `rc`, else → `latest`.
+3. **`publish-image`** (depends on `test`, runs in parallel with
+   `publish-npm`; only where applicable — modules with a container
+   image artifact) — builds the Dockerfile, pushes to
    `ghcr.io/parachutecomputer/<repo-name>` with tags `:rc` / `:stable` /
    `:v<X>.<Y>.<Z>[-rc.<N>]`.
 
@@ -25,7 +26,7 @@ Release flow becomes:
 # 1. Code-touching PR merges to main with rc.N bump
 # 2. Operator pulls latest main, pushes a matching tag
 git pull --ff-only
-VERSION="v$(node -p "require('./package.json').version")"
+VERSION="v$(bun -e "console.log(require('./package.json').version)")"
 git tag "$VERSION" && git push origin "$VERSION"
 # CI takes over: tests → publishes
 ```
@@ -140,33 +141,33 @@ The runtime bash check (`if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]`)
 disambiguates rc-vs-stable for the dist-tag and the image-tag derivation,
 not the workflow trigger.
 
-## Cross-references
+## Examples
 
 - [`parachute-hub/.github/workflows/release.yml`](https://github.com/ParachuteComputer/parachute-hub/blob/main/.github/workflows/release.yml)
-  — canonical reference implementation.
+  — canonical reference implementation (three jobs incl. publish-image).
 - [`parachute-hub/RELEASING.md`](https://github.com/ParachuteComputer/parachute-hub/blob/main/RELEASING.md)
-  — operator-facing release flow doc (per-repo).
-- [`patterns/governance.md`](./governance.md) Rule 2 — the RC versioning
-  rule this workflow enforces.
+  — operator-facing release flow doc (per-repo template).
 
-## Rollout plan
+## Interaction with other rules
 
-Pilot: parachute-hub (landed 2026-05-24, hub#359).
+This pattern operates under [`governance.md`](./governance.md) Rule 2
+(RC versioning) and Rule 5 (CHANGELOG discipline). Specifically, the
+doc-only-exemption in Rule 2 means some merges never produce a tag,
+which per Rule 5 also means they produce no CHANGELOG entry — these
+merges get rolled into the next rc.N or stable bump's CHANGELOG section.
+No special-casing needed.
 
-Per-repo rollout (separate PRs):
+## Rollout
 
-- [ ] parachute-vault — same shape, no image job (npm only)
-- [ ] parachute-scribe — same shape, no image job
-- [ ] parachute-app — multi-package workspace; publish from
-  `packages/app-host`; no image job
-- [ ] parachute-runner — same shape, no image job
+Pilot: parachute-hub (landed 2026-05-24, hub#359). Per-repo rollout
+(vault / scribe / app / runner) tracked in
+[parachute-patterns#91](https://github.com/ParachuteComputer/parachute-patterns/issues/91).
 
-Each rollout PR:
-1. Adds `.github/workflows/release.yml` (copied + adapted from hub)
-2. Adds `RELEASING.md` (copied + adapted)
-3. Bumps `rc.N` (the first tag CI can react to)
-
-Operator adds `NPM_TOKEN` secret to each repo before the first tag push.
+Each rollout adapts hub's workflow + RELEASING.md, plus an `NPM_TOKEN`
+secret added by the operator before the first tag push. `parachute-app`
+publishes from `packages/app-host` (multi-package workspace); other
+modules are single-package. None except hub need the `publish-image`
+job today.
 
 ## History
 


### PR DESCRIPTION
## Summary

Pilot landed in [parachute-hub#359](https://github.com/ParachuteComputer/parachute-hub/pull/359): tag-triggered GitHub Actions workflow publishes to npm (with provenance) and ghcr.io on `v*` tag push, replacing manual `npm publish --tag rc` from Aaron's terminal.

This PR documents the convention so the next module deployed follows the same shape.

## Changes

### `patterns/release-ci.md` (new)

- TL;DR of the convention (3-job workflow: test → publish-npm → publish-image)
- Why tag-triggered (audit trail, deliberate gate without 2FA)
- Why ghcr alongside npm (image-pinned future deploys)
- One-time operator setup per repo (`NPM_TOKEN` secret, ghcr visibility toggle)
- Canonical workflow YAML shape
- Version-vs-tag guard explanation
- Tag pattern details (glob filter + runtime disambiguation)
- Rollout plan per-repo (hub done; vault / scribe / app / runner queued)
- Cross-refs to hub's `release.yml` + `RELEASING.md`

### `patterns/governance.md` Rule 2 update

- Replaces "publisher runs `npm publish --tag rc`" with tag-push CI flow
- Promotion path: PR drops rc suffix, push bare-version tag, CI publishes with `dist-tag=latest` + image `:stable`
- Doc-only policy clarified: EXEMPT from rc.N bumping during active rc chain (was "follow the same convention for uniformity" which was incorrect)

## Test plan

- [x] Markdown only — no code change
- [x] Doc-only PR; skips rc per governance

🤖 Generated with [Claude Code](https://claude.com/claude-code)