### PR TITLE
docs(protocol): modular-UI architecture — module-owned config + connections + self-registration discovery

### DIFF
--- a/design/2026-06-09-modular-ui-architecture.md
+++ b/design/2026-06-09-modular-ui-architecture.md
@@ -1,0 +1,71 @@
+# Modular UI architecture — discovery, module-owned config, hub-native connections
+
+**Status:** design → build (2026-06-09). Workspace-wide architecture shift. Aaron-mandated, comprehensive.
+**Repos:** parachute-patterns (protocol), parachute-hub (discovery + shell + connections), parachute-vault, parachute-scribe, parachute-channel, parachute-runner, parachute-surface (per-module config UIs + events/actions).
+
+## The problem
+
+Three different concerns got conflated into "the hub admin", and the result is awkward + inconsistent:
+
+1. **Module discovery/install is gated by a hardcoded whitelist.** `CURATED_MODULES = ["vault","scribe"]` (hub `api-modules.ts`) decides what the Modules screen shows. The channel module is running, proxied, supervised, and self-registered in `services.json` — yet it's **administratively invisible and can't be installed** because it isn't in that constant. Three registries disagree (`CURATED_MODULES` vs `services.json` vs `FIRST_PARTY_FALLBACKS`/`KNOWN_MODULES`): a module can be running but invisible.
+2. **Module config UIs get hard-coded into the hub admin SPA.** The deprecated generic `ModuleConfig` form was the old anti-pattern; the new Channels view (hub#624) is a fresh instance. The hub admin SPA shouldn't grow a bespoke React view per module.
+3. **There's no machine-readable contract for "a module owns a config surface at X."** `module.json` has `uiUrl`/`managementUrl` but no `configUiUrl`/`configSchema`/capabilities, and no `events`/`actions`. The good half-pattern (vault + scribe serve their own admin UI; hub links via `managementUrl`) is inconsistent and under-declared.
+
+## The model — three clean concerns
+
+| Concern | Owner | Mechanism |
+|---|---|---|
+| **Discovery / install / lifecycle** | Hub | Driven by **self-registration** (`services.json` + `module.json`), NOT a whitelist. A `focus` tier de-emphasizes (never hides) exploration modules. |
+| **A module's own config/admin UI** | The **module** | Module serves it + declares `configUiUrl` (+ `configSchema`, `adminCapabilities`) in `module.json`. The hub renders a consistent **shell** that links to / frames the module-owned surface. Never hard-coded in the hub SPA. |
+| **Connections (cross-module wiring)** | Hub | The hub is the only thing with cross-module authority (mint tokens, register triggers). A **general Connections surface** wires "when [event] in [module] → do [action] in [module]" (the sink is always an `action`, never an `event`). Modules declare the `events` they emit + `actions` they accept. "Add a vault-backed channel" is the first connection (`vault.note.created` → `channel.message.deliver`), not channel-specific config. |
+
+The hub admin shrinks to genuinely hub-level things: users, OAuth, tokens, expose, vault provisioning, **module discovery**, and **connections**. Everything module-specific is module-owned and hub-linked.
+
+## The protocol extension (`module.json`)
+
+The contract everything builds on. Add (all optional, additive — back-compatible):
+
+```jsonc
+{
+  // ... existing: name, displayName, tagline, port, paths, health, startCmd,
+  //               uiUrl, managementUrl, stripPrefix, scopes ...
+
+  "focus": "core" | "experimental",        // discovery tier (default "experimental" for unlisted)
+  "configUiUrl": "/scribe/admin",           // where the module's OWN config surface lives (hub links/frames it)
+  "configSchema": { /* JSON Schema */ },    // optional: declarative config (promote the unused field)
+  "adminCapabilities": ["config","credentials","logs"],  // optional metadata
+
+  // --- Connections ---
+  "events":  [ { "key": "note.created", "title": "...", "filterSchema": {...} } ],   // what this module EMITS
+  "actions": [ { "key": "message.deliver", "title": "...", "inputSchema": {...},
+                "provision": { /* how the hub wires this action — e.g. register a vault trigger */ } } ]
+}
+```
+
+Defined in `parachute-patterns/patterns/module-json-extensibility.md` (+ `module-protocol.md`), typed in hub `module-manifest.ts`.
+
+## Per-phase plan
+
+- **P1 — Protocol** (patterns + hub `module-manifest.ts`): add the fields above to the schema/spec/types. No behavior yet.
+- **P2 — Discovery fix** (hub): the Modules screen + `/api/modules` enumerate self-registered modules (`services.json` ∪ `module.json` ∪ supervisor), not `CURATED_MODULES`. `focus` tier sorts/labels (core vs experimental); install action resolves via `KNOWN_MODULES`/`module.json` package, not the whitelist. **Fixes channel-not-installed.** Keep one source of truth; the other registries become bootstrap-only.
+- **P3 — Config shell** (hub): a uniform module-config shell that links to / frames each module's `configUiUrl`; delete the deprecated generic `ModuleConfig` form. Module-owned UI is the only pattern.
+- **P4 — Per-module config UIs:**
+  - **vault** — has an admin SPA; declare `configUiUrl` + `focus:"core"`; conform.
+  - **scribe** — has admin HTML; declare `configUiUrl` + `focus:"core"`; conform.
+  - **surface** — has admin; declare + conform.
+  - **channel** — BUILD a config/admin UI (manage channels/transports) served by the channel module; declare `configUiUrl` + `focus:"experimental"`. (Distinct from the *connection* of adding a vault-backed channel, which is P5.)
+  - **runner** — BUILD a config/admin UI (job listing/config) served by runner; declare `configUiUrl`.
+- **P5 — Connections** (hub + every module): the general Connections surface (build/list/remove connections); modules declare `events`/`actions`; the hub orchestrates provisioning via each action's `provision` block (vault actions use the runtime trigger API from vault#469; the channel-add flow becomes `vault.note.created (filter: tag #channel-message/inbound) → channel.message.deliver`, the sink being the channel **action** that delivers an inbound message + wakes the session). Reframe hub#624's Channels view into this. First-class events to declare: vault `note.created`/`note.updated`/`note.deleted`; scribe `transcription.complete`; channel `message.received`/`message.sent`. First-class actions: channel `message.deliver`; vault `note.create`; scribe `transcribe`.
+- **P6 — Integrate, e2e, deploy, prove.**
+
+## Migration
+
+This is an architectural shift quoting `CURATED_MODULES`, the hub admin nav, and the module protocol across repos → a `parachute-patterns/migrations/2026-06-09-modular-ui.md` propagation checklist ships alongside, tracking every code/doc location.
+
+## Principles (hold the line)
+
+- **Self-registration is the single source of truth for discovery.** Whitelists become bootstrap-only or die.
+- **Modules own their config UIs.** The hub frames/links; it never hard-codes a per-module config view.
+- **Connections are hub-native + general.** No per-module-pair hard-coding; everything flows from declared `events`/`actions`.
+- **Additive + back-compatible** at every step; default behavior unchanged for unmigrated modules.
+- **Every PR reviewer-gated + gate-green; no NUL/binary files** (bitten once this arc).

--- a/migrations/2026-06-09-modular-ui.md
+++ b/migrations/2026-06-09-modular-ui.md
@@ -1,0 +1,167 @@
+---
+title: Modular-UI architecture migration
+date: 2026-06-09
+status: active
+originating-pr: parachute-patterns (this PR — protocol docs + migration file)
+---
+
+# Modular-UI architecture migration
+
+The shift: **stop conflating three concerns in the hub admin** — module
+discovery, a module's own config UI, and cross-module connections — and give
+each a clean owner and a machine-readable contract.
+
+- **Discovery** becomes **self-registration-driven** (`services.json` ∪
+  `module.json` ∪ supervisor), not the hardcoded `CURATED_MODULES` whitelist.
+  A `focus: "core" | "experimental"` tier de-emphasizes (never hides)
+  exploration modules. **This fixes channel-not-installed** — channel runs,
+  is proxied + supervised + self-registered, yet is administratively invisible
+  today because it isn't in the whitelist.
+- **A module's own config UI is module-owned + hub-linked.** Each module
+  serves its config surface and declares `configUiUrl` in `module.json`; the
+  hub renders one uniform config shell that frames / links it. The hub SPA
+  never grows a bespoke per-module config view (the deprecated generic
+  `ModuleConfig` form, and hub#624's per-module Channels view, are the
+  anti-pattern this retires).
+- **Connections are hub-native + general.** The hub — the only thing with
+  cross-module authority — owns a general Connections surface wiring "when
+  [event] → do [action]". Modules declare the `events` they emit and the
+  `actions` they accept in `module.json`.
+
+Full design — the three-concern model, the protocol extension, and the
+per-phase plan (P1–P6) — is in
+[`../design/2026-06-09-modular-ui-architecture.md`](../design/2026-06-09-modular-ui-architecture.md).
+
+This is the propagation checklist. Every code/doc location the shift touches,
+across hub + every module + the pattern docs. **All items start unchecked.**
+
+## Protocol (patterns) — P1
+
+- [ ] patterns:`patterns/module-json-extensibility.md` — document the new
+  `module.json` fields (`focus`, `configUiUrl`, `configSchema`,
+  `adminCapabilities`, `events`, `actions`) with descriptions + examples
+  (this PR)
+- [ ] patterns:`patterns/module-protocol.md` — note the module-owned config UI
+  (`configUiUrl`) + the `events`/`actions` connection contract (this PR)
+- [ ] patterns:`patterns/module-discovery.md` — self-registration as the single
+  source of truth; the `focus` tier; retire the curated-whitelist model
+  (this PR)
+- [ ] patterns:`patterns/module-ui-declaration.md` — `configUiUrl` alongside
+  `uiUrl` (discovery tile) + `managementUrl` (admin deep-link) (this PR)
+- [ ] patterns:`migrations/2026-06-09-modular-ui.md` — this file (this PR)
+- [ ] hub:`src/module-manifest.ts` — extend the manifest validator/types with
+  the six new optional fields; route them through `composeServiceSpec`
+  (P1 — hub)
+
+## Discovery fix — retire `CURATED_MODULES` — P2
+
+- [ ] hub:`src/api-modules.ts` — `CURATED_MODULES` retirement; `/api/modules`
+  enumerates self-registered modules (`services.json` ∪ `module.json` ∪
+  supervisor), not the whitelist; `focus` tier sorts/labels (core vs
+  experimental) (P2 — hub)
+- [ ] hub:install-action resolution — resolve installable name → package via
+  `KNOWN_MODULES` / `module.json`, **not** the whitelist; demote
+  `KNOWN_MODULES` to an install-time bootstrap index, not a visibility gate
+  (P2 — hub)
+- [ ] hub: Modules-screen SPA — render every self-registered module; surface
+  the `focus` tier visually (core first, experimental de-emphasized but
+  never hidden). **Verify channel now appears + is installable.** (P2 — hub)
+
+## Config shell + retire the deprecated form — P3
+
+- [ ] hub: hub-admin nav / shell — shrink the hub admin to genuinely hub-level
+  things (users, OAuth, tokens, expose, vault provisioning, discovery,
+  connections); module-specific config moves out of the hub SPA (P3 — hub)
+- [ ] hub: **delete the deprecated generic `ModuleConfig` form** — module-owned
+  config UI (framed / linked via `configUiUrl`) is the only pattern (P3 — hub)
+- [ ] hub: uniform module-config shell — links to / frames each module's
+  declared `configUiUrl` (P3 — hub)
+
+## Per-module config UIs + `module.json` additions — P4
+
+Each module emits the new `module.json` fields inside its npm artifact;
+modules without a config surface today **build** one.
+
+- [ ] vault:`.parachute/module.json` — declare `configUiUrl` (existing admin
+  SPA) + `focus: "core"`; conform (P4 — vault)
+- [ ] scribe:`.parachute/module.json` — declare `configUiUrl` (existing admin
+  HTML) + `focus: "core"`; conform (P4 — scribe)
+- [ ] surface:`.parachute/module.json` — declare `configUiUrl` (existing
+  admin) + `focus: "core"` (it's committed-core); conform (P4 — surface)
+- [ ] channel: **build** a config/admin UI (manage channels / transports)
+  served by the channel module; `.parachute/module.json` declares
+  `configUiUrl` + `focus: "experimental"` (P4 — channel)
+- [ ] runner: **build** a config/admin UI (job listing / config) served by
+  runner; `.parachute/module.json` declares `configUiUrl` (P4 — runner)
+
+## Connections — general surface + per-module declarations — P5
+
+- [ ] hub: general **Connections** surface — build / list / remove connections;
+  the hub orchestrates provisioning via each action's `provision` block
+  (vault actions use the runtime trigger-registration API from vault#469)
+  (P5 — hub)
+- [ ] hub: **reframe hub#624's Channels view** into a Connection — the
+  channel-add flow becomes `vault.note.created (filter: tag
+  #channel-message/inbound) → channel.message.deliver` (sink is the channel
+  **action**, never the `message.received` event), not channel-specific config
+  (P5 — hub)
+- [ ] vault:`.parachute/module.json` — declare `events`
+  (`note.created` / `note.updated` / `note.deleted`) + `actions`
+  (`note.create`); wire action `provision` to the trigger API (P5 — vault)
+- [ ] scribe:`.parachute/module.json` — declare `events`
+  (`transcription.complete`) + `actions` (`transcribe`) (P5 — scribe)
+- [ ] channel:`.parachute/module.json` — declare `events` (`message.received` /
+  `message.sent`) + `actions` (`message.deliver` — the inbound sink, with a
+  `provision` block that registers a vault runtime trigger webhooking the
+  channel's inbound endpoint with a hub-minted `channel:send` bearer)
+  (P5 — channel)
+
+## Integrate, e2e, deploy — P6
+
+- [ ] hub + modules: end-to-end — install channel via the discovery screen;
+  open each module's config UI via the hub shell; build a vault-backed-channel
+  Connection through the general Connections surface; deploy live + prove
+  (P6 — hub + modules)
+
+## Doc references
+
+- [ ] patterns:`patterns/module-surfaces.md` — confirm the canonical
+  capabilities framing still holds with `configUiUrl` added (audit; update if
+  it enumerates UI fields)
+- [ ] hub:`CLAUDE.md` / `README.md` — describe self-registration-driven
+  discovery + the hub-admin shrink (drop any "curated modules" framing)
+  (P2/P3 — hub)
+- [ ] parachute.computer: any public copy describing the Modules screen,
+  module config, or "what the hub admin does" (P6 — parachute.computer)
+- [ ] run [`../scripts/audit-canonical-refs.sh`](../scripts/audit-canonical-refs.sh)
+  after the code lands — catch any missed `CURATED_MODULES` / "whitelist" /
+  hardcoded-config-view references
+
+## Operator-facing references
+
+- [ ] hub: the Modules screen itself is the primary operator-facing surface —
+  experimental modules now visible (channel, runner); covered by P2 + P4
+
+## External references
+
+- (none significant — npm package descriptions unaffected; `module.json`
+  additions are additive + back-compatible, so unmigrated modules keep
+  working)
+
+## Notes
+
+- **Additive + back-compatible at every step.** All six `module.json` fields
+  are optional; default behavior is unchanged for unmigrated modules. A module
+  with no `focus` is treated as `"experimental"`; one with no `configUiUrl`
+  gets no config-shell link; one with no `events`/`actions` has no Connections
+  surface. P-phases can land independently.
+- **`KNOWN_MODULES` survives** as an install-time bootstrap index (name →
+  installable package), demoted from a visibility gate. This mirrors the
+  earlier `FIRST_PARTY_FALLBACKS` → bootstrap-only trajectory
+  ([workspace `CLAUDE.md`](../../CLAUDE.md) "Note on hub's
+  `FIRST_PARTY_FALLBACKS`").
+- **Vault trigger API dependency.** P5's vault `actions` provisioning rides on
+  the runtime trigger-registration API (vault#469) — already shipped; this arc
+  consumes it.
+- Every PR is reviewer-gated + gate-green; **no NUL/binary files** (this arc
+  has been bitten once).

--- a/patterns/module-discovery.md
+++ b/patterns/module-discovery.md
@@ -36,6 +36,37 @@
    └──────────────────────────────────────────────────────────┘
 ```
 
+## Self-registration is the single source of truth (2026-06-09)
+
+The **[modular-UI architecture](../design/2026-06-09-modular-ui-architecture.md)**
+shift settles a long-standing inconsistency: discovery is driven by
+**self-registration**, not a curated whitelist.
+
+Previously the hub's Modules screen was gated by a hardcoded
+`CURATED_MODULES = ["vault","scribe"]` constant. A module could be running,
+proxied, supervised, and self-registered in `services.json` — yet
+administratively invisible and un-installable because it wasn't in that
+constant (channel hit exactly this). Three registries disagreed
+(`CURATED_MODULES` vs `services.json` vs `FIRST_PARTY_FALLBACKS` /
+`KNOWN_MODULES`).
+
+The model now:
+
+- **Enumeration = self-registration.** The Modules screen and `/api/modules`
+  enumerate the union of `services.json` ∪ each module's `module.json` ∪ the
+  supervisor's live children. **No whitelist decides visibility.** The other
+  registries (`KNOWN_MODULES`) survive only as an **install-time bootstrap**
+  index (resolve a name → installable package), not as a visibility gate.
+- **`focus` de-emphasizes, never hides.** A module's `module.json` declares
+  `focus: "core" | "experimental"` (see
+  [`module-json-extensibility.md` — Modular-UI fields](./module-json-extensibility.md#modular-ui-fields)).
+  The hub uses it to **sort and label** — `"core"` first, `"experimental"`
+  de-emphasized — but every self-registered module appears. Unlisted →
+  `"experimental"`.
+
+This retires the curated-whitelist model. The propagation checklist is
+[`../migrations/2026-06-09-modular-ui.md`](../migrations/2026-06-09-modular-ui.md).
+
 ## If you're trying to…
 
 ### Understand the three-layer module contract (services.json, well-known, module.json)
@@ -52,9 +83,10 @@ Read [`module-json-extensibility.md`](./module-json-extensibility.md).
 The full `module.json` field catalog — `name`, `manifestName`,
 `displayName`, `tagline`, `port`, `paths`, `health`,
 `startCmd`, `scopes`, `dependencies`, plus the extensibility fields
-(`hasAuth`, `init`, `urlForEntry`, `managementUrl`, `uiUrl`). No
-`@openparachute/` scope or `parachute-*` prefix required; the
-contract is what makes a module a module.
+(`hasAuth`, `init`, `urlForEntry`, `managementUrl`, `uiUrl`) and the
+2026-06-09 modular-UI fields (`focus`, `configUiUrl`, `configSchema`,
+`adminCapabilities`, `events`, `actions`). No `@openparachute/` scope or
+`parachute-*` prefix required; the contract is what makes a module a module.
 
 ### Render your module in the hub's discovery section
 

--- a/patterns/module-json-extensibility.md
+++ b/patterns/module-json-extensibility.md
@@ -73,6 +73,12 @@ one file the author controls.
 | `init` | Optional post-install one-shot the CLI runs after `parachute install <name>`. Object with a `command` argv. Safety: first arg must equal a bin defined by the installed npm package. See [Install-time behaviors](#install-time-behaviors). |
 | `urlForEntry` | Optional declarative URL adjustments keyed by consumer. Today's only operations: `appendPath` (append a suffix) or `replaceWith` (full override). See [Install-time behaviors](#install-time-behaviors). |
 | `managementUrl` | Optional path-or-full-URL where the module's admin UI lives. Hub renders a "Manage" link when present. See [Hub UI fields](#hub-ui-fields). |
+| `configUiUrl` | Optional path-or-full-URL where the **module's own config surface** lives. The hub frames / links it from a uniform config shell — it never hard-codes a per-module config view. See [Modular-UI fields](#modular-ui-fields). |
+| `focus` | Optional discovery tier — `"core"` or `"experimental"`. De-emphasizes (never hides) exploration modules on the Modules screen. Unlisted defaults to `"experimental"`. See [Modular-UI fields](#modular-ui-fields). |
+| `configSchema` | Optional JSON Schema for declarative config (promotes the existing-but-unused `/.parachute/config/schema` field into the manifest). See [Modular-UI fields](#modular-ui-fields). |
+| `adminCapabilities` | Optional `string[]` metadata advertising admin facets (e.g. `["config","credentials","logs"]`). See [Modular-UI fields](#modular-ui-fields). |
+| `events` | Optional array of `{key,title,filterSchema?}` describing the events this module **emits** — the source half of a Connection. See [Modular-UI fields](#modular-ui-fields). |
+| `actions` | Optional array of `{key,title,inputSchema?,provision?}` describing the actions this module **accepts** — the sink half of a Connection. See [Modular-UI fields](#modular-ui-fields). |
 | `scopes.defines` | OAuth scopes the module owns. Namespaced by `name` so collisions don't happen — see [`oauth-scopes.md`](./oauth-scopes.md). |
 | `dependencies` | Other modules this one wants to talk to. Each entry has `optional` and `scopes` fields; CLI uses these to auto-wire on install (env-var injection) — see [`service-to-service-auth.md`](./service-to-service-auth.md). |
 
@@ -307,6 +313,121 @@ under the module's own origin keeps the boundary clean: hub stays a
 thin directory + link-out; each module owns its admin surface
 end-to-end. Decision recorded 2026-05-02 (Aaron's call) after an
 initial pass at hub-side per-vault detail pages was reverted.
+
+## Modular-UI fields
+
+Added 2026-06-09 by the **modular-UI architecture** shift (design doc:
+[`../design/2026-06-09-modular-ui-architecture.md`](../design/2026-06-09-modular-ui-architecture.md);
+migration: [`../migrations/2026-06-09-modular-ui.md`](../migrations/2026-06-09-modular-ui.md)).
+The shift splits three conflated concerns — **discovery** (hub-owned, driven
+by self-registration), **a module's own config UI** (module-owned, hub-framed),
+and **connections** (hub-native, cross-module wiring) — and gives each a
+machine-readable contract here. All six fields are optional and additive;
+existing manifests stay valid unchanged.
+
+### `focus: "core" | "experimental"`
+
+```ts
+focus?: "core" | "experimental";  // default "experimental" for unlisted
+```
+
+Discovery tier. The hub's Modules screen enumerates **every self-registered
+module** (`services.json` ∪ `module.json` ∪ supervisor — no whitelist; see
+[`module-discovery.md`](./module-discovery.md)) and uses `focus` to sort and
+label rather than to gate: `"core"` modules surface first; `"experimental"`
+ones are de-emphasized but **never hidden**. This is what lets a running,
+self-registered module (e.g. channel) be administratively visible without an
+entry in a curated constant. Absent → treated as `"experimental"`.
+
+### `configUiUrl: string`
+
+```ts
+configUiUrl?: string;  // path or full URL — the module's OWN config surface
+```
+
+Where the **module's own** config/admin surface lives. The hub renders a
+uniform config shell that links to / frames this URL; it never grows a
+bespoke per-module config view in its SPA. This is the machine-readable
+form of the "modules own their config UIs" principle.
+
+`configUiUrl` is distinct from `managementUrl` and `uiUrl`:
+
+| Field | Surface | Meaning |
+| --- | --- | --- |
+| `uiUrl` | Hub discovery page | The discovery **tile** — where the module's user-facing UI lives. |
+| `managementUrl` | Hub admin pages (e.g. vault list) | An admin **deep-link** — "Manage `<name>`" per instance. |
+| `configUiUrl` | Hub config shell | The module's **own config surface** the hub frames / links. |
+
+Resolution follows the same rules as `managementUrl` (relative resolves
+against the module's own well-known origin; absolute is verbatim). See
+[`module-ui-declaration.md`](./module-ui-declaration.md) for the full
+three-way comparison.
+
+### `configSchema: { /* JSON Schema */ }`
+
+```ts
+configSchema?: object;  // JSON Schema
+```
+
+Promotes the existing-but-unused `/.parachute/config/schema` runtime endpoint
+(see [`module-protocol.md`](./module-protocol.md) §2) into the install-time
+manifest. Declarative config a consumer can render without round-tripping to
+the running module. Optional; a module with a custom `configUiUrl` surface
+needn't declare it.
+
+### `adminCapabilities: string[]`
+
+```ts
+adminCapabilities?: string[];  // e.g. ["config","credentials","logs"]
+```
+
+Free-form metadata advertising which admin facets a module's config surface
+covers. Hint-only — the hub may use it to label the config shell. No fixed
+vocabulary at v1.
+
+### `events` + `actions` — the Connections contract
+
+```ts
+events?:  Array<{ key: string; title: string; filterSchema?: object }>;
+actions?: Array<{
+  key: string;
+  title: string;
+  inputSchema?: object;
+  provision?: object;   // how the hub wires this action (e.g. register a vault trigger)
+}>;
+```
+
+The declarative surface for **hub-native connections** — wiring "when
+[event] in [module] → do [action] in [module]". A module declares the
+`events` it **emits** (the source half) and the `actions` it **accepts**
+(the sink half). The hub — the only thing with cross-module authority to
+mint tokens and register triggers — owns a general Connections surface that
+reads these declarations and orchestrates provisioning via each action's
+`provision` block. No per-module-pair hard-coding.
+
+A connection's right-hand **sink is always an `action`** (something a module
+*accepts*), never an `event` (something a module *emits*). Keep the two halves
+straight — an event can only ever be a connection's *source*.
+
+First-class declarations the committed-core modules ship:
+
+- **vault** emits `note.created` / `note.updated` / `note.deleted`; accepts `note.create`.
+- **scribe** emits `transcription.complete`; accepts `transcribe`.
+- **channel** emits `message.received` / `message.sent`; accepts `message.deliver`.
+
+"Add a vault-backed channel" becomes the connection
+`vault.note.created (filter: tag #channel-message/inbound) →
+channel.message.deliver` — a general Connection, not channel-specific config.
+The sink is the channel **action** `message.deliver` ("Deliver an inbound
+message (wakes the session)"); its `provision` block tells the hub to register
+a vault runtime trigger (vault#469) that webhooks the channel's inbound
+endpoint with a hub-minted `channel:send` bearer. The channel `message.received`
+/ `message.sent` **events** are the *source* half for *other* connections that
+want to react to channel activity — they are never the inbound sink.
+`filterSchema` shapes the event filter (e.g. "only notes with tag X");
+`inputSchema` shapes the action's arguments; `provision` tells the hub how to
+wire it. Both arrays are optional; a module with no cross-module surface
+declares neither.
 
 ## Why this shape
 

--- a/patterns/module-protocol.md
+++ b/patterns/module-protocol.md
@@ -56,6 +56,18 @@ Reference implementation dispatches these in
 (`/.parachute/info`, `/.parachute/icon.svg`, `/.parachute/config/schema`,
 `/.parachute/config`).
 
+**Module-owned config UI + connections (added 2026-06-09).** Under the
+[modular-UI architecture](../design/2026-06-09-modular-ui-architecture.md),
+a module's config UI is the module's own surface — it serves it and declares
+`configUiUrl` in `module.json`; the hub frames / links it from a uniform
+config shell rather than hard-coding a per-module view. The same shift adds
+`events` (what a module emits) and `actions` (what it accepts) to `module.json`,
+which feed the hub's general **Connections** surface (when [event] → do
+[action]). The runtime `/.parachute/config` + `/.parachute/config/schema`
+endpoints remain the live-config seam; `configSchema` in `module.json`
+promotes the schema to install-time. Full field catalog:
+[`module-json-extensibility.md` — Modular-UI fields](./module-json-extensibility.md#modular-ui-fields).
+
 ### 3. Discovery — `/.well-known/parachute.json`
 
 The hub aggregates every installed service's storage entry into a single
@@ -118,7 +130,14 @@ the hub page fetch lives in
   [`hub-as-issuer.md`](./hub-as-issuer.md) and
   [`oauth-scopes.md`](./oauth-scopes.md).
 - Third-party module manifest (`.parachute/module.json`) shape — see
-  [`module-json-extensibility.md`](./module-json-extensibility.md).
+  [`module-json-extensibility.md`](./module-json-extensibility.md), including
+  the 2026-06-09 modular-UI fields (`configUiUrl`, `focus`, `events`,
+  `actions`).
+- Self-registration-driven discovery (no whitelist) + the `focus` tier — see
+  [`module-discovery.md`](./module-discovery.md).
+- Where a module's user / admin / config UI is declared (`uiUrl` /
+  `managementUrl` / `configUiUrl`) — see
+  [`module-ui-declaration.md`](./module-ui-declaration.md).
 - Well-known metadata for OAuth (RFC 8414 / RFC 9728) — see
   [`well-known-discovery-rfc.md`](./well-known-discovery-rfc.md).
 

--- a/patterns/module-ui-declaration.md
+++ b/patterns/module-ui-declaration.md
@@ -166,6 +166,57 @@ under `/notes` declares both `uiUrl: "/notes"` and `managementUrl:
 "/notes/admin"`), one, or neither. They serve different surfaces and
 don't conflict.
 
+## `configUiUrl` — the module's own config surface (2026-06-09)
+
+The **[modular-UI architecture](../design/2026-06-09-modular-ui-architecture.md)**
+shift adds a third UI-declaration field: `configUiUrl`. It completes the
+trio by naming **where the module's own config surface lives** — the surface
+the hub frames / links from a uniform config shell, instead of hard-coding a
+per-module config view in the hub SPA (the deprecated generic `ModuleConfig`
+form, and the bespoke per-module Channels view, were the anti-pattern this
+retires).
+
+The three fields divide cleanly by audience and surface:
+
+| Field | Surface | Renders | Resolution base |
+| --- | --- | --- | --- |
+| `uiUrl` | Hub **discovery** page | One **tile** per service (the user-facing UI) | hub origin |
+| `managementUrl` | Hub **admin** pages | "Manage `<name>`" **deep-link** per instance | module's own well-known origin |
+| `configUiUrl` | Hub **config shell** | The module's **own config surface** (hub frames / links it) | module's own well-known origin |
+
+```ts
+configUiUrl?: string;  // path or full URL — the module's own config surface
+```
+
+- **uiUrl = the discovery tile.** "Here's the thing; go use it."
+- **managementUrl = an admin deep-link.** "Manage this instance" from a
+  hub admin list (today: the per-vault list).
+- **configUiUrl = the module's own config surface.** The hub renders one
+  consistent config shell and frames / links each module's `configUiUrl`;
+  the module owns the config UI end-to-end. This is the machine-readable
+  form of the "modules own their config UIs" principle. Resolution follows
+  `managementUrl`'s rules (relative → module's well-known origin; absolute →
+  verbatim).
+
+A module may declare any subset. Examples from the modular-UI arc:
+
+- **scribe** — `uiUrl: "/scribe/admin"` (discovery tile) and
+  `configUiUrl: "/scribe/admin"` may point at the same self-served surface;
+  scribe's admin HTML *is* its config UI. Note the two strings resolve
+  against **different bases** — `uiUrl` against the hub origin, `configUiUrl`
+  against the module's own origin — and only collapse to the same URL because
+  scribe is co-located on the hub origin. A third-party module hosted
+  elsewhere would see them diverge.
+- **channel** — builds + serves a config/admin UI (manage channels /
+  transports) and declares `configUiUrl` for it (`focus: "experimental"`).
+- **runner** — builds + serves a job-listing / config UI and declares
+  `configUiUrl`.
+
+Full field catalog + the `focus` / `events` / `actions` peers:
+[`module-json-extensibility.md` — Modular-UI fields](./module-json-extensibility.md#modular-ui-fields).
+The discovery-side `focus` tier (self-registration, no whitelist) is in
+[`module-discovery.md`](./module-discovery.md).
+
 ## Examples
 
 - **`parachute-notes`** — declares `uiUrl: "/notes"`. The Notes PWA is


### PR DESCRIPTION
Design doc + module-protocol extension (configUiUrl, configSchema, adminCapabilities, focus, events, actions) + migration checklist for the modular-UI arc. Reviewer LGTM (events-vs-actions sink semantics fixed: connection sinks are always actions; channel sink is message.deliver). Spec: design/2026-06-09-modular-ui-architecture.md. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)