### PR TITLE
docs(oauth-scopes): vault-bound consent drops foreign scopes (hub#487)

### DIFF
--- a/patterns/oauth-scopes.md
+++ b/patterns/oauth-scopes.md
@@ -71,6 +71,15 @@ Canonical implementations:
 - **Per-vault audience binding.** Hub-issued vault JWTs carry
   `aud=vault.<name>` and vault strict-checks it on each request — a token
   scoped for one vault cannot be replayed against another.
+- **Vault-bound consent drops foreign scopes.** When a client sends an
+  RFC 8707 `resource=<origin>/vault/<name>/mcp` indicator (an MCP client
+  connecting to one vault), the hub narrows the consent — and the minted
+  token — to that vault's `vault:<name>:<verb>` scopes and **drops** any
+  non-vault scope (`scribe:*`, `channel:send`, `hub:admin`). Those are
+  unusable inside an `aud=vault.<name>` token and would only inflate the
+  consent surface a friend sees connecting a single vault. A client that
+  legitimately wants a `scribe:` token runs a separate flow naming the scribe
+  resource. (hub#487; see `parachute-hub/src/resource-binding.ts`.)
 - **`pvt_*` tokens are unaffected.** They predate the resource-bound
   shape; they're scoped at issue-time inside vault's own DB and the JWT
   validation layer is bypassed for them.


### PR DESCRIPTION
Records the rule shipped in **hub#487**: a vault-bound OAuth flow (RFC 8707 `resource=<origin>/vault/<name>/mcp`) narrows consent + the minted token to `vault:<name>:<verb>` and **drops** any non-vault scope (`scribe:*`, `channel:send`, `hub:admin`).

Added as a bullet under "Per-vault audience binding" in `patterns/oauth-scopes.md` — the rule it follows from (those scopes are unusable in an `aud=vault.<name>` token). Closes the reviewer follow-up from hub#487; documents shipped behavior, so no downstream adoption is needed (hub already enforces it). References hub#487 + `resource-binding.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)