### PR TITLE
docs: runtime-tenancy contract reconcile + surface-client Phase 1 migration

### DIFF
--- a/migrations/2026-06-03-surface-client.md
+++ b/migrations/2026-06-03-surface-client.md
@@ -1,0 +1,48 @@
+---
+title: surface-client Phase 1 — standalone bootstrap first-class + docs truth
+date: 2026-06-03
+status: active
+originating-pr: parachute-surface (surface-client Phase 1)
+---
+
+# surface-client Phase 1
+
+The [surface-client design doc](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-06-03-surface-client.md) plans the work that makes a custom Parachute surface a thin `import` instead of a ~1,300-line fork. Phase 1 is "make importing actually work for a standalone external dev": the standalone Dynamic-Client-Registration (DCR) OAuth bootstrap becomes first-class, and the package stops lying about its own name, version, and tenancy contract.
+
+This file is the propagation checklist. Phase 1 is mostly **additive + docs-truth** — the only *quoted-statement* shift is the runtime-tenancy contract reconcile (`getVaultPath` / `parachute-tenant-id` did not match the code). Later phases (the `createVaultSurface` factory, the `@openparachute/surface-render` extraction, the notes-ui + my-vault-ui migrations, the onboarding-prompt rewrite) get their own checklist items here as they land.
+
+## Scope (Phase 1)
+
+- Make the **standalone DCR bootstrap** usable through `ParachuteOAuth` (new `useClientId()` so the hosted-only `/surface/<name>/oauth-client` endpoint is never required).
+- README docs-truth: package name `@openparachute/app-client` → `@openparachute/surface-client`; quick-start leads with the standalone path; runtime-tenancy `<meta>` contract + fallbacks documented; typed-error → UI affordance guide.
+- Version drift: `index.ts` `APP_CLIENT_VERSION` (`0.1.0-rc.4`) reconciled to `package.json` (`0.1.0`); add correctly-named `SURFACE_CLIENT_VERSION`, keep `APP_CLIENT_VERSION` as a deprecated alias.
+- `examples/standalone-spa` — a minimal framework-free standalone surface proving the DCR flow.
+- Pattern-doc reconcile: `runtime-tenancy-contract.md` named `getVaultPath` + a `parachute-tenant-id` meta tag; the code exports `getVaultUrl` and derives tenant-id from the mount path. Code is the source of truth; the pattern doc was fixed to match.
+
+## Code references
+
+### parachute-surface (surface-client)
+
+- [x] `packages/surface-client/src/oauth.ts`: add `useClientId(info)` — seeds the in-memory client-info cache for the standalone DCR bootstrap so `beginFlow` / `handleCallback` / `refreshAccessToken` never hit the hosted endpoint. Tracked-by: surface-client Phase 1 PR.
+- [x] `packages/surface-client/src/index.ts`: `SURFACE_CLIENT_VERSION = "0.1.0"` (matches package.json); `APP_CLIENT_VERSION` kept as a deprecated alias. Tracked-by: surface-client Phase 1 PR.
+- [x] `packages/surface-client/src/__tests__/oauth.test.ts`: tests for the `useClientId` standalone path (5 new tests). Tracked-by: surface-client Phase 1 PR.
+
+### parachute-patterns
+
+- [x] `patterns/runtime-tenancy-contract.md`: drop `getVaultPath` (code exports `getVaultUrl`), drop the `parachute-tenant-id` meta tag (tenant-id is derived from the mount path via `getTenantId`), add `parachute-vault-origin`, note the never-throw/null-for-standalone semantics. Tracked-by: this PR.
+
+## Doc references
+
+- [x] `parachute-surface/packages/surface-client/README.md`: package name fixed; standalone-first quick-start; runtime-tenancy contract + fallback table; error-handling guide. Tracked-by: surface-client Phase 1 PR.
+- [ ] `parachute.computer/design/onboarding/surface-build.md`: rewrite from "hit the raw HTTP API / token-paste" to "import surface-client (+ surface-render)". **Phase 6** — not in Phase 1. Tracked-by: (pending).
+
+## Later-phase items (not Phase 1)
+
+- [ ] `createVaultSurface` factory with hosted/standalone auto-detect + auto-refresh VaultClient (**Phase 2**, surface-client). Tracked-by: (pending).
+- [ ] Extract `@openparachute/surface-render` (markdown + wikilinks + embeds + multi-format + MDX-safe-default) (**Phase 3**, parachute-surface). Tracked-by: (pending).
+- [ ] Migrate notes-ui onto surface-render; reconcile its `discovery.ts` shim against `createVaultSurface`'s `clientName` (**Phase 4**). Tracked-by: (pending).
+- [ ] Adopt both packages in `~/Code/my-vault-ui`, deleting its hand-rolled oauth/api/pkce/types + Markdown/AudioEmbed (**Phase 5**, external). Tracked-by: (pending).
+
+## Audit
+
+Run [`../scripts/audit-canonical-refs.sh`](../scripts/audit-canonical-refs.sh) before the next surface-client release to catch any lingering `@openparachute/app-client` references in docs.

--- a/patterns/runtime-tenancy-contract.md
+++ b/patterns/runtime-tenancy-contract.md
@@ -22,23 +22,32 @@ meta tags plus a `<base>` element in the served HTML:
   <meta name="parachute-mount" content="/surface/<name>">     <!-- runtime code reads this -->
   <meta name="parachute-hub" content="https://...">       <!-- hub origin for OAuth discovery -->
   <meta name="parachute-vault" content="/vault/<name>">   <!-- when operator's session is vault-bound -->
-  <meta name="parachute-tenant-id" content="<name>">      <!-- tenant's logical name within this host -->
+  <meta name="parachute-vault-origin" content="https://..."> <!-- cloud / cross-origin vault only -->
 </head>
 ```
+
+There is **no** `parachute-tenant-id` meta tag — the tenant's logical id is
+*derived* from the mount path (`getTenantId()` takes the last segment of
+`/surface/<name>`), not injected separately. The host injects the mount; the
+id falls out of it.
 
 Tenants consume via `@openparachute/surface-client`:
 
 ```ts
 import {
-  getMountBase,
-  getHubOrigin,
-  getVaultPath,
-  getTenantId,
+  getMountBase,   // mount path (React Router basename), trailing slash stripped
+  getHubOrigin,   // hub origin for OAuth discovery
+  getVaultUrl,    // fully-qualified vault URL (origin + path), ready for fetch()
+  getTenantId,    // logical tenant id, derived from the mount path
 } from '@openparachute/surface-client';
 ```
 
-The helpers read the meta tags, return typed values, and throw clear
-errors when the host hasn't injected what the tenant expects.
+The helpers read the meta tags and return typed values. They **never throw**:
+a missing tag returns `null` and the caller chooses the fallback (this is
+load-bearing for *standalone* surfaces, which have no host injecting the tags
+— see the surface-client README's "Runtime-tenancy contract" section). Note
+the exported reader is **`getVaultUrl`** (returns a fully-qualified URL so
+`fetch(getVaultUrl())` works directly) — there is no `getVaultPath` export.
 
 ## Two-layer rationale
 


### PR DESCRIPTION
Companion to **parachute-surface PR #67** (surface-client Phase 1). These two changes live in parachute-patterns and so ship as their own PR.

## Changes

**1. `patterns/runtime-tenancy-contract.md` reconcile (code is source of truth).**
The pattern doc named `getVaultPath` and a `parachute-tenant-id` meta tag. The actual `surface-client` code:
- exports **`getVaultUrl`** (returns a fully-qualified URL — origin + path — so `fetch(getVaultUrl())` works), **not** `getVaultPath`;
- derives the tenant id from the mount path via **`getTenantId`**, with **no** `parachute-tenant-id` tag.

Per the [surface-client design doc](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-06-03-surface-client.md) §8 + §10, the code is the source of truth. Fixed the doc to match: corrected the import example + the `<meta>` block, added `parachute-vault-origin` (cross-origin vault), and documented the never-throw / null-off-host semantics that **standalone** surfaces depend on (they have no host injecting the tags).

**2. `migrations/2026-06-03-surface-client.md`.**
The propagation checklist the design doc §6 says lands with Phase 1. Seeded with Phase 1's items (all checked: standalone bootstrap, README docs-truth, version reconcile, examples SPA, this pattern-doc reconcile) and the later-phase items (createVaultSurface factory, surface-render extraction, notes-ui + my-vault-ui migrations, onboarding rewrite) tracked as not-yet-done.

## Patterns check

Touches `runtime-tenancy-contract.md` (conforms it to the shipped code; no new convention) and adds a migration tracker (follows `migrations/README.md` format + the `2026-05-27-app-to-surface.md` template). Docs-only — no rc bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)