### PR TITLE
migrations(surface-client): mark Phases 2–4 landed + log follow-on hardening

### DIFF
--- a/migrations/2026-06-03-surface-client.md
+++ b/migrations/2026-06-03-surface-client.md
@@ -38,10 +38,16 @@ This file is the propagation checklist. Phase 1 is mostly **additive + docs-trut
 
 ## Later-phase items (not Phase 1)
 
-- [ ] `createVaultSurface` factory with hosted/standalone auto-detect + auto-refresh VaultClient (**Phase 2**, surface-client). Tracked-by: (pending).
-- [ ] Extract `@openparachute/surface-render` (markdown + wikilinks + embeds + multi-format + MDX-safe-default) (**Phase 3**, parachute-surface). Tracked-by: (pending).
-- [ ] Migrate notes-ui onto surface-render; reconcile its `discovery.ts` shim against `createVaultSurface`'s `clientName` (**Phase 4**). Tracked-by: (pending).
-- [ ] Adopt both packages in `~/Code/my-vault-ui`, deleting its hand-rolled oauth/api/pkce/types + Markdown/AudioEmbed (**Phase 5**, external). Tracked-by: (pending).
+- [x] `createVaultSurface` factory with hosted/standalone auto-detect + auto-refresh VaultClient (**Phase 2**, surface-client). Tracked-by: surface#68. surface-client published v0.2.0.
+- [x] Extract `@openparachute/surface-render` (markdown + wikilinks + embeds + multi-format + MDX-safe-default) (**Phase 3**, parachute-surface). Tracked-by: surface#69 (dep-fix #70). Published v0.1.0 via npm Trusted Publishing.
+- [x] Migrate notes-ui onto surface-render; deleted its MarkdownView/remark-wikilinks/VaultImage/render dupes, kept `buildWikilinkResolver` + `NotesLink` (**Phase 4**, dogfood gate). Tracked-by: surface#73. Confirmed API fit with zero surface-render changes; friction → #74.
+- [ ] Adopt both packages in `~/Code/my-vault-ui` / `parachute-brain`, deleting hand-rolled oauth/api/pkce/types + Markdown/AudioEmbed (**Phase 5**, external). Tracked-by: Aaron's parachute-brain build (in progress, separate context).
+
+### Follow-on hardening (landed alongside the phases)
+
+- [x] surface-render DX polish — `useVaultFetchBlob`/`vaultClientFetchBlob`, unified `highlight` hook, baseline `styles.css`, `unresolvedLink`/`resolvedLink`/`INERT`, override-type re-exports. Tracked-by: surface#74 / #75. **surface-render not yet republished — bump→0.2.0 + tag `render-v0.2.0` is gated on the ship decision.**
+- [x] Version-drift guard — `SURFACE_CLIENT_VERSION` / `SURFACE_RENDER_VERSION` codegen'd from `package.json` (`prebuild` + drift-guard test) so the constants can't stall behind the shipped version. Tracked-by: surface#77 (closes surface#57).
+- [x] CI workflow-lint — `yaml.safe_load` + pinned actionlint on `.github/workflows/**`, so a `release.yml` YAML typo can't silently `startup_failure` and no-op publishes. Tracked-by: surface#76 (closes surface#72).
 
 ## Audit
 

--- a/migrations/2026-06-03-surface-client.md
+++ b/migrations/2026-06-03-surface-client.md
@@ -45,7 +45,7 @@ This file is the propagation checklist. Phase 1 is mostly **additive + docs-trut
 
 ### Follow-on hardening (landed alongside the phases)
 
-- [x] surface-render DX polish — `useVaultFetchBlob`/`vaultClientFetchBlob`, unified `highlight` hook, baseline `styles.css`, `unresolvedLink`/`resolvedLink`/`INERT`, override-type re-exports. Tracked-by: surface#74 / #75. **surface-render not yet republished — bump→0.2.0 + tag `render-v0.2.0` is gated on the ship decision.**
+- [x] surface-render DX polish — `useVaultFetchBlob`/`vaultClientFetchBlob`, unified `highlight` hook, baseline `styles.css`, `unresolvedLink`/`resolvedLink`/`INERT`, override-type re-exports. Tracked-by: surface#74 (issue) / #75 (PR). **surface-render not yet republished — bump→0.2.0 + tag `render-v0.2.0` is gated on the ship decision.**
 - [x] Version-drift guard — `SURFACE_CLIENT_VERSION` / `SURFACE_RENDER_VERSION` codegen'd from `package.json` (`prebuild` + drift-guard test) so the constants can't stall behind the shipped version. Tracked-by: surface#77 (closes surface#57).
 - [x] CI workflow-lint — `yaml.safe_load` + pinned actionlint on `.github/workflows/**`, so a `release.yml` YAML typo can't silently `startup_failure` and no-op publishes. Tracked-by: surface#76 (closes surface#72).
 


### PR DESCRIPTION
The surface-client migration tracker still listed Phases 2–4 as pending, but they're merged:

- **Phase 2** — `createVaultSurface` factory (surface#68; surface-client published v0.2.0)
- **Phase 3** — `@openparachute/surface-render` extraction (surface#69, dep-fix #70; published v0.1.0 via Trusted Publishing)
- **Phase 4** — notes-ui dogfood onto surface-render (surface#73; zero surface-render changes needed, friction → #74)

Marks them done with PR refs and adds a **Follow-on hardening** section logging what landed alongside the phases:
- #74/#75 — surface-render DX polish (note: republish to 0.2.0 is still **gated on the ship decision**)
- #77 — version-drift codegen guard (closes surface#57)
- #76 — CI workflow-lint (closes surface#72)

Phase 5 (parachute-brain) is Aaron's external build in a separate context; Phase 6 (starter-prompt rewrite) still pending. Docs-only, keeps the propagation tracker honest per the migration discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)