### PR TITLE
migrations: track Render → Fly self-host shift (Phase 1)

### DIFF
--- a/migrations/2026-05-26-render-to-fly-self-host.md
+++ b/migrations/2026-05-26-render-to-fly-self-host.md
@@ -1,90 +1,89 @@
 ---
-title: Render → Fly self-host migration (Phase 1)
+title: Add Fly as peer self-host option (alongside Render)
 date: 2026-05-26
 status: active
 originating-pr: parachute.computer#62 (Fly migration design doc)
 ---
 
-# Render → Fly self-host migration (Phase 1)
+# Add Fly as peer self-host option (alongside Render)
 
-Migrates the **canonical self-host path** from Render to Fly.io. Render support is preserved (`render.yaml` stays in the repo) — this shift recommends Fly as the primary path, with Render as an alternative for operators already on it.
+Adds Fly.io as a **peer self-host option** alongside the existing Render path. Both are first-class — operators pick the platform they prefer. Aaron's framing (2026-05-26): _"For now, this is a self-host offering alongside render."_
 
-The full migration arc has four phases; this file tracks **Phase 1 only** (~2 weeks of work). Phases 2 (hosted offering via `parachute.cloud`), 3 (public launch), and 4 (Render sunset) are scoped in the design doc but require fresh commitment to start.
+The design doc ([`parachute.computer/design/2026-05-26-fly-migration-path.md`](../../parachute.computer/design/2026-05-26-fly-migration-path.md)) sketches a four-phase arc where later phases (hosted offering on `parachute.cloud`) might eventually shift the substrate balance. This file tracks **Phase 1 only**: the work to make Fly a viable self-host choice. No primacy reordering between Render and Fly is implied.
 
-Full architectural reasoning: [`parachute.computer/design/2026-05-26-fly-migration-path.md`](../../parachute.computer/design/2026-05-26-fly-migration-path.md).
+## Why add Fly
 
-## Why the shift
-
-- **Lock-in symmetry.** Render disks have no portable snapshot export. Fly volumes do (`fly volumes snapshot create`, restorable into other orgs). The escape hatch matters for self-hosters and matters more when a hosted offering is on the table.
-- **Substrate alignment.** A future hosted offering (`parachute.cloud`, Phase 2+) runs the same image on the same platform as self-host. One CI pipeline, one bug-fix path, one ops model.
-- **Cost shape.** Fly shared-cpu-1x 512MB iad is $3.34/mo all-in vs Render Starter $7/mo. The delta funds the hosted offering's margin.
+- **Operator choice.** Some operators already have Fly orgs and would prefer to use them; some prefer Render's GUI-first ops; some want the lower cost. Offering both serves both.
+- **Lock-in symmetry for future cloud option.** Fly volume snapshots are portable (`fly volumes snapshot create`, restorable into other orgs). When the hosted-on-cloud option arrives (Phase 2+, separate decision), the export-to-self-host primitive matters more on Fly than Render. This Phase 1 work makes Fly a viable target for that.
+- **Cost shape.** Fly shared-cpu-1x 512MB iad is $3.34/mo all-in vs Render Starter $7/mo. Operator savings, not a forcing factor.
 - **Non-driver: reliability.** Fly and Render both have intermittent edge-router issues (Fly `fly-proxy` regressions; Render `portdetectorv2` flap caught at [hub#399](https://github.com/ParachuteComputer/parachute-hub/issues/399)). This shift is not motivated by reliability.
 
-## Phase 1 — self-host on Fly
+## Phase 1 — add Fly self-host path
 
-Aaron committed 2026-05-26 to Phase 1 only (Option A in the design doc): spike the Fly track for self-hosters, with explicit decision point at the end before committing to Phase 2 (hosted offering).
+Aaron committed 2026-05-26 to Phase 1 only (Option A in the design doc): add the Fly track for self-hosters as a peer option. Explicit decision point at the end before any work on Phase 2 (hosted offering) starts.
 
 ### Exit criteria
 
-A friend can fork `parachute-hub` + run `./scripts/deploy-to-fly.sh` + install vault from the admin SPA, in under 5 minutes, with the same UX as the Render path.
+A friend can fork `parachute-hub` + run `./scripts/deploy-to-fly.sh` + install vault from the admin SPA, in under 5 minutes, with the same UX as the Render path. Existing Render operators see no breakage; nothing about the Render path changes substantively.
 
 ## Code references
 
 ### parachute-hub
 
 - [ ] `fly.toml` — new file at repo root, alongside the existing `render.yaml`. Pinned to shared-cpu-1x 512MB / iad / 1GB volume at `/parachute`. Tracked-by: (pending PR)
-- [ ] `src/hub-server.ts:263` — `canonicalOrigin` resolver recognizes `FLY_APP_NAME` (composes `https://${FLY_APP_NAME}.fly.dev` as a peer to the existing `RENDER_EXTERNAL_URL` branch). Tracked-by: (pending PR)
-- [ ] `src/setup-wizard.ts:236` — auto-skip-expose step recognizes Fly the same way it recognizes Render (platform routes URL publicly without operator action). Tracked-by: (pending PR)
-- [ ] `src/api-hub.ts:145` — Fly equivalents for `RENDER_GIT_COMMIT` + `RENDER_GIT_BRANCH` (Fly sets `FLY_RELEASE_COMMAND`, `FLY_REGION` — different shape; decide what the admin "build info" panel actually needs). Tracked-by: (pending PR)
+- [ ] `src/hub-server.ts` — `resolveIssuer` (the function reading `RENDER_EXTERNAL_URL`) gains a `FLY_APP_NAME` peer branch (compose `https://${FLY_APP_NAME}.fly.dev` when set). Tracked-by: (pending PR)
+- [ ] `src/hub-server.ts` — `platformOrigin` field in the admin-SPA setup-status response also needs a `FLY_APP_NAME`-derived value when on Fly (currently only reads `RENDER_EXTERNAL_URL`). Tracked-by: (pending PR)
+- [ ] `src/setup-wizard.ts` — `detectAutoExposeMode` recognizes Fly the same way it recognizes Render (platform routes URL publicly without operator action). The existing comment "Add more platforms here when we encounter them — e.g. Fly.io" calls out the exact slot. Tracked-by: (pending PR)
+- [ ] `src/api-hub.ts` — `buildInfo` block exposes Fly equivalents alongside `RENDER_GIT_COMMIT` / `RENDER_GIT_BRANCH`. Fly sets `FLY_RELEASE_COMMAND` + `FLY_REGION` (different shape — decide what the admin "build info" panel actually surfaces). Tracked-by: (pending PR)
 - [ ] `scripts/deploy-to-fly.sh` — new wrapper that detects `flyctl`, installs if missing, runs `fly launch --copy-config --yes`, prints the URL. Tracked-by: (pending PR)
-- [ ] `README.md` — Deploy-to-Fly as the primary path; Render moves to alternative. Tracked-by: (pending PR)
+- [ ] `README.md` — Deploy section gains a Fly walkthrough as a peer to the Render one. Both presented as equally supported. Tracked-by: (pending PR)
 
 ### parachute.computer
 
-- [ ] `deploy/render.njk` — soften framing from "the canonical self-host path" to "one of two paths"; cross-link to Fly. Tracked-by: (pending PR)
-- [ ] `deploy/fly.njk` — new doc, sibling of `deploy/render.njk`, walkthrough for the Fly path. Tracked-by: (pending PR)
-- [ ] `deploy/index.njk` (if it exists; else `/deploy` landing) — show both options, Fly first. Tracked-by: (pending PR)
+- [ ] `deploy/fly.njk` — new doc, sibling of `deploy/render.njk`, walkthrough for the Fly path. Same shape, same depth. Tracked-by: (pending PR)
+- [ ] `deploy/index.njk` (or `/deploy` landing) — show both options as peers. Tracked-by: (pending PR)
+- [ ] `deploy/render.njk` — no substantive change needed. Optionally add a "Or deploy on Fly →" pointer at the top. Tracked-by: (verify)
 
 ### parachute-patterns
 
+- [ ] `patterns/bun-container-deploy.md` — references Render-specific URL examples (`parachute-hub.onrender.com`) and frames the deploy from a Render-primary perspective. Update opening tagline to mention Fly as a peer platform. Tracked-by: (pending PR)
+- [ ] `patterns/release-ci.md` — "Matches Render auto-deploy semantics" rationale should mention `fly deploy` on push as the equivalent Fly pattern. Tracked-by: (pending PR)
 - [ ] `patterns/canonical-ports.md` — no change expected (ports are platform-agnostic). Verify.
 - [ ] `patterns/module-self-registration.md` — verify no platform-specific assumptions.
 
 ## Doc references
 
-- [ ] `parachute.computer/design/2026-05-18-v06-deploy-architecture.md` — current doc names Render as primary self-host path. Add companion note pointing at the Fly migration doc + note that Phase 1 recommends Fly. Tracked-by: (pending PR)
+- [ ] `parachute.computer/design/2026-05-18-v06-deploy-architecture.md` — current doc names Render as the deploy target. Add companion note pointing at the Fly migration doc + reframe as "container substrate; Render OR Fly per operator preference." Tracked-by: (pending PR)
 
 ## Operator-facing references
 
 - [ ] `parachute-hub/README.md` — Deploy section. Tracked-by: (pending PR)
 - [ ] `parachute.computer/index.njk` — landing page CTA. Tracked-by: (verify if changes needed)
-- [ ] `parachute.computer/roadmap.njk` — note the substrate shift if roadmap items reference Render. Tracked-by: (verify)
+- [ ] `parachute.computer/roadmap.njk` — note Fly added as a peer target if roadmap items reference Render specifically. Tracked-by: (verify)
 
 ## External references
 
-- [ ] npm package descriptions for `@openparachute/hub` — if they mention Render, update. (Likely no mention; verify.)
-- [ ] GitHub repo description for `parachute-hub` — if it mentions Render, update.
-- [ ] Any existing blog posts on `parachute.computer/blog/` that name Render — leave historical posts intact, but the next "shipping" post should name Fly as canonical.
+- [ ] npm package descriptions for `@openparachute/hub` — if they mention Render specifically, broaden. (Likely no mention; verify.)
+- [ ] GitHub repo description for `parachute-hub` — if it mentions Render specifically, broaden.
+- [ ] Existing blog posts on `parachute.computer/blog/` that name Render — leave historical posts intact; the next "shipping" post can mention Fly as an added option.
 
 ## Aaron's existing Render deploy
 
-Aaron's `parachute-hub.onrender.com` is currently the live demo. Migration plan:
+Aaron's `parachute-hub.onrender.com` is the live demo and stays on Render. Migration plan for Aaron specifically:
 
 1. Phase 1 lands fly.toml + scripts.
-2. Aaron runs `./scripts/deploy-to-fly.sh` to provision `parachute-hub.fly.dev` (or chosen subdomain).
-3. Smoke-test the Fly deploy end-to-end (wizard, install vault, install scribe, OAuth flow).
-4. Decision: keep both running, or cut over (Render disk → Fly volume migration).
-5. If cutting over: `sqlite3 hub.db ".backup ..."` from Render SSH, restore into Fly volume.
-
-Aaron's call on cutover timing; both deploys can coexist indefinitely.
+2. Aaron OPTIONALLY runs `./scripts/deploy-to-fly.sh` to dogfood a Fly deploy alongside the Render one.
+3. Both can coexist indefinitely.
+4. No cutover required. Render demo URL stays as long as Aaron wants it.
 
 ## What this migration does NOT do
 
-- Does not retire Render. `render.yaml` stays in the repo; operators on Render keep working.
+- Does not retire Render. `render.yaml` stays in the repo; operators on Render keep working unchanged.
+- Does not reorder primacy — Render and Fly are presented as peer choices throughout. No "primary self-host path" framing.
 - Does not change the local-install path (`parachute install ...` from npm). Local installs are platform-agnostic.
-- Does not start work on Phase 2 (hosted offering). That requires a fresh commitment.
+- Does not start work on Phase 2 (hosted offering on `parachute.cloud`). That requires a fresh commitment.
 - Does not change vault/scribe/app self-registration shape. Modules are platform-agnostic.
 
 ## Audit
 
-Run [`../scripts/audit-canonical-refs.sh`](../scripts/audit-canonical-refs.sh) after Phase 1 lands to verify no stale Render-as-only-path references remain in unexpected places.
+Run [`../scripts/audit-canonical-refs.sh`](../scripts/audit-canonical-refs.sh) after Phase 1 lands to verify no stale "Render is the path" framing leaked through.

--- a/migrations/2026-05-26-render-to-fly-self-host.md
+++ b/migrations/2026-05-26-render-to-fly-self-host.md
@@ -1,0 +1,90 @@
+---
+title: Render → Fly self-host migration (Phase 1)
+date: 2026-05-26
+status: active
+originating-pr: parachute.computer#62 (Fly migration design doc)
+---
+
+# Render → Fly self-host migration (Phase 1)
+
+Migrates the **canonical self-host path** from Render to Fly.io. Render support is preserved (`render.yaml` stays in the repo) — this shift recommends Fly as the primary path, with Render as an alternative for operators already on it.
+
+The full migration arc has four phases; this file tracks **Phase 1 only** (~2 weeks of work). Phases 2 (hosted offering via `parachute.cloud`), 3 (public launch), and 4 (Render sunset) are scoped in the design doc but require fresh commitment to start.
+
+Full architectural reasoning: [`parachute.computer/design/2026-05-26-fly-migration-path.md`](../../parachute.computer/design/2026-05-26-fly-migration-path.md).
+
+## Why the shift
+
+- **Lock-in symmetry.** Render disks have no portable snapshot export. Fly volumes do (`fly volumes snapshot create`, restorable into other orgs). The escape hatch matters for self-hosters and matters more when a hosted offering is on the table.
+- **Substrate alignment.** A future hosted offering (`parachute.cloud`, Phase 2+) runs the same image on the same platform as self-host. One CI pipeline, one bug-fix path, one ops model.
+- **Cost shape.** Fly shared-cpu-1x 512MB iad is $3.34/mo all-in vs Render Starter $7/mo. The delta funds the hosted offering's margin.
+- **Non-driver: reliability.** Fly and Render both have intermittent edge-router issues (Fly `fly-proxy` regressions; Render `portdetectorv2` flap caught at [hub#399](https://github.com/ParachuteComputer/parachute-hub/issues/399)). This shift is not motivated by reliability.
+
+## Phase 1 — self-host on Fly
+
+Aaron committed 2026-05-26 to Phase 1 only (Option A in the design doc): spike the Fly track for self-hosters, with explicit decision point at the end before committing to Phase 2 (hosted offering).
+
+### Exit criteria
+
+A friend can fork `parachute-hub` + run `./scripts/deploy-to-fly.sh` + install vault from the admin SPA, in under 5 minutes, with the same UX as the Render path.
+
+## Code references
+
+### parachute-hub
+
+- [ ] `fly.toml` — new file at repo root, alongside the existing `render.yaml`. Pinned to shared-cpu-1x 512MB / iad / 1GB volume at `/parachute`. Tracked-by: (pending PR)
+- [ ] `src/hub-server.ts:263` — `canonicalOrigin` resolver recognizes `FLY_APP_NAME` (composes `https://${FLY_APP_NAME}.fly.dev` as a peer to the existing `RENDER_EXTERNAL_URL` branch). Tracked-by: (pending PR)
+- [ ] `src/setup-wizard.ts:236` — auto-skip-expose step recognizes Fly the same way it recognizes Render (platform routes URL publicly without operator action). Tracked-by: (pending PR)
+- [ ] `src/api-hub.ts:145` — Fly equivalents for `RENDER_GIT_COMMIT` + `RENDER_GIT_BRANCH` (Fly sets `FLY_RELEASE_COMMAND`, `FLY_REGION` — different shape; decide what the admin "build info" panel actually needs). Tracked-by: (pending PR)
+- [ ] `scripts/deploy-to-fly.sh` — new wrapper that detects `flyctl`, installs if missing, runs `fly launch --copy-config --yes`, prints the URL. Tracked-by: (pending PR)
+- [ ] `README.md` — Deploy-to-Fly as the primary path; Render moves to alternative. Tracked-by: (pending PR)
+
+### parachute.computer
+
+- [ ] `deploy/render.njk` — soften framing from "the canonical self-host path" to "one of two paths"; cross-link to Fly. Tracked-by: (pending PR)
+- [ ] `deploy/fly.njk` — new doc, sibling of `deploy/render.njk`, walkthrough for the Fly path. Tracked-by: (pending PR)
+- [ ] `deploy/index.njk` (if it exists; else `/deploy` landing) — show both options, Fly first. Tracked-by: (pending PR)
+
+### parachute-patterns
+
+- [ ] `patterns/canonical-ports.md` — no change expected (ports are platform-agnostic). Verify.
+- [ ] `patterns/module-self-registration.md` — verify no platform-specific assumptions.
+
+## Doc references
+
+- [ ] `parachute.computer/design/2026-05-18-v06-deploy-architecture.md` — current doc names Render as primary self-host path. Add companion note pointing at the Fly migration doc + note that Phase 1 recommends Fly. Tracked-by: (pending PR)
+
+## Operator-facing references
+
+- [ ] `parachute-hub/README.md` — Deploy section. Tracked-by: (pending PR)
+- [ ] `parachute.computer/index.njk` — landing page CTA. Tracked-by: (verify if changes needed)
+- [ ] `parachute.computer/roadmap.njk` — note the substrate shift if roadmap items reference Render. Tracked-by: (verify)
+
+## External references
+
+- [ ] npm package descriptions for `@openparachute/hub` — if they mention Render, update. (Likely no mention; verify.)
+- [ ] GitHub repo description for `parachute-hub` — if it mentions Render, update.
+- [ ] Any existing blog posts on `parachute.computer/blog/` that name Render — leave historical posts intact, but the next "shipping" post should name Fly as canonical.
+
+## Aaron's existing Render deploy
+
+Aaron's `parachute-hub.onrender.com` is currently the live demo. Migration plan:
+
+1. Phase 1 lands fly.toml + scripts.
+2. Aaron runs `./scripts/deploy-to-fly.sh` to provision `parachute-hub.fly.dev` (or chosen subdomain).
+3. Smoke-test the Fly deploy end-to-end (wizard, install vault, install scribe, OAuth flow).
+4. Decision: keep both running, or cut over (Render disk → Fly volume migration).
+5. If cutting over: `sqlite3 hub.db ".backup ..."` from Render SSH, restore into Fly volume.
+
+Aaron's call on cutover timing; both deploys can coexist indefinitely.
+
+## What this migration does NOT do
+
+- Does not retire Render. `render.yaml` stays in the repo; operators on Render keep working.
+- Does not change the local-install path (`parachute install ...` from npm). Local installs are platform-agnostic.
+- Does not start work on Phase 2 (hosted offering). That requires a fresh commitment.
+- Does not change vault/scribe/app self-registration shape. Modules are platform-agnostic.
+
+## Audit
+
+Run [`../scripts/audit-canonical-refs.sh`](../scripts/audit-canonical-refs.sh) after Phase 1 lands to verify no stale Render-as-only-path references remain in unexpected places.


### PR DESCRIPTION
Propagation checklist for the Fly migration accepted 2026-05-26. Phase 1 only (~2 weeks). See `parachute.computer/design/2026-05-26-fly-migration-path.md` for the full architectural reasoning.