### PR TITLE
docs(patterns): missing-dependency UX pattern + migration (#188)

### DIFF
--- a/migrations/2026-05-29-missing-dependency-ux.md
+++ b/migrations/2026-05-29-missing-dependency-ux.md
@@ -1,0 +1,127 @@
+---
+title: Missing-dependency UX — actionable install messages across all spawn sites (task #188)
+date: 2026-05-29
+status: active
+originating-pr: parachute-patterns (this normative-contract PR)
+---
+
+# Missing-dependency UX
+
+Every external-binary spawn site that can crash with a cryptic `Executable
+not found in $PATH` must instead give an **actionable install message** —
+"install it via `<OS commands>` / or ask your system administrator." The
+normative contract is [`patterns/missing-dependency-ux.md`](../patterns/missing-dependency-ux.md):
+one wire shape (`error_type: "missing_dependency"`, HTTP 503), one 5-part
+message anatomy, three surfaces (CLI / HTTP / SPA). The registry + formatter +
+ENOENT helpers live in a shared lib, **`@openparachute/depcheck`** (built in
+`parachute-hub/packages/depcheck`, mirroring the `scope-guard` subpackage);
+each module wires its own spawn sites.
+
+## Why the shift
+
+Audit (2026-05-29, task #188) across the four committed-core repos + runner:
+**77 external-binary spawn sites; 21 produce cryptic crashes when the binary is
+missing.** This generalizes two prior point-fixes into one ecosystem contract:
+
+- **vault#415** — `git`-not-installed leaked the raw spawn error on a git-less
+  server; the fix (`git-preflight.ts`: `GitNotInstalledError`,
+  `ensureGitAvailable`, `isGitNotFoundSpawnError`, 503 `git_not_installed`) is
+  the shape depcheck generalizes across every binary.
+- **cloudflared (hub)** — `dnf install cloudflared` returns "No match for
+  argument: cloudflared" on Amazon Linux 2023; `cloudflaredInstallHint` taught
+  us the static-binary curl recipe wins over distro packages, and an unknown
+  arch drops to docs rather than fabricating a 404ing URL.
+
+## Adoption checklist
+
+Each line gets a PR-number slot, filled as it lands.
+
+- [ ] **depcheck lib publish** — `@openparachute/depcheck` in
+  `parachute-hub/packages/depcheck`: `DepSpec`, registry, `ensureExecutable`,
+  `rethrowIfMissing`, `formatMissingDependency`, `toWire`. Published to npm `rc`
+  dist-tag so siblings can depend on it. — _PR TBD (parachute-hub)_
+- [ ] **hub adoption** — wire hub's own spawn sites + the shared SPA error
+  component switch on `error_type === "missing_dependency"`. — _PR TBD (parachute-hub)_
+- [ ] **vault adoption** — route the vault gap sites through depcheck; fold the
+  existing `git-preflight.ts` into the shared lib (or have it re-export). —
+  _PR TBD (parachute-vault)_
+- [ ] **scribe adoption** — wire the transcription-provider spawn sites
+  (`whisper` / `parakeet` / `onnx` / `ffmpeg`) with `optional` + `altHint`. —
+  _PR TBD (parachute-scribe)_
+- [ ] **runner adoption** — wire the `claude` spawn site (`optional` + altHint:
+  install Claude Code). — _PR TBD (parachute-runner)_
+
+## The 21 gap sites (adopter work list)
+
+Grouped by repo. Each adopter routes these through `ensureExecutable` +
+`rethrowIfMissing` (belt-and-suspenders) and maps the HTTP path to 503 +
+`error_type: "missing_dependency"`.
+
+### parachute-hub
+
+- [ ] `tailscale` — `src/.../run.ts:12`
+- [ ] supervisor `startCmd` (the bare "failed") — `src/.../lifecycle.ts:81`
+- [ ] `tail` — `src/.../lifecycle.ts:949`
+- [ ] `install.ts:739` — `parachute-vault` spawn
+
+### parachute-vault
+
+- [ ] `tail` — `src/cli.ts:1647`
+- [ ] `git` (mirror credentials) — `src/mirror-credentials.ts:646`, `:657`, `:680`, `:687`
+- [ ] `launchctl` — `src/launchd.ts:105`
+- [ ] `systemctl` — `src/systemd.ts:57`–`:77`
+- [ ] `tar` (backup) — `src/backup.ts:249`, `:252`
+
+### parachute-scribe
+
+- [ ] `parakeet` — `src/.../parakeet-mlx.ts:12` (optional / altHint)
+- [ ] `whisper` — `src/.../whisper.ts:16` (optional / altHint)
+- [ ] `onnx` — `src/.../onnx-asr.ts:25` (optional / altHint)
+- [ ] `ffmpeg` — `src/.../onnx-asr.ts:15` (foundational within the provider)
+
+### parachute-runner
+
+- [ ] `claude` — `src/spawn.ts:160` (optional / altHint)
+
+> Line numbers are from the 2026-05-29 audit snapshot; adopters should confirm
+> against the live tree before wiring (the spawn sites may have drifted).
+
+## Code references
+
+- [ ] `parachute-hub/packages/depcheck/**` — the shared lib (NEW package). —
+  _PR TBD_
+- [ ] hub / vault / scribe / runner spawn sites above — _per-repo PRs TBD_
+- [ ] `parachute-vault/src/git-preflight.ts` — reconcile with depcheck (fold or
+  re-export so vault doesn't carry a parallel registry). — _PR TBD_
+- [ ] hub's shared SPA error component — add the
+  `error_type === "missing_dependency"` branch (install card). — _PR TBD_
+
+## Doc references
+
+- [x] `parachute-patterns/patterns/missing-dependency-ux.md` — the normative
+  contract (this PR).
+- [x] `parachute-patterns/scripts/audit-canonical-refs.sh` — drift block for
+  hand-synced install strings outside depcheck (this PR).
+- [ ] `@openparachute/depcheck` README — usage + registry shape. — _PR TBD (with the lib)_
+
+## Operator-facing references
+
+- None today. The operator-visible change is *better error messages*, not a
+  command/flag change; no README install-step or blog copy references these
+  spawn sites by name. (Adopter PRs may update per-repo troubleshooting docs.)
+
+## External references
+
+- [ ] npm: `@openparachute/depcheck` package description (set when first
+  published). No GitHub repo description change — the lib lives inside
+  parachute-hub.
+
+## Cross-references
+
+- [`../patterns/missing-dependency-ux.md`](../patterns/missing-dependency-ux.md)
+  — the normative contract.
+- [`../patterns/service-to-service-auth.md`](../patterns/service-to-service-auth.md)
+  — the `@openparachute/scope-guard` precedent depcheck's packaging mirrors.
+- vault#415 (`git-preflight.ts`) — the point-fix this generalizes.
+- hub `cloudflaredInstallHint` (`src/cloudflare/detect.ts`) — the
+  static-binary-over-distro lesson.

--- a/migrations/2026-05-29-missing-dependency-ux.md
+++ b/migrations/2026-05-29-missing-dependency-ux.md
@@ -2,7 +2,7 @@
 title: Missing-dependency UX — actionable install messages across all spawn sites (task #188)
 date: 2026-05-29
 status: active
-originating-pr: parachute-patterns (this normative-contract PR)
+originating-pr: patterns#110
 ---
 
 # Missing-dependency UX
@@ -36,12 +36,18 @@ missing.** This generalizes two prior point-fixes into one ecosystem contract:
 
 Each line gets a PR-number slot, filled as it lands.
 
-- [ ] **depcheck lib publish** — `@openparachute/depcheck` in
+- [x] **depcheck lib built + merged** — `@openparachute/depcheck` in
   `parachute-hub/packages/depcheck`: `DepSpec`, registry, `ensureExecutable`,
-  `rethrowIfMissing`, `formatMissingDependency`, `toWire`. Published to npm `rc`
-  dist-tag so siblings can depend on it. — _PR TBD (parachute-hub)_
-- [ ] **hub adoption** — wire hub's own spawn sites + the shared SPA error
-  component switch on `error_type === "missing_dependency"`. — _PR TBD (parachute-hub)_
+  `rethrowIfMissing`, `formatMissingDependency`, `toMissingDependencyWire`. —
+  **hub#483** (merged to hub main, rc.19). _npm publish to the `rc` dist-tag
+  still PENDING — needs the one-time npm Trusted-Publisher rule for the new
+  package + a `depcheck-v0.1.0-rc.1` tag push; siblings can't depend on it
+  until then._
+- [x] **hub adoption** — wired hub's spawn sites (tailscale, supervisor
+  `startCmd`→`services.json` status, tail, cloudflare/detect fold,
+  api-modules-ops) + the shared SPA install card switch on
+  `error_type === "missing_dependency"`. — **hub#483**. _(install.ts:739
+  vault-init spawn deferred — see gap list.)_
 - [ ] **vault adoption** — route the vault gap sites through depcheck; fold the
   existing `git-preflight.ts` into the shared lib (or have it re-export). —
   _PR TBD (parachute-vault)_
@@ -59,10 +65,10 @@ Grouped by repo. Each adopter routes these through `ensureExecutable` +
 
 ### parachute-hub
 
-- [ ] `tailscale` — `src/.../run.ts:12`
-- [ ] supervisor `startCmd` (the bare "failed") — `src/.../lifecycle.ts:81`
-- [ ] `tail` — `src/.../lifecycle.ts:949`
-- [ ] `install.ts:739` — `parachute-vault` spawn
+- [x] `tailscale` — `src/.../run.ts:12` — hub#483
+- [x] supervisor `startCmd` (the bare "failed") — `src/.../lifecycle.ts:81` → `services.json` `lastStartError` — hub#483
+- [x] `tail` — `src/.../lifecycle.ts:949` — hub#483
+- [ ] `install.ts:739` — `parachute-vault` spawn (deferred in hub#483; captures exit code rather than raw-crashing — low priority)
 
 ### parachute-vault
 
@@ -88,13 +94,13 @@ Grouped by repo. Each adopter routes these through `ensureExecutable` +
 
 ## Code references
 
-- [ ] `parachute-hub/packages/depcheck/**` — the shared lib (NEW package). —
-  _PR TBD_
-- [ ] hub / vault / scribe / runner spawn sites above — _per-repo PRs TBD_
+- [x] `parachute-hub/packages/depcheck/**` — the shared lib (NEW package). —
+  hub#483
+- [x] hub spawn sites — hub#483. _vault / scribe / runner spawn sites: per-repo PRs TBD_
 - [ ] `parachute-vault/src/git-preflight.ts` — reconcile with depcheck (fold or
-  re-export so vault doesn't carry a parallel registry). — _PR TBD_
-- [ ] hub's shared SPA error component — add the
-  `error_type === "missing_dependency"` branch (install card). — _PR TBD_
+  re-export so vault doesn't carry a parallel registry). — _PR TBD (vault adoption)_
+- [x] hub's shared SPA error component — `error_type === "missing_dependency"`
+  install card. — hub#483
 
 ## Doc references
 

--- a/patterns/missing-dependency-ux.md
+++ b/patterns/missing-dependency-ux.md
@@ -1,0 +1,283 @@
+# Missing-dependency UX
+
+> When a module shells out to an external binary that isn't installed, the
+> operator gets an **actionable install message** — never a raw `Executable
+> not found in $PATH` crash. One wire shape, one message anatomy, three
+> surfaces. The dependency registry + message formatter live in one shared
+> lib (`@openparachute/depcheck`); every spawn site routes through it.
+
+## The convention (TL;DR)
+
+A Parachute module spawns external binaries (`git`, `tail`, `tar`,
+`systemctl`, `launchctl`, `ffmpeg`, `whisper`, `claude`, …). When the binary
+is absent, the module must:
+
+1. **Preflight** existence before the spawn (`ensureExecutable`), AND
+2. **Catch** post-spawn ENOENT (`rethrowIfMissing`) — belt-and-suspenders for
+   the check-then-act race.
+
+Both paths produce one `MissingDependencyError` carrying a `DepSpec`. That
+error renders to the right surface:
+
+- **CLI** → full install block + `Or ask your system administrator…` trailer
+  on stderr, exit 1 (ANSI-coloured).
+- **HTTP** → **503 Service Unavailable** with the
+  [proxy-error-ui](https://github.com/ParachuteComputer/parachute-hub/blob/main/src/proxy-error-ui.ts)
+  wire shape, `error_type: "missing_dependency"`.
+- **SPA** → the shared error component switches on `error_type` and renders a
+  dedicated install card (copy-buttons, docs link).
+
+The registry, the message formatter, and the ENOENT helpers are owned by
+**`@openparachute/depcheck`** (built in `parachute-hub/packages/depcheck`,
+mirroring the [`scope-guard`](https://github.com/ParachuteComputer/parachute-hub/tree/main/packages/scope-guard)
+subpackage). Each module wires its own spawn sites; the strings live in one
+place.
+
+This pattern is **normative**. Even modules that don't (yet) adopt depcheck —
+and external module authors — follow the wire shape, status code, and message
+anatomy below.
+
+## Why
+
+Audit (2026-05-29, task #188) across the four committed-core repos + runner
+found **77 external-binary spawn sites; 21 crash with a cryptic error when the
+binary is missing.** Raw `Executable not found in $PATH: "git"` (HTTP 500,
+`error_type: internal`) on a fresh Amazon Linux EC2 box; `tail` / `tar` /
+`systemctl` / `launchctl` in the vault CLI; scribe's transcription providers
+(`whisper` / `ffmpeg` / `parakeet` / `onnx`); the supervisor's `startCmd`
+showing a bare "failed."
+
+Two prior incidents established the shape this pattern generalizes:
+
+- **vault#415** — `git` missing on a git-less server leaked the raw spawn
+  error through the import / sync / mirror paths. The fix
+  ([`git-preflight.ts`](https://github.com/ParachuteComputer/parachute-vault/blob/main/src/git-preflight.ts))
+  introduced `GitNotInstalledError`, `ensureGitAvailable`, the
+  `isGitNotFoundSpawnError` belt-and-suspenders heuristic, and the **503
+  `git_not_installed`** mapping ahead of the generic `internal` catch. This
+  pattern is that fix, generalized across every binary and module.
+- **cloudflared** — hub's `cloudflaredInstallHint`
+  ([`src/cloudflare/detect.ts`](https://github.com/ParachuteComputer/parachute-hub/blob/main/src/cloudflare/detect.ts))
+  learned the hard way that `sudo dnf install cloudflared` returns *"No match
+  for argument: cloudflared"* on Amazon Linux 2023 — so the static-binary
+  `curl` recipe is the reliable cross-distro path, and an unknown arch drops
+  to the docs URL rather than fabricating a 404ing download.
+
+The product owner's requirement (Aaron, 2026-05-29): **every missing-dependency
+path gives an actionable "install it via `<OS commands>` / or ask your
+sys-admin" message.**
+
+## The wire shape
+
+Aligned with the `{ error, error_type, error_description }` snake_case
+convention already used in
+[`proxy-error-ui.ts`](https://github.com/ParachuteComputer/parachute-hub/blob/main/src/proxy-error-ui.ts)
+(and `api-modules-config.ts` etc.). The SPA discriminates on `error_type`, not
+the numeric status.
+
+```ts
+interface MissingDependencyWire {
+  error: "missing_dependency";
+  error_type: "missing_dependency";
+  /** The full interactive:false install block — ANSI + sysadmin trailer STRIPPED.
+   *  Always present; the universal fallback for any consumer that doesn't
+   *  special-case error_type. */
+  error_description: string;
+
+  /** Structured fields so a rich consumer (SPA) can render its own card. */
+  binary: string;                     // "git", "ffmpeg", "tail", …
+  why: string;                        // "import a repo", "transcode audio", …
+  docs_url: string;                   // ALWAYS present
+  install: {
+    darwin?: string;                  // e.g. "brew install git"
+    linux?: string;                   // distro lines and/or a curl recipe
+    generic?: string;                 // fallback when platform is unknown
+  };
+  /** Foundational deps only — replaced by an altHint for optional provider deps. */
+  sysadmin_hint?: string;             // "Or ask your system administrator to install it for you."
+}
+```
+
+### HTTP status = 503
+
+**503 Service Unavailable**, not 424. This matches the `proxy-error-ui.ts`
+precedent (upstream-starting / unreachable already use 502/503) and vault#415's
+`git_not_installed` → 503 mapping. RFC 9110: 503 = "the request can't be served
+right now; a dependency is missing — fix it and retry." The SPA and CLI
+discriminate on `error_type`, never on the numeric code.
+
+## The 5-part message anatomy
+
+Every rendered message is built from these parts, in order. The formatter
+(`formatMissingDependency`) owns the assembly so the shape never drifts:
+
+1. **The problem line.**
+   `<binary> is required to <why>, but it was not found on PATH.`
+   e.g. `ffmpeg is required to transcode audio, but it was not found on PATH.`
+
+2. **The install block.** An `Install it:` header, then OS-specific lines (see
+   *show all distro lines* below).
+
+3. **The docs URL.** Always present — the durable reference even when the
+   install lines don't fit the operator's box.
+
+4. **The sysadmin trailer** (foundational deps): the line Aaron explicitly
+   asked for —
+   `Or ask your system administrator to install it for you.`
+   On **every foundational** dependency.
+
+5. **For `optional: true` provider deps, part 4 is REPLACED by an `altHint`** —
+   e.g. `…or switch transcription provider (PARACHUTE_SCRIBE_PROVIDER).` An
+   operator who can't install `whisper` has a product-level escape hatch a
+   sysadmin can't provide, so the sysadmin trailer would be the wrong advice.
+
+## The "show all distro lines, don't detect" rule
+
+When the platform is known, **lead with that OS's line but STILL list the
+others.** Operators routinely SSH into a box the formatter mis-detects
+(containers, cross-arch, an env that lies about `process.platform`); it's
+cheaper to print three lines than to gamble on one. This is the vault
+git-preflight precedent — `GitNotInstalledError`'s message names `dnf` /
+`apt-get` / `brew` all at once rather than detecting the distro.
+
+When the platform is **unknown**, show all families + the docs URL.
+
+```
+Install it:
+  macOS:          brew install ffmpeg          ← led with (detected darwin)
+  Debian/Ubuntu:  sudo apt-get install ffmpeg
+  Fedora/RHEL:    sudo dnf install ffmpeg
+  Docs:           https://ffmpeg.org/download.html
+```
+
+## The "static binary over distro package" rule
+
+A `linuxBinaryUrl` curl recipe **WINS** over distro packages when the DepSpec
+sets it. The cloudflared incident is the canonical lesson: `dnf install
+cloudflared` returns *"No match for argument: cloudflared"* on Amazon Linux
+2023, so a distro line that *looks* right actively misleads. When a static
+binary release exists, prefer it:
+
+```
+Install it (static binary — works across distros):
+  curl -L -o /usr/local/bin/cloudflared \
+    https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
+  sudo chmod +x /usr/local/bin/cloudflared
+```
+
+**Never fabricate a 404ing URL for an unknown arch.** If the DepSpec can't map
+the host arch to a real release artifact, drop the curl recipe and fall back to
+the docs URL — same as `cloudflaredInstallHint` returns the docs link for an
+unrecognized arch.
+
+## Belt-and-suspenders: preflight AND catch
+
+Every spawn site does **both**:
+
+```ts
+// 1. Preflight — fail fast with the friendly error before spawning.
+ensureExecutable(GIT_DEP);            // throws MissingDependencyError if `which git` is empty
+
+// 2. Catch — covers the check-then-act race (binary removed between check and spawn,
+//    or a nested spawn we didn't preflight).
+try {
+  await Bun.spawn(["git", "clone", url]);
+} catch (err) {
+  rethrowIfMissing(err, GIT_DEP);     // ENOENT → MissingDependencyError; else re-throw
+  throw err;
+}
+```
+
+`ensureExecutable` is the `ensureGitAvailable` shape generalized; `rethrowIfMissing`
+is `isGitNotFoundSpawnError` generalized. Neither alone is sufficient: the
+preflight gives the best error before any work starts; the catch closes the
+race and covers spawn sites buried in libraries you can't preflight.
+
+## Three-surface degradation
+
+| Surface | How it renders | sysadmin trailer | ANSI |
+|---|---|---|---|
+| **CLI** | `formatMissingDependency(spec, { interactive: true })` → stderr, exit 1. Full 5-part block. | ✅ present | ✅ coloured |
+| **HTTP** | 503 + `toWire(spec)`. `error_description` is the `interactive: false` block. | ❌ **stripped** | ❌ stripped |
+| **SPA** | Shared error component switches on `error_type === "missing_dependency"` → dedicated install card (copy-buttons per OS line, docs link, muted hint). Falls back to `error_description` verbatim. | (rendered as muted hint) | n/a |
+
+Why the HTTP wire **strips** the sysadmin trailer and ANSI: a daemon-log
+reader **is** the sysadmin. Telling the person reading the server log to "ask
+your system administrator" is circular; and ANSI escapes are noise in a log
+file or a JSON field. The SPA re-adds the human-facing affordances (copy
+buttons, the muted hint) from the structured fields.
+
+**The SPA fallback is load-bearing.** The component renders the dedicated card
+*only* when it recognizes `error_type`; for any unrecognized type — or an older
+bundle that predates this pattern — it falls back to printing
+`error_description` verbatim. That string is always a complete, human-readable
+message, so a stale SPA degrades to "correct but plain," never to "blank box."
+
+## Foundational vs optional
+
+The `DepSpec` carries `optional?: boolean` + `altHint?: string`:
+
+- **Foundational** (`git`, `tail`, `tar`, `systemctl`, `launchctl`, `ffmpeg`)
+  — the operation cannot proceed without it; there's no product-level
+  alternative. → **sysadmin hint** (message part 4).
+- **Provider-style / optional** (`whisper`, `onnx`, `parakeet`, `claude`) — a
+  swappable backend; the operator can pick a different one. → **altHint**
+  replaces the sysadmin trailer (message part 5). `ffmpeg` is foundational
+  *within* a provider that needs it even though the provider itself is
+  optional — the distinction is "is there an alternative the operator
+  controls," not "is the parent feature optional."
+
+## The canonical implementation: `@openparachute/depcheck`
+
+The shared lib owns:
+
+- **`DepSpec`** — `{ binary, why, docsUrl, install: { darwin?, linux?, generic? }, linuxBinaryUrl?, optional?, altHint? }`.
+- **The registry** — one `DepSpec` per known binary, keyed by binary name. The
+  single source of truth for install strings. No module hand-syncs them.
+- **`ensureExecutable(spec, which = Bun.which)`** — preflight; throws
+  `MissingDependencyError`. `which` is a test seam.
+- **`rethrowIfMissing(err, spec)`** — ENOENT heuristic; re-throws as
+  `MissingDependencyError`, passes everything else through.
+- **`formatMissingDependency(spec, { interactive })`** — the 5-part assembler.
+- **`toWire(spec)`** — the `MissingDependencyWire` builder (503 body).
+
+```ts
+import { ensureExecutable, rethrowIfMissing, toWire } from "@openparachute/depcheck";
+```
+
+The lib is the **engine, not the policy** — same shape as scope-guard (the lib
+matches scopes; per-service vocabularies stay in each service). DepSpecs for
+binaries unique to one module live with that module and register at import; the
+registry holds the cross-cutting foundational ones (`git`, `tail`, `tar`, …).
+
+**Every NEW spawn site, in any module, must route through `ensureExecutable` +
+`rethrowIfMissing`.** Hand-rolling a bespoke install string in a new spawn site
+is the drift this pattern exists to prevent. The audit script
+([`scripts/audit-canonical-refs.sh`](../scripts/audit-canonical-refs.sh)) flags
+modules carrying their own `brew install` / `apt-get install` / `dnf install`
+/ `Executable not found` literals outside depcheck.
+
+## Patterns check (governance rule 3)
+
+Reviewers: when a PR adds or touches an external-binary spawn site, verify it
+(a) preflights with `ensureExecutable`, (b) catches with `rethrowIfMissing`,
+(c) maps the HTTP path to 503 + `error_type: "missing_dependency"`, and (d)
+adds no hand-synced install strings outside `@openparachute/depcheck`. A new
+foundational binary needs a registry DepSpec, not an inline message.
+
+## History
+
+- **2026-05-29** — established (task #188). Generalizes vault#415's
+  `git-preflight.ts` (the 503 `git_not_installed` shape) and the hub
+  `cloudflaredInstallHint` static-binary-over-distro lesson. Adoption tracked
+  in [`migrations/2026-05-29-missing-dependency-ux.md`](../migrations/2026-05-29-missing-dependency-ux.md).
+
+## Related patterns
+
+- [`service-to-service-auth.md`](./service-to-service-auth.md) — the other
+  shared-lib precedent (`@openparachute/scope-guard`); depcheck mirrors its
+  packaging shape.
+- [`report-contract.md`](./report-contract.md) — structured-not-narrative
+  shape, the same instinct applied to agent reports.
+- [`design-system.md`](./design-system.md) — the SPA error card lives in the
+  shared error component this pattern hooks `error_type` into.

--- a/patterns/missing-dependency-ux.md
+++ b/patterns/missing-dependency-ux.md
@@ -93,8 +93,10 @@ interface MissingDependencyWire {
     linux?: string;                   // distro lines and/or a curl recipe
     generic?: string;                 // fallback when platform is unknown
   };
-  /** Foundational deps only — replaced by an altHint for optional provider deps. */
-  sysadmin_hint?: string;             // "Or ask your system administrator to install it for you."
+  /** ALWAYS present. The foundational-dep trailer ("Or ask your system
+   *  administrator to install it for you."), or — for optional provider deps
+   *  — the spec's altHint instead. Never omitted. */
+  sysadmin_hint: string;
 }
 ```
 
@@ -133,14 +135,17 @@ Every rendered message is built from these parts, in order. The formatter
 
 ## The "show all distro lines, don't detect" rule
 
-When the platform is known, **lead with that OS's line but STILL list the
-others.** Operators routinely SSH into a box the formatter mis-detects
-(containers, cross-arch, an env that lies about `process.platform`); it's
-cheaper to print three lines than to gamble on one. This is the vault
-git-preflight precedent — `GitNotInstalledError`'s message names `dnf` /
-`apt-get` / `brew` all at once rather than detecting the distro.
+When the platform is known, show **all of that platform family's options** —
+never detect the distro. On Linux that means listing **both `apt-get` and
+`dnf`** (plus the static-binary curl recipe when set): we can tell Linux from
+macOS via `process.platform`, but we cannot tell Debian from Fedora, and a box
+we guess wrong on (containers, cross-distro, an env that lies) actively
+misleads. This is the vault git-preflight lesson — name every in-family manager
+rather than gambling on one. (The formatter scopes to the detected *platform
+family*; it does not print macOS `brew` on a Linux box, the one case where the
+cross-platform line carries no value.)
 
-When the platform is **unknown**, show all families + the docs URL.
+When the platform is **unknown** (`win32`/other), show all families + the docs URL.
 
 ```
 Install it:
@@ -231,18 +236,19 @@ The `DepSpec` carries `optional?: boolean` + `altHint?: string`:
 
 The shared lib owns:
 
-- **`DepSpec`** — `{ binary, why, docsUrl, install: { darwin?, linux?, generic? }, linuxBinaryUrl?, optional?, altHint? }`.
+- **`DepSpec`** — `{ binary, why, docsUrl, install: { darwin?, linuxApt?, linuxDnf?, linuxBinaryUrl?, generic? }, optional?, altHint? }`. (`install` carries the granular per-manager recipes; the flattened `MissingDependencyWire.install` collapses the Linux variants to a single `linux?` line for SPA rendering.)
 - **The registry** — one `DepSpec` per known binary, keyed by binary name. The
   single source of truth for install strings. No module hand-syncs them.
-- **`ensureExecutable(spec, which = Bun.which)`** — preflight; throws
-  `MissingDependencyError`. `which` is a test seam.
-- **`rethrowIfMissing(err, spec)`** — ENOENT heuristic; re-throws as
-  `MissingDependencyError`, passes everything else through.
-- **`formatMissingDependency(spec, { interactive })`** — the 5-part assembler.
-- **`toWire(spec)`** — the `MissingDependencyWire` builder (503 body).
+- **`ensureExecutable(binary, { which })`** — preflight; looks `binary` up in the
+  registry + throws `MissingDependencyError` when `which(binary)` is null.
+  `which` defaults to `Bun.which`; it's a test seam.
+- **`rethrowIfMissing(err, binary)`** — ENOENT heuristic; re-throws a
+  not-found error as `MissingDependencyError`, passes everything else through.
+- **`formatMissingDependency(binary, spec, { interactive })`** — the 5-part assembler (CLI/daemon text).
+- **`toMissingDependencyWire(binary, spec)`** — the `MissingDependencyWire` builder (503 body); also reachable as `MissingDependencyError#toWire()`.
 
 ```ts
-import { ensureExecutable, rethrowIfMissing, toWire } from "@openparachute/depcheck";
+import { ensureExecutable, rethrowIfMissing, toMissingDependencyWire } from "@openparachute/depcheck";
 ```
 
 The lib is the **engine, not the policy** — same shape as scope-guard (the lib

--- a/scripts/audit-canonical-refs.sh
+++ b/scripts/audit-canonical-refs.sh
@@ -200,6 +200,37 @@ echo "(vault no longer mints pvt_* opaque tokens — access tokens are hub-issue
 } || true
 echo ""
 
+# --- Missing-dependency UX: hand-synced install strings outside depcheck ----
+# patterns/missing-dependency-ux.md (task #188, migration 2026-05-29) makes
+# `@openparachute/depcheck` the single owner of dependency install strings +
+# the message formatter. A module carrying its own `brew install` /
+# `apt-get install` / `dnf install` recipe, or a raw `Executable not found`
+# literal, in `src/` is drift back to hand-synced strings — the exact thing
+# the shared lib exists to prevent.
+#
+# Advisory, not a hard fail (like the rest of the script). Expected legitimate
+# hits during the adoption arc: depcheck's own registry (packages/depcheck),
+# vault's git-preflight.ts (being folded into depcheck), hub's
+# cloudflaredInstallHint (the static-binary precedent) — these ARE the
+# canonical sources and are excluded. Anything else is a candidate to route
+# through depcheck.
+
+echo "--- Hand-synced install strings / raw 'Executable not found' outside @openparachute/depcheck ---"
+echo "(missing-dependency-ux.md — depcheck owns install recipes + the ENOENT message; modules wire spawn sites, they don't carry strings)"
+{
+  grep -rn "${GREP_DIR_EXCLUDES[@]}" \
+    --include='*.ts' --include='*.tsx' \
+    --exclude='*.test.ts*' \
+    --exclude-dir=depcheck \
+    -E "brew install|apt-get install|dnf install|Executable not found in \\\$PATH|not found on PATH" \
+    "$WORKSPACE"/parachute-hub "$WORKSPACE"/parachute-vault \
+    "$WORKSPACE"/parachute-scribe "$WORKSPACE"/parachute-runner 2>/dev/null \
+    | grep -v "$LINE_EXCLUDES" \
+    | grep -v "git-preflight\|cloudflaredInstallHint\|cloudflare/detect" \
+    | head -30
+} || true
+echo ""
+
 echo "=== Done. Review findings; cross-check against migrations/*.md. ==="
 echo ""
 echo "Notes:"
@@ -207,4 +238,5 @@ echo "  - Vendor/build dirs (node_modules, _site, dist, build, .next, .git, migr
 echo "  - CHANGELOGs + DEPRECATED.md are excluded line-level (they're historical record)."
 echo "  - parachute-notes/canonical-ports.md/service-spec.ts are excluded from the port-1942 check (they're the canonical source)."
 echo "  - parachute-agent retirement docs + launch-day artifacts are excluded from the agent check."
+echo "  - depcheck's own registry + vault git-preflight.ts + hub cloudflaredInstallHint are excluded from the install-string check (canonical sources)."
 echo "  - Add new grep blocks above when you hit a new class of stale ref."


### PR DESCRIPTION
## What

Establishes the **normative contract** for actionable missing-dependency UX across every external-binary spawn site in the ecosystem. When a module shells out to a binary that isn't installed, the operator gets an actionable "install it via `<OS commands>` / or ask your system administrator" message — never a raw `Executable not found in $PATH` crash.

Generalizes two prior point-fixes into one ecosystem contract:
- **vault#415** — `git-preflight.ts` (`GitNotInstalledError`, `ensureGitAvailable`, `isGitNotFoundSpawnError`, 503 `git_not_installed`).
- **hub cloudflaredInstallHint** — the static-binary-over-distro lesson (`dnf install cloudflared` → "No match for argument" on Amazon Linux 2023).

Audit (task #188) across the four committed-core repos + runner: **77 external-binary spawn sites; 21 crash cryptically when the binary is missing.**

## Files

- **`patterns/missing-dependency-ux.md`** — the normative contract. Pins: the `MissingDependencyWire` shape (`error_type: "missing_dependency"`, aligned with `proxy-error-ui.ts`); **HTTP 503** (not 424); the 5-part message anatomy; the "show all distro lines, don't detect" rule; the "static binary over distro package" rule; belt-and-suspenders (preflight `ensureExecutable` + catch `rethrowIfMissing`); the three-surface degradation table (CLI / HTTP / SPA); foundational-vs-optional (`sysadmin_hint` vs `altHint`); `@openparachute/depcheck` as the canonical implementation; a patterns-check note.
- **`migrations/2026-05-29-missing-dependency-ux.md`** — propagation checklist: depcheck publish + hub/vault/scribe/runner adoption (PR slots TBD), and the 21 gap sites grouped by repo.
- **`scripts/audit-canonical-refs.sh`** — advisory drift block flagging hand-synced `brew install` / `apt-get install` / `dnf install` / `Executable not found` literals in `src/` outside depcheck. Excludes the canonical sources (depcheck registry, vault git-preflight, hub cloudflaredInstallHint).

## Governance

- **Docs-only** — no version bump, no rc (doc-only exemption per governance rule 2).
- Audit script still runs clean (exit 0); the new block correctly surfaces the pre-adoption drift sites that the adoption arc will route through depcheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)