### PR TITLE
pattern(boundary): the hub–module boundary charter + migration + Phase A doc alignment

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,67 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-06-09 — The hub–module boundary: thin hub, module-owned instance lifecycle
+
+**Change:** new ownership charter
+[`hub-module-boundary.md`](../patterns/hub-module-boundary.md) — the hub
+owns the substrate (identity, issuance, identity transactions, transport,
+catalog, supervision, bootstrap); modules own their domain, including
+their **instance lifecycle** and all admin/config UX; the seam is *module
+surfaces driving hub identity APIs*. Two normative consequences ripple
+through the existing docs (amended in the same PR):
+
+1. **Provisioning split** — the hub owns the provisioning *transaction*
+   (`POST /vaults` / `DELETE /vaults/<name>`, `parachute:host:admin`);
+   the module's own surface owns the provisioning *UX* (vault's
+   daemon-level home at `/vault/admin/`). The hub keeps the setup wizard
+   + a zero-instances bootstrap affordance (the bootstrap exception).
+   "Admin SPA route inside hub" is no longer a valid module admin-UI
+   shape (the hub#624 failure mode).
+2. **B4 URL-resolution unification** — `uiUrl` / `managementUrl` /
+   `configUiUrl` share one rule set decided by the string's form:
+   `http(s)://` verbatim · leading-`/` origin-absolute verbatim ·
+   no-leading-slash joined to the module's mount (per instance for
+   multi-instance modules). Vault's manifest becomes
+   `uiUrl`/`managementUrl: "admin/"` + `configUiUrl: "/vault/admin/"`;
+   the legacy literal `"/admin/"` on a vault entry mount-joins under a
+   one-release compat shim with a deprecation warning.
+
+Also folded: lifecycle symmetry (every provision flow ships its
+identity-cascading deprovision flow; long-lived mints must be
+registered), and supersession markers on the retired `pvt_*`
+module-as-issuer model (`token-auth.md` banner; `oauth-scopes.md`
+scrubbed; `agent:*` scopes moved to a retired-scopes note).
+
+Docs amended in this PR: `oauth-scopes.md`, `module-ui-declaration.md`,
+`module-json-extensibility.md`, `module-surfaces.md`, `design-system.md`,
+`token-auth.md`, `design/2026-06-09-modular-ui-architecture.md`,
+`migrations/2026-06-09-modular-ui.md`.
+
+**Affected:**
+
+- `parachute-hub` — Phase B hub waves 1+2: `DELETE /vaults/<name>` +
+  identity cascade, reserved-name consolidation, B4 resolver unification
+  + compat shim, the `/vault/admin` route, SPA slimming (`NewVault.tsx`
+  retires, feature-detected); Phase C/D hardening + residue.
+- `parachute-vault` — Phase B vault wave: the `/vault/admin/` surface,
+  reserved-name validators, new manifest (`"admin/"` +
+  `configUiUrl: "/vault/admin/"`).
+- `parachute-channel` — delete symmetry (channel's page drives
+  `DELETE /admin/connections/<id>` alongside the daemon mechanics).
+- `parachute-runner` — working config-UI auth via the generic
+  module-token mint (scribe pattern); stale `pvt_*` schema text fix.
+- `parachute-surface` — session→mint sign-in replacing the pasted-bearer
+  TokenSetup.
+- `parachute.computer` — supersession banners on the 2026-04-20
+  module-architecture + hub-as-portal design docs (Phase D4).
+
+**Status:** Phase A (charter + doc amendments) in this PR. Build phases
+queued — tracked in
+[`migrations/2026-06-09-hub-module-boundary.md`](../migrations/2026-06-09-hub-module-boundary.md).
+
+---
+
 ## 2026-06-02 — hub-as-supervisor unification: retire the manager-less detached-daemon model
 
 **Change:** the hub no longer runs as a manager-less detached daemon on

--- a/design/2026-06-09-modular-ui-architecture.md
+++ b/design/2026-06-09-modular-ui-architecture.md
@@ -3,6 +3,16 @@
 **Status:** design → build (2026-06-09). Workspace-wide architecture shift. Aaron-mandated, comprehensive.
 **Repos:** parachute-patterns (protocol), parachute-hub (discovery + shell + connections), parachute-vault, parachute-scribe, parachute-channel, parachute-runner, parachute-surface (per-module config UIs + events/actions).
 
+> **Superseded in part (2026-06-09, same day).** The hub–module boundary
+> charter ([`../patterns/hub-module-boundary.md`](../patterns/hub-module-boundary.md))
+> extends this doc and amends one item: this doc's "genuinely hub-level"
+> list included *vault provisioning* wholesale. The charter splits it —
+> the provisioning **transaction** (`POST /vaults` / `DELETE
+> /vaults/<name>`, host-admin-gated identity transaction) is hub-level;
+> the provisioning **UX** is module-owned (vault's daemon-level surface
+> at `/vault/admin/`). Everything else here stands. Migration:
+> [`../migrations/2026-06-09-hub-module-boundary.md`](../migrations/2026-06-09-hub-module-boundary.md).
+
 ## The problem
 
 Three different concerns got conflated into "the hub admin", and the result is awkward + inconsistent:
@@ -19,7 +29,7 @@ Three different concerns got conflated into "the hub admin", and the result is a
 | **A module's own config/admin UI** | The **module** | Module serves it + declares `configUiUrl` (+ `configSchema`, `adminCapabilities`) in `module.json`. The hub renders a consistent **shell** that links to / frames the module-owned surface. Never hard-coded in the hub SPA. |
 | **Connections (cross-module wiring)** | Hub | The hub is the only thing with cross-module authority (mint tokens, register triggers). A **general Connections surface** wires "when [event] in [module] → do [action] in [module]" (the sink is always an `action`, never an `event`). Modules declare the `events` they emit + `actions` they accept. "Add a vault-backed channel" is the first connection (`vault.note.created` → `channel.message.deliver`), not channel-specific config. |
 
-The hub admin shrinks to genuinely hub-level things: users, OAuth, tokens, expose, vault provisioning, **module discovery**, and **connections**. Everything module-specific is module-owned and hub-linked.
+The hub admin shrinks to genuinely hub-level things: users, OAuth, tokens, expose, the vault-provisioning *transaction* (`POST /vaults` / `DELETE /vaults/<name>` — the provisioning *UX* is vault's own surface; see [`../patterns/hub-module-boundary.md`](../patterns/hub-module-boundary.md)), **module discovery**, and **connections**. Everything module-specific is module-owned and hub-linked.
 
 ## The protocol extension (`module.json`)
 

--- a/migrations/2026-06-09-hub-module-boundary.md
+++ b/migrations/2026-06-09-hub-module-boundary.md
@@ -65,9 +65,12 @@ one-release compat shim for the old vault manifest.
       `recordTokenMint` — no registry row → unrevocable until expiry, and
       `teardownConnection` deletes channel's *copy*, not the credential.
       Fix: record both mints (`created_via: "connection_provision"`), persist
-      the jtis on the ConnectionRecord, make teardown revoke them, and
-      rotate/re-provision existing connections (one-time migration). Charter
-      rule: any mint with TTL beyond ~10 min MUST be registered. (hub)
+      the jtis on the ConnectionRecord, make teardown revoke them. Existing
+      connections are NOT auto-rotated (settled in hub#637): legacy records
+      are flagged `legacy: true` on the list wire shape and their unregistered
+      mints ride to original expiry — re-create a connection to get revocable
+      credentials. Charter rule: any mint with TTL beyond ~10 min MUST be
+      registered. (hub)
 - [ ] **B1 hub: `DELETE /vaults/<name>`** (host:admin Bearer; explicit
       `confirm: "<name>"` body). Mechanics: shell to
       `parachute-vault remove --yes` (module CLI stays the source of truth,
@@ -154,7 +157,8 @@ one-release compat shim for the old vault manifest.
       warning (server boot / selfRegister already calls `listVaults()`) when
       a vault named `admin`/`new`/`assets` exists, naming the shadowing
       consequence + recovery. Recovery procedure (no rename command exists):
-      `parachute-vault export → create <newname> → import → remove`. (vault)
+      `parachute-vault export <dir> --vault admin → create <newname> →
+      import <dir> --vault <newname> → remove admin --yes`. (vault)
 - [ ] **B3 vault: the `/vault/admin/` surface.** Sub-items, all required:
       - `routing.ts`: daemon-level `/vault/admin` branch **before**
         `isAdminSpaPath`, reusing `serveAdminSpa` with its own prefix-strip;

--- a/migrations/2026-06-09-hub-module-boundary.md
+++ b/migrations/2026-06-09-hub-module-boundary.md
@@ -1,0 +1,284 @@
+# Migration: the hub–module boundary (thin hub / module-owned lifecycle)
+
+**Decided:** 2026-06-09 (Aaron — "make sure we have an aligned direction, and
+then chart a path and build this"). **Pattern:**
+[`patterns/hub-module-boundary.md`](../patterns/hub-module-boundary.md).
+**Grounding:** 7-repo multi-agent audit + 5-lens adversarial design review
+(10 blocking / 17 serious findings, all folded below), 2026-06-09.
+
+The shift: vault's instance-lifecycle UX moves into vault's own surface at
+**`/vault/admin/`** (completing the `channel/admin` · `scribe/admin` ·
+`surface/admin` · `vault/admin` symmetry); the hub keeps the identity
+transactions and gains the missing **delete cascades**; the seam mechanisms
+get hardened; the docs stop contradicting each other.
+
+**Sequencing law (version skew on real boxes):** hub and vault upgrade
+independently (both rc chains in flight). Order: **Phase A docs → hub wave 1
+(B0+B1+B2h+B4h+route) → vault wave (B2v+B3+manifest) → hub wave 2 (B5,
+feature-detected) → C → D.** Every hub-side semantic change ships with a
+one-release compat shim for the old vault manifest.
+
+## Phase A — docs (this PR)
+
+- [ ] `patterns/hub-module-boundary.md` — the charter (new; includes the
+      panel-added sections: lifecycle-symmetry definition + registered-mint
+      rule, per-module-view definition, trust-statement XSS honesty, the
+      vault-only-identity Known gap, the corrected third-party test)
+- [ ] this file (new)
+- [ ] `patterns/oauth-scopes.md` — (a) provisioning re-framed: hub owns the
+      *transaction*, the module's surface owns the UX; (b) fix the internal
+      synonym-vs-enforced contradiction on `vault:<name>:<verb>` (enforced is
+      current truth); (c) mark the pvt_* paragraph superseded (consistent
+      with token-auth.md's banner); (d) move `agent:*` scopes to a
+      retired-scopes note
+- [ ] `patterns/module-ui-declaration.md` — **full rewrite of §Resolution
+      rules + §Multi-instance + §Rules + vault examples** (they teach the
+      mount-prefixing of `"/admin/"` that B4 retires); resolve the
+      provisioning-ownership contradiction with oauth-scopes; document the
+      resolveManagementUrl-family per-instance-relative contract
+- [ ] `patterns/module-json-extensibility.md` — §managementUrl resolution
+      semantics rewritten to match B4 (leading-`/` = origin-absolute)
+- [ ] `patterns/module-surfaces.md` — remove the standing license for
+      "admin SPA route inside hub" as a valid module admin-UI shape (the
+      hub#624 failure mode); add hub-module-boundary to Related
+- [ ] `patterns/design-system.md` — §admin-SPA verb/title tables +
+      §Circle-1 surface list: retire `/admin/vaults` create-form refs, add
+      `/vault/admin/`
+- [ ] `patterns/token-auth.md` — supersession banner (pvt_* module-as-issuer
+      retired; hub-minted JWTs per tag-scoped-tokens.md + 2026-05-28
+      migration)
+- [ ] `design/2026-06-09-modular-ui-architecture.md` — amend the "genuinely
+      hub-level" list: vault *provisioning UX* is NOT hub-level; the
+      transaction endpoint is
+- [ ] `migrations/2026-06-09-modular-ui.md` — cross-link note
+- [ ] `adoption/migration-notes.md` — entry for this shift
+- [ ] run `scripts/audit-canonical-refs.sh` with `uiUrl` / `managementUrl` /
+      `/admin/vaults` added to the sweep before merging
+
+## Phase B — vault lifecycle (the flagship)
+
+### Hub wave 1 (one hub release; lands FIRST)
+
+- [ ] **B0 (prerequisite): register the connections engine's long-lived
+      mints.** `admin-connections.ts` mints two 90-day tokens (channel reply
+      token `vault:<v>:write` + webhook bearer) via `signAccessToken` with NO
+      `recordTokenMint` — no registry row → unrevocable until expiry, and
+      `teardownConnection` deletes channel's *copy*, not the credential.
+      Fix: record both mints (`created_via: "connection_provision"`), persist
+      the jtis on the ConnectionRecord, make teardown revoke them, and
+      rotate/re-provision existing connections (one-time migration). Charter
+      rule: any mint with TTL beyond ~10 min MUST be registered. (hub)
+- [ ] **B1 hub: `DELETE /vaults/<name>`** (host:admin Bearer; explicit
+      `confirm: "<name>"` body). Mechanics: shell to
+      `parachute-vault remove --yes` (module CLI stays the source of truth,
+      mirroring create). Cascade, enumerated (the lifecycle-symmetry
+      checklist):
+      - registry sweep: revoke every tokens-row whose scopes name the vault —
+        **split + exact-match scope segments, never SQL `LIKE`** (`_` in
+        vault names is a LIKE wildcard);
+      - grants: **rewrite** each grant's scope list removing
+        `vault:<name>:*` entries; drop the row only when empty (a row can
+        name multiple vaults — dropping it over-revokes);
+      - `user_vaults` rows for the vault;
+      - **invites**: invalidate unredeemed invites pinned to the vault
+        (redemption would resurrect the name);
+      - connections: tear down records whose source/sink is the vault
+        (now revoking the B0-registered jtis), AND scan channel's
+        `/api/channels` for legacy pre-connections vault-backed entries
+        referencing it;
+      - **daemon eviction**: the running vault daemon caches open store
+        handles — rmSync alone leaves the "deleted" vault serving from the
+        open fd. v1: supervisor-restart vault as a cascade step; the
+        boundary-conformant daemon eviction endpoint is E9. Verify with a
+        live test (delete → immediately replay a pre-delete request);
+      - **last-vault semantics**: vault boot auto-creates `default` when
+        `listVaults()===0` — deleting the last vault would silently resurrect
+        it (with a fresh global API key). Design decision: `DELETE /vaults`
+        **refuses last-vault deletion** (409 + guidance; CLI is the escape
+        hatch). Sidesteps the resurrection class and protects against
+        fat-finger disasters; the `auto_create: false` marker for CLI users
+        is the vault wave's `cmdRemove` improvement;
+      - services.json + store eviction in one move: the cascade's
+        supervisor-restart re-runs vault's boot `selfRegister`, which
+        rebuilds paths from `listVaults()` — dropping the deleted path AND
+        evicting the cached store handle. Vault's `cmdRemove` additionally
+        gains its own `selfRegister` refresh (vault wave) so the CLI-only
+        path stops going stale. Proxy + well-known read per-request, so the
+        removal is live post-restart.
+      Documented bound: ≤10-min unregistered interactive mints ride to
+      expiry. (hub + vault)
+- [ ] **B2 hub: reserved-name consolidation.** Hub has TWO validators —
+      `admin-vaults.ts` `RESERVED_VAULT_NAMES={list,new,assets}` (POST
+      /vaults only) and `vault-name.ts` `RESERVED_NAMES={list}` (used by the
+      **setup wizard and invite redemption** — a non-admin invite redeemer
+      can name a vault `admin` today and capture the new mount; `new`/
+      `assets` squats are the same pre-existing drift). Collapse to ONE set
+      `{list, new, assets, admin}` in `vault-name.ts`; `admin-vaults.ts`
+      imports it. DELETE accepts reserved names (so a squatted `admin` vault
+      can be removed). (hub)
+- [ ] **B4 hub: URL-resolution unification + compat shim.** Adopt standard
+      semantics — `http(s)://` verbatim · leading-`/` = origin-absolute
+      verbatim · relative = mount-joined — in **all three resolver
+      families**, same release:
+      - `api-modules.ts` `resolveModuleUrl` (two test pins at ~:530-577 and
+        ~:739-790 encode the old semantics and invert);
+      - `well-known.ts` `buildWellKnown`'s vault uiUrl branch — it currently
+        REQUIRES leading-`/` and always mount-joins (flip the guard:
+        relative becomes the valid per-instance form; leading-`/` passes
+        through; emit a daemon-level `configUiUrl` once, not per instance);
+      - the `resolveManagementUrl` triplet (`hub-server.ts`,
+        `account-vault-admin-token.ts` — incl. its hardcoded `"/admin/"`
+        fallback → `"admin/"` — and `web/ui/src/lib/api.ts`): document the
+        per-instance-relative contract; audit `hub.ts`
+        `loadServiceUiMetadata` as a fourth consumer.
+      **Compat shim (one release):** the literal legacy `"/admin/"` family on
+      a *vault* entry mount-joins with a deprecation warning, removed after
+      vault's new manifest reaches @latest. Old-hub + new-vault is a known
+      cosmetic 404 (links only, no auth impact) — documented. (hub)
+- [ ] **B-route hub: the daemon-level mount.** Route `/vault/admin` +
+      `/vault/admin/*` to the vault module's port — resolve the
+      `parachute-vault` services row directly via
+      `findServiceByShort(services, "vault")` (the channelEntry shape),
+      **BEFORE `findVaultUpstream`**, applying the same
+      publicExposure/loopback cloak as `proxyToVault`. Vault must **NOT**
+      self-register `/vault/admin` in paths[] — every consumer deriving
+      instance names from paths (`vaultInstanceNameFor`, well-known fan-out,
+      `findExistingVault`, mint allowlists, the users vault-picker) would
+      fabricate a phantom vault named `admin`. Gated on the B2 reservation.
+      (hub)
+
+### Vault wave (one vault release; lands SECOND)
+
+- [ ] **B2 vault: validators.** Add the consolidated reserved set to vault's
+      `vault-name.ts` AND `cmdCreate`'s separate inline check. Boot-time loud
+      warning (server boot / selfRegister already calls `listVaults()`) when
+      a vault named `admin`/`new`/`assets` exists, naming the shadowing
+      consequence + recovery. Recovery procedure (no rename command exists):
+      `parachute-vault export → create <newname> → import → remove`. (vault)
+- [ ] **B3 vault: the `/vault/admin/` surface.** Sub-items, all required:
+      - `routing.ts`: daemon-level `/vault/admin` branch **before**
+        `isAdminSpaPath`, reusing `serveAdminSpa` with its own prefix-strip;
+        the bare-mount 301-to-trailing-slash must fire for the new mount
+        (else relative assets resolve to `/vault/assets/...`). Don't merge
+        the regexes — `/vault/admin/admin` must not boot per-vault mode for
+        name="admin";
+      - `web/ui` `mount.ts`: detect `/vault/admin` FIRST → basename
+        `/vault/admin`, null mounted-vault; `main.tsx`: skip the per-vault
+        mint in multi-vault mode; `App.tsx`: a third route tree (multi-vault
+        home);
+      - **data plane**: list from `/.well-known/parachute.json` `vaults[]`
+        (public, CORS `*` — the exact read hub's VaultsList uses today, so
+        the pattern moves wholesale); per-vault usage via the authed
+        `/vault/<name>/.parachute/usage` with per-vault minted bearers. The
+        daemon's `/vaults`/`/vaults/list` are NOT reachable through the hub
+        and `/vaults` rejects hub JWTs — do not use them;
+      - **create**: drives hub `POST /vaults` with a host-admin Bearer
+        minted from the session cookie (the NewVault flow, relocated);
+        **delete**: drives B1 with the confirm body;
+      - **per-vault deep-links are full-document navigations**
+        (`<a href="/vault/<name>/admin/">`, origin-absolute) — React Router
+        `Link` under basename `/vault/admin` mangles them, and the SPA's
+        token cache is one-vault-per-document. Amend `web/ui/CLAUDE.md`'s
+        no-leading-slash rule with this carve-out in the same PR;
+      - reuse `SignInBanner` (incl. the non-admin "go to your account" case)
+        in multi-vault mode; direct-on-:1940 (no hub) degrades to a
+        read-only banner (no well-known doc, no session);
+      - `module.json`: `uiUrl`/`managementUrl: "admin/"` (relative →
+        per-instance, behavior preserved under B4) + `configUiUrl:
+        "/vault/admin/"` (origin-absolute → the daemon-level home).
+      (vault)
+
+### Hub wave 2 (lands THIRD, feature-detected)
+
+- [ ] **B5 hub: slim the SPA.** Remove `NewVault.tsx` + the Home vault
+      special-case (hub#635's in-shell `/vaults` card — superseded; vault's
+      module card now behaves exactly like channel/scribe/surface via
+      `config_ui_url`). **Feature-detect**: only redirect `/vaults` +
+      `/vaults/new` → `/vault/admin/` when `/api/modules` reports vault's
+      `config_ui_url === "/vault/admin/"`; otherwise render the legacy list
+      (protects boxes whose vault predates B3). Also: re-point the legacy
+      301s (`/vault`, `/vault/new`) directly at the new target (no
+      redirect-into-404 chains); repoint/drop the nav "Vaults" link; update
+      the wizard vault-step fine-print + the hub-server dispatch comment;
+      rewrite the five `Home.test.tsx` cases pinning the old special-case
+      (+ pin the disabled-card fallback when `config_ui_url` is null).
+      **Zero-instances empty state** (wizard-skip leaves vault installed
+      with no instances and no daemon — hub#607): keep a hub-side "create
+      your first vault" affordance that deep-links the re-enterable
+      `/admin/setup` vault step (bootstrap exception). Wizard + invite
+      redemption keep `provisionVault`; Users page keeps per-user vault
+      assignment (identity view). (hub)
+
+## Phase C — seam hardening (REORDERED: C2 first)
+
+- [ ] **C1 hub: CSRF belt** on cookie-gated `/admin/*` JSON POST/DELETE
+      (hub#632) — confirmed no CSRF token / no Origin check today on
+      `/admin/connections` + `/admin/channels`. Lands BEFORE the channel
+      teardown work builds on those endpoints. (B1/B3's `/vaults` endpoints
+      are Bearer-gated and CSRF-immune — Phase B does not block on this.)
+      (hub)
+- [ ] **C2 channel: delete symmetry.** Deleting a vault-backed channel from
+      channel's admin page also drives hub `DELETE /admin/connections/<id>`
+      (which, post-B0, revokes the registered jtis + deregisters the vault
+      trigger). Daemon's `DELETE /api/channels` stays mechanics-only; the
+      page composes both. (channel)
+- [ ] **C3 runner: working auth + config.** Config page mints `runner:admin`
+      via `/admin/module-token/runner` (scribe pattern — every data call
+      401s behind auth today; the admin-ui comment claiming hub injects
+      Authorization is wrong); add the config write form + link-to-vault
+      flow (channel pattern) for `vault_token`; fix the stale `pvt_*` schema
+      text + README's retired generic-config-form flow. (runner)
+- [ ] **C4 surface: session→mint sign-in** replacing the pasted-bearer
+      TokenSetup (its planned Phase 1.3; scribe pattern). (surface)
+- [ ] **C5 hub: re-gate the generic module-token mint** on self-registration
+      (services.json row + readable module.json) instead of
+      `isKnownModuleShort` — closes the charter-test gap for third-party
+      modules; the forged-short concern is answered by "registered row +
+      manifest exists" (same-disk write = already-trusted). (hub)
+
+## Phase D — residue retirement
+
+- [ ] D1 hub: retire `/admin/channels` + `admin-channels.ts` + SPA helpers
+      (superseded by Connections; ensure the legacy-channel scan from B1
+      lands first)
+- [ ] D2 hub: `NO_UI_FOLLOWUPS` stale entries (scribe, runner) + stale
+      comments; generalize or retire the Connections `CHANNEL_ADD_PRESET`
+      (module-specific hub-SPA code — the per-module-view test fails it)
+- [ ] D3 hub: retire channel's `FIRST_PARTY_FALLBACKS` entry once its
+      module.json declaration is confirmed complete
+- [ ] D4 parachute.computer: supersession banners on the 2026-04-20
+      module-architecture + hub-as-portal design docs (point at
+      hub-module-boundary)
+
+## Phase E — tracked, not built now (file issues)
+
+- [ ] E1 scribe shared-secret → hub-minted `scribe:transcribe` JWTs (failed
+      migration = scribe silently open; needs care)
+- [ ] E2 scribe install-time provider config → scribe-owned first-boot UX
+- [ ] E3 vault vestigial owner-password/TOTP retirement (gated on hub
+      expose-preflight scoring hub credentials — the inverse holdover)
+- [ ] E4 services.json registration API (multi-host/cloud)
+- [ ] E5 hub guarantees RFC 7592 client DELETE (surface DCR orphans)
+- [ ] E6 `/admin/channel-token` vs generic mint (chat UI needs read+send,
+      not admin — decide when a second module needs a non-admin UI mint)
+- [ ] E7 generic instance-scope API (`<short>:<instance>:<verb>` grammar +
+      picker + attenuation + per-instance mint + assignment — extract from
+      the vault precedent; unblocks third-party multi-instance modules with
+      per-instance identity)
+- [ ] E8 default CSP on proxied module pages (defense-in-depth for the
+      stored-XSS-in-module-surfaces threat the trust statement names)
+- [ ] E9 vault daemon store-eviction endpoint (replaces the B1
+      supervisor-restart cascade step)
+- [ ] E10 `/login` on a no-admin box renders JSON 503 instead of a
+      finish-setup page (pre-existing; surfaced by the B3 empty-state review)
+
+## Status
+
+| Item | PR | State |
+|---|---|---|
+| Phase A | (this PR) | open |
+| B0, B1, B2h, B4, B-route (hub wave 1) | — | queued |
+| B2v, B3 (vault wave) | — | queued |
+| B5 (hub wave 2) | — | queued |
+| C1–C5, D1–D3 | — | queued |
+| D4, E1–E10 | — | issues to file |

--- a/migrations/2026-06-09-modular-ui.md
+++ b/migrations/2026-06-09-modular-ui.md
@@ -72,6 +72,12 @@ across hub + every module + the pattern docs. **All items start unchecked.**
 - [ ] hub: hub-admin nav / shell — shrink the hub admin to genuinely hub-level
   things (users, OAuth, tokens, expose, vault provisioning, discovery,
   connections); module-specific config moves out of the hub SPA (P3 — hub)
+  > **Superseded in part** by
+  > [`2026-06-09-hub-module-boundary.md`](./2026-06-09-hub-module-boundary.md)
+  > (same day): "vault provisioning" stays hub-level only as the
+  > *transaction* (`POST /vaults` / `DELETE /vaults/<name>`); the
+  > provisioning *UX* moves to vault's own surface at `/vault/admin/`
+  > (that migration's Phase B). The rest of this item stands.
 - [ ] hub: **delete the deprecated generic `ModuleConfig` form** — module-owned
   config UI (framed / linked via `configUiUrl`) is the only pattern (P3 — hub)
 - [ ] hub: uniform module-config shell — links to / frames each module's

--- a/patterns/auth-stack.md
+++ b/patterns/auth-stack.md
@@ -13,7 +13,7 @@
 └──────────────────────────────┬──────────────────────────────┘
                                │
                                │  OAuth code-flow (RFC 6749 + PKCE)
-                               │  or paste `pvt_*` PAT
+                               │  or paste a hub-minted JWT
                                ▼
 ┌─────────────────────────────────────────────────────────────┐
 │  hub (the OAuth issuer for the whole ecosystem)              │
@@ -29,7 +29,7 @@
 │  resource server (vault / agent / scribe — today only vault) │
 │  • Validates JWT vs hub JWKS, checks `aud` + `iss`           │
 │  • Per-token attributes: scoped_tags allowlist               │
-│  • Falls back to `pvt_*` (PAT) for direct-vault clients      │
+│  • Pure resource server — no module mints (pvt_* retired)    │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -63,21 +63,22 @@ hub-side implementation pointers.
 
 ### Mint a token a user pastes into a script or CLI
 
-Read [`token-auth.md`](./token-auth.md). The `pvt_*` PAT path —
-prefix, sha256-only storage, scoping, one-time reveal. This is the
-**user-facing** counterpart to OAuth bearers; same scope vocabulary,
-different lifetime + storage model. Live alongside hub-issued JWTs;
-both validate at the same vault entrypoint.
+Hub-minted JWTs are the **only live issuance**: `parachute auth
+mint-token --scope vault:<name>:<verb>` (optionally `--ephemeral`), or
+the admin SPA tokens page. Scoping incl. tag-allowlists:
+[`tag-scoped-tokens.md`](./tag-scoped-tokens.md). The historical
+module-minted `pvt_*` PAT path is retired — see the supersession
+banner on [`token-auth.md`](./token-auth.md).
 
 ### Narrow a token to a specific slice of a vault
 
 Read [`tag-scoped-tokens.md`](./tag-scoped-tokens.md). Tokens can
 declare a `scoped_tags` allowlist at mint time. The OAuth scope
-claim (`vault:<name>:<verb>`) stays clean; tag scoping is a
-**per-token vault-internal attribute**, not a scope-string
-extension. Hierarchy expansion via `tags.parent_names`,
-string-form fallback for orphan sub-tags, fail-closed delete-tag
-guards.
+claim (`vault:<name>:<verb>`) stays clean; the allowlist rides the
+hub-issued JWT in a dedicated **`permissions.scoped_tags` claim**
+(post-C0, 2026-05-28), not a scope-string extension. Hierarchy
+expansion via `tags.parent_names`, string-form fallback for orphan
+sub-tags, fail-closed delete-tag guards.
 
 ### Wire one service to call another
 
@@ -110,28 +111,25 @@ sole AS; vault/agent/scribe as RS) plus migration tracker
 Research-tier — pattern docs are for resolved patterns; this is
 the longer arc still being worked through.
 
-## The two token paths
+## The two token paths (one live, one historical)
 
-Two paths reach the same resource server, with the same scope
-vocabulary:
+Two paths used to reach the same resource server with the same scope
+vocabulary; since the `pvt_*` retirement (vault#412, the 2026-05-28
+capability-attenuation arc) only the OAuth path issues:
 
-| Path | Issuer | Token shape | Storage | Audience | When to use |
+| Path | Issuer | Token shape | Storage | Audience | Status |
 | --- | --- | --- | --- | --- | --- |
-| **OAuth bearer** | hub | JWT signed by hub JWKS | not stored; validated stateless | bound (`aud=vault.<name>` etc.) | agent-to-service, third-party SPA, programmatic API consumer |
-| **`pvt_*` PAT** | vault (or other RS) | random opaque token, `pvt_` prefix | sha256 hash in RS DB | implicit (per-row) | human pastes into CLI/script; standalone-vault deployments with no hub |
+| **OAuth bearer** | hub | JWT signed by hub JWKS | not stored; validated stateless | bound (`aud=vault.<name>` etc.) | **the only live issuance** — agents, third-party SPAs, programmatic consumers, *and* paste-into-script credentials (`parachute auth mint-token`, optionally `--ephemeral`) |
+| **`pvt_*` PAT** | vault (or other RS) | random opaque token, `pvt_` prefix | sha256 hash in RS DB | implicit (per-row) | **retired** — see the supersession banner on [`token-auth.md`](./token-auth.md) |
 
-The PAT path is **legacy and direct**: hub doesn't see it, no JWT
-involved, vault validates against its own `tokens` table. The OAuth
-path is **the canonical future**: hub validates the consent dance,
-mints the JWT, vault validates the JWT signature + claims. Both share
-the scope string and the same scope-inheritance rules; they diverge on
-storage, lifetime, and revocation.
-
-The migration arc is *not* "kill PATs." PATs solve a real ergonomic
-problem (pasted secrets in scripts, standalone-vault no-hub
-deployments). The arc is "make sure the PAT path doesn't accumulate
-its own DCR-substitute layer cake" — keep the OAuth path as the rich
-one, keep PATs as the deliberate-flat-secret escape hatch.
+The PAT path was legacy and direct: hub never saw it, vault validated
+against its own `tokens` table. The ergonomic problems PATs solved
+(pasted secrets in scripts, short-lived automation credentials) are
+now served by hub-minted JWTs — scoped, optionally ephemeral, and
+revocable through the hub's token registry — so the flat-secret
+escape hatch retired instead of accumulating its own layer cake. No
+module mints; issuance is the hub's
+([`hub-module-boundary.md`](./hub-module-boundary.md)).
 
 ## How the cluster composes
 
@@ -145,8 +143,8 @@ files because the underlying concepts compose:
   per-token attribute (`tag-scoped-tokens` shape), and gets enforced
   at request time on the RS.
 - A new client either goes through DCR (`oauth-dcr-approval`) and
-  consents (hub-side) or asks the operator to paste a PAT
-  (`token-auth`).
+  consents (hub-side) or asks the operator to paste a hub-minted JWT
+  (`parachute auth mint-token`; the retired PAT path is `token-auth`).
 - A new inter-service edge either inherits the validator seam
   (`service-to-service-auth`) on a shared-secret basis or upgrades
   to hub-issued JWTs (Phase B2 cutover).
@@ -159,7 +157,8 @@ Rule 3 should name which auth-cluster docs the change touches.
 - [`hub-as-issuer.md`](./hub-as-issuer.md) — the issuer architecture
 - [`oauth-scopes.md`](./oauth-scopes.md) — the scope vocabulary
 - [`oauth-dcr-approval.md`](./oauth-dcr-approval.md) — DCR + consent
-- [`token-auth.md`](./token-auth.md) — `pvt_*` PAT path
+- [`token-auth.md`](./token-auth.md) — `pvt_*` PAT path (historical —
+  superseded; see its banner)
 - [`tag-scoped-tokens.md`](./tag-scoped-tokens.md) — sub-vault scope
 - [`service-to-service-auth.md`](./service-to-service-auth.md) —
   inter-service edges

--- a/patterns/design-system.md
+++ b/patterns/design-system.md
@@ -312,7 +312,7 @@ Three domains where the audit found the most drift. Implementers updating copy i
 |---|---|---|
 | `/admin/modules` row actions | `Restart`, `Upgrade`, `Configure`, `Uninstall` | unchanged |
 | `/admin/modules` install button | `Install` | unchanged |
-| `/admin/vaults` create form | `Create vault` | unchanged |
+| Vault create form — moved to vault's own surface at `/vault/admin/` (2026-06-09 boundary shift, [`hub-module-boundary.md`](./hub-module-boundary.md)); the hub keeps the setup-wizard vault step + a zero-instances bootstrap affordance | `Create vault` | unchanged — the verb moves with the surface |
 | `/admin/tokens` mint | `Mint token` | unchanged |
 | `/admin/tokens` row action | `Revoke` | unchanged |
 | `/admin/permissions` row action | `Revoke` (the grant) | unchanged |
@@ -340,7 +340,7 @@ Examples:
 - `/login` → `Sign in · Parachute`
 - `/oauth/authorize` (consent) → `Approve <client> · Parachute`
 - `/oauth/authorize` (pending-client) → `Approve <client>? · Parachute`
-- `/admin/vaults` → `Vaults · Parachute`
+- `/vault/admin/` (vault's multi-vault home; the hub's `/admin/vaults` route retires per [`hub-module-boundary.md`](./hub-module-boundary.md)) → `Vaults · Parachute`
 - `/admin/approve-client/<id>` → `Approve <client> · Parachute`
 - `/` → `Parachute`
 
@@ -810,7 +810,7 @@ Every surface in this ring uses the canonical mark (§2), canonical palette (§3
 | Module | Surfaces in scope |
 |---|---|
 | `parachute-hub` | `/`, `/hub.html`, `/login`, `/logout`, `/account/change-password`, `/oauth/*`, `/admin/setup`, `/admin/*` (the SPA), all generic error pages |
-| `parachute-vault` | `/vault/<name>/admin/*` (the per-vault SPA mounted via hub proxy), the standalone vault admin SPA at `/admin/` (when reachable; Workstream E is retiring the standalone OAuth surface separately — see §10) |
+| `parachute-vault` | `/vault/<name>/admin/*` (the per-vault SPA mounted via hub proxy), `/vault/admin/*` (the daemon-level multi-vault home — create/delete vaults; 2026-06-09 boundary shift, [`hub-module-boundary.md`](./hub-module-boundary.md)), the standalone vault admin SPA at `/admin/` (when reachable; Workstream E is retiring the standalone OAuth surface separately — see §10) |
 | `parachute-surface` | `/surface/admin/*` (the app-admin SPA — currently the largest outlier; Workstream B brings it into conformance) |
 | `parachute-scribe` | `/scribe/admin` (the server-rendered admin) |
 

--- a/patterns/hub-as-issuer.md
+++ b/patterns/hub-as-issuer.md
@@ -119,13 +119,14 @@ change between Phase 1 and Phase B2. Only the implementation does.
 - **Multi-vault and scope narrowing.** A single hub fronts N vaults
   today, each at `/vault/<name>`. The issuer is still the hub origin
   for all of them; per-vault narrowing is a scope concern, not an
-  issuer concern. See `oauth-scopes.md` "Future: per-resource
+  issuer concern. See `oauth-scopes.md` "Future: deeper per-resource
   narrowing".
-- **Token format at the Phase B2 cutover.** Today's tokens are opaque
-  `pvt_*` strings looked up by hash on the issuing vault. Phase B2 is
-  expected to switch to signed JWTs; the transition needs a bridge
-  period where both formats validate. Specced in the design doc, not
-  yet implemented.
+- **Token format at the Phase B2 cutover — resolved.** Tokens were
+  opaque `pvt_*` strings looked up by hash on the issuing vault; the
+  cutover to hub-signed JWTs completed, and the `pvt_*` issuance path
+  then retired entirely (vault#412 — see
+  [`token-auth.md`](./token-auth.md)'s supersession banner). No bridge
+  period remains: hub-minted JWTs are the only issuance.
 - **Refresh and step-up flows across modules.** A token granted
   `vault:read` requesting `scribe:transcribe` later is conceptually one
   hub re-prompt, but the dance touches every module. Designed in

--- a/patterns/hub-module-boundary.md
+++ b/patterns/hub-module-boundary.md
@@ -132,9 +132,10 @@ third-party content** (Telegram messages in channel's UI, synced notes,
 transcripts). A stored XSS in any same-origin module surface escalates to
 host-admin via the ambient cookie + the mint endpoints. Mitigations, each
 load-bearing: the first-admin gate, 10-minute mint TTLs, `NON_REQUESTABLE`
-scopes, the CSRF belt on `/admin/*` JSON POSTs (hub#632), rigorous output
-escaping in every module surface, and (tracked) default CSP on proxied module
-pages. Do not weaken any of these to make a seam flow more convenient.
+scopes, and rigorous output escaping in every module surface. In progress,
+each tracked: the CSRF belt on `/admin/*` JSON POSTs (hub#632 — Phase C1 of
+the migration, sequenced first) and default CSP on proxied module pages (E8).
+Do not weaken any of these to make a seam flow more convenient.
 
 ## The bootstrap exception
 

--- a/patterns/hub-module-boundary.md
+++ b/patterns/hub-module-boundary.md
@@ -1,0 +1,221 @@
+# The hub–module boundary
+
+> The hub owns the substrate. Modules own their domain. The seam between
+> them: **module surfaces drive hub identity APIs.**
+
+This is the ownership charter the other module patterns hang off. When you
+can't tell whether a capability belongs in the hub or in a module, answer
+here first.
+
+## The principle
+
+**Irreducibly the hub's (the substrate)** — the things that must have exactly
+one answer across all modules:
+
+| Substrate concern | Why it can't be a module's |
+|---|---|
+| **Identity** — user store, sessions, login/2FA, invites | one answer to "who is this person" across every module |
+| **Issuance** — OAuth (DCR, consent, token/refresh), signing keys + JWKS, revocation list, **scope-model enforcement** | every module validates against one issuer; no module can police its siblings' scope claims |
+| **Identity transactions** — token mints, grants, connection provisioning, lifecycle *cascades* (revoke/deregister on delete) | anything that mints, grants, or revokes authority is issuance in motion |
+| **Transport** — the canonical origin, reverse proxy, trust-layer gating (`layerOf`, `publicExposure`) | one origin, one router; a module can't own the router that routes to it |
+| **Catalog** — `/.well-known/parachute.json` aggregation, `/api/modules` | aggregation across siblings; modules *write* their own rows (self-registration), the hub owns the read side |
+| **Supervision** — install, start/stop/restart, crash-restart, ports | a crashed module can't restart itself |
+| **Bootstrap** — first-run wizard, first admin, first module install | exists before any module does |
+
+**The module's domain — everything else about itself:** its daemon, its data,
+its config, its **instance lifecycle** (creating/listing/deleting its own
+instances — vaults, channels, surfaces, jobs), its admin/config/user surfaces,
+its MCP server, its declared `events`/`actions`, its external-service
+credentials.
+
+### "The hub never renders a per-module view" — defined
+
+A **per-module view** renders *module-domain data* fetched from the module's
+own APIs (a channels list, a vault's notes, scribe's providers). The hub never
+builds one — that's the hub#624 failure mode the 2026-06-09 modular-UI shift
+retired.
+
+An **identity view** renders *hub-owned tables* that happen to *name* module
+instances — the Users page's per-user vault assignment, the OAuth consent
+picker. Those are substrate, and they stay. The distinction is whose data and
+whose API, not whether a module's name appears on screen.
+
+(The hub SPA's Connections `CHANNEL_ADD_PRESET` is module-specific hub-SPA
+code that fails this test — tracked as a holdover in the migration, to be
+generalized into declaration-driven presets or retired.)
+
+Module-specific knowledge inside hub code is otherwise either
+install-bootstrap (`KNOWN_MODULES` — you can't ask an uninstalled module to
+self-describe) or a tracked, transitional holdover.
+
+## The seam — how module surfaces drive hub identity APIs
+
+A module's surface, served same-origin behind the hub proxy, composes the
+substrate with the operator's session. Four mechanisms, all live today:
+
+1. **Cookie-gated short-lived mints.** The page loads open; its JS trades the
+   operator's session cookie for a 10-min admin Bearer:
+   `GET /admin/module-token/<short>` (generic, `<short>:admin`),
+   `GET /admin/vault-admin-token/<name>` (per-instance vault),
+   `GET /admin/host-admin-token` (host-admin authority). All
+   first-admin-gated, `NON_REQUESTABLE` via public OAuth, same-origin only.
+   Reference: scribe `src/admin-ui.ts` (scribe#73). *Known limitation: the
+   generic mint is currently gated on the install-bootstrap registry, so a
+   genuinely third-party module 404s — tracked in the migration (the fix is
+   re-gating on self-registration + manifest presence).*
+2. **Identity-transaction endpoints the surface drives with operator
+   approval.** The exemplar is channel's link-a-vault: channel's own page
+   POSTs the hub's `/admin/connections` (`credentials: "include"`); the hub
+   mints the cross-module tokens, registers the vault trigger, records
+   provenance — one operator click, the hub does every identity step.
+   Provisioning endpoints (`POST /vaults`, `DELETE /vaults/<name>`) are the
+   same shape: the hub orchestrates the transaction, the module's CLI/API
+   does the mechanics ("the CLI is the single source of truth for how you
+   create a vault" — hub `admin-vaults.ts`), and the *UX lives in the
+   module's surface*.
+3. **Self-registration + self-declaration.** The module writes its own
+   `services.json` row at boot and describes itself in
+   `.parachute/module.json` (`uiUrl`/`managementUrl`/`configUiUrl`, scopes,
+   events/actions). The hub reads, never authors.
+4. **Resource-server validation.** Modules validate hub JWTs against
+   `/.well-known/jwks.json` + the revocation list. No module mints.
+
+Cross-origin surfaces (the origin-free static-SPA pattern, e.g. my-vault-ui)
+use the public OAuth flow instead of cookies — same substrate, different
+front door.
+
+## Lifecycle symmetry (the rule the 2026-06-09 audit added)
+
+**Every provision flow must have a deprovision flow that cascades the
+identity artifacts it created.**
+
+**An identity artifact is any hub-DB row or unexpired signed credential that
+names the instance.** Today's hub-DB columns carrying instance names:
+`tokens.scopes`, `grants.scopes`, `auth_codes.scopes`,
+`user_vaults.vault_name`, `invites.vault_name`, `connections` records,
+`clients.scopes`. The destroy-side PR for any instance type must enumerate
+this list and handle every entry — revoke the scoped tokens, rewrite or drop
+the grants, drop the assignments, invalidate the pinned invites, tear down
+the connections, deregister the catalog row.
+
+Two precision notes the implementations must carry:
+
+- **Long-lived mints must be registered.** A token minted with a TTL beyond
+  the interactive class (~10 min) MUST be recorded in the hub's token
+  registry — an unregistered long-lived token is *unrevocable by
+  construction* (the revocation list can only carry registered jtis). The
+  audit found the connections engine minting 90-day tokens unregistered;
+  that is the bug class this rule exists to prevent.
+- **Short-lived interactive JWTs ride to expiry by design.** The cascade
+  revokes persisted rows and publishes the revocation list; a ≤10-min
+  unregistered mint window is an accepted, documented bound — do not claim
+  instant revocation the system doesn't make.
+
+Mechanics deletion without identity cascade is a security hole, not a feature
+gap. The audit found three live violations: vault delete (CLI-only, no
+cascade at all), vault-backed-channel delete (orphaned trigger + live minted
+tokens), surface DCR revocation (orphans client records on hub 404/405).
+When you build a create, build the symmetric destroy in the same PR.
+
+## The trust statement
+
+Installing a module extends operator trust to its surfaces. A module page
+served behind the proxy is **same-origin** — it can drive every cookie-gated
+identity API with the operator's ambient session, and *per-module mint
+restriction is impossible same-origin*: origin-wide mint authority is a
+deliberate, accepted consequence of installing a module. This is coherent
+with the trust gradient (an installed module already runs a daemon on your
+machine, strictly more power than a cookie).
+
+Name the active threat honestly: module surfaces render **untrusted
+third-party content** (Telegram messages in channel's UI, synced notes,
+transcripts). A stored XSS in any same-origin module surface escalates to
+host-admin via the ambient cookie + the mint endpoints. Mitigations, each
+load-bearing: the first-admin gate, 10-minute mint TTLs, `NON_REQUESTABLE`
+scopes, the CSRF belt on `/admin/*` JSON POSTs (hub#632), rigorous output
+escaping in every module surface, and (tracked) default CSP on proxied module
+pages. Do not weaken any of these to make a seam flow more convenient.
+
+## The bootstrap exception
+
+Pre-install and first-run flows (setup wizard, invite redemption) are
+hub-owned — there is no module surface yet to defer to. They MUST consume the
+same module-owned mechanics (shell out to the module CLI, call the module
+API), never reimplement them. Hub `provisionVault` shelling to
+`parachute-vault create --json` is the reference. The same exception covers
+the **zero-instances empty state**: a hub affordance that deep-links back
+into the (re-enterable) setup flow is substrate, not a per-module view.
+
+## Known gap: per-instance identity is vault-only today
+
+Be honest about why vault is special. Vault instances are
+*identity-entangled*: per-instance scopes (`vault:<name>:<verb>`), audience
+binding (`vault.<name>`), capability attenuation rules, the consent-time
+vault picker, per-user instance assignment (`user_vaults`), and the
+per-instance mint endpoint are all **vault-hardcoded in hub code**. There is
+no generic `<short>:<instance>:<verb>` machinery.
+
+What this means for a multi-instance module author today:
+
+- **Instances that don't need per-instance hub scopes** (channel's channels,
+  surface's apps, runner's jobs): own the lifecycle fully module-side.
+  Channel is the reference — `POST/DELETE /api/channels` on the module
+  daemon, `<short>:admin`-gated, zero hub involvement.
+- **Instances that DO need per-instance hub scopes**: impossible without hub
+  changes today. Vault is the precedent the future generic instance-scope
+  API will be extracted from — tracked in the migration (E7), not promised.
+
+## The test
+
+A third-party **single-instance** module author ships a daemon +
+`.parachute/module.json` + self-registration + their own admin surface, and
+receives: proxy, discovery, OAuth scope declaration, and Connections — with
+zero hub code changes. (The generic admin-token mint currently still requires
+bootstrap-registry presence — a tracked gap, not a design intent.)
+Per-instance identity is the documented exception above. Any *other*
+capability that fails this test is either substrate (move it behind a generic
+hub API) or a holdover (move it into the module).
+
+## Current state (2026-06-09 audit)
+
+Conformant: channel (instance lifecycle fully module-owned; link-vault is the
+seam exemplar), scribe (config UI + load-open mint), surface (DCR + tenancy
+contract), runner (jobs are vault notes), vault per-vault config/tokens/mirror
+(its own SPA at `/vault/<name>/admin/`).
+
+Holdovers, tracked in
+[`migrations/2026-06-09-hub-module-boundary.md`](../migrations/2026-06-09-hub-module-boundary.md):
+vault **provisioning UX** in the hub SPA (the flagship move → `/vault/admin/`),
+the missing **delete cascades** (all three above), unregistered long-lived
+connection mints, legacy `/admin/channels` endpoint, the Connections
+`CHANNEL_ADD_PRESET`, `FIRST_PARTY_FALLBACKS` residue, scribe install-time
+config writes, the vault-side vestigial owner-password/TOTP the hub's
+expose-preflight still reads (an *inverse* holdover: identity state living
+module-side), runner's unauthenticatable config UI, surface's pasted-bearer
+sign-in, the bootstrap-registry gate on the generic mint.
+
+## Related
+
+[`module-protocol.md`](./module-protocol.md) ·
+[`module-surfaces.md`](./module-surfaces.md) ·
+[`module-discovery.md`](./module-discovery.md) ·
+[`module-ui-declaration.md`](./module-ui-declaration.md) ·
+[`module-json-extensibility.md`](./module-json-extensibility.md) ·
+[`hub-as-issuer.md`](./hub-as-issuer.md) ·
+[`oauth-scopes.md`](./oauth-scopes.md) ·
+[`trust-gradient-isolation.md`](./trust-gradient-isolation.md) ·
+[`bootstrap-on-first-boot.md`](./bootstrap-on-first-boot.md)
+
+## History
+
+- **2026-04-20** — module-architecture design doc states "Hub is thin. It
+  orchestrates but doesn't own module logic" but ships hub-rendered config
+  forms + hub-owned provisioning (the portal era).
+- **2026-06-09** — modular-UI architecture moves config UIs + discovery +
+  connections to the thin shape; Aaron asks the question that names the
+  boundary ("why can vault provisioning not happen inside the module? …this
+  might be a pattern to deeply look at as we grow"); a 7-repo audit grounds
+  this charter; a 5-lens adversarial review (10 blocking, 17 serious
+  findings) hardens it — the lifecycle-symmetry definition, the registered-
+  mint rule, the per-module-view definition, and the Known-gap section all
+  come from that pass.

--- a/patterns/mcp-transport.md
+++ b/patterns/mcp-transport.md
@@ -3,10 +3,10 @@
 ## Convention
 
 Parachute-hosted MCP servers speak **Streamable HTTP** at `<base>/mcp`
-and authenticate via OAuth bearer tokens (or `pvt_*` PATs) over
-`Authorization: Bearer <token>`. The OAuth bearer path is the
-agent-and-service default; `pvt_*` is the user-facing PAT — see
-[`token-auth.md`](./token-auth.md).
+and authenticate via hub-issued OAuth bearer JWTs over
+`Authorization: Bearer <token>`. (The historical `pvt_*` PAT
+alternate is retired — see [`token-auth.md`](./token-auth.md)'s
+supersession banner.)
 
 - Canonical example: `parachute-vault` serves its MCP at `<vault-url>/mcp`.
 - Clients: agents in `@openparachute/agent` connect via

--- a/patterns/module-discovery.md
+++ b/patterns/module-discovery.md
@@ -166,7 +166,11 @@ The field catalog is in
 `uiUrl` / `managementUrl` use the B4 relative form (no leading slash —
 joined onto each instance's mount: `/vault/<name>/admin/`; trailing
 slash deliberate per the fragment-token-SPA section) while
-`configUiUrl` is origin-absolute (the daemon-level multi-vault home);
+`configUiUrl` is origin-absolute (the daemon-level multi-vault home).
+(This is the target shape — vault's shipped manifest carries the legacy
+`"/admin/"` form until the vault wave of
+[`2026-06-09-hub-module-boundary.md`](../migrations/2026-06-09-hub-module-boundary.md)
+lands; the hub's one-release compat shim bridges the gap.)
 `init` carries a safety constraint that `command[0]` must equal a bin
 from the installed npm package.
 

--- a/patterns/module-discovery.md
+++ b/patterns/module-discovery.md
@@ -92,15 +92,17 @@ The full `module.json` field catalog — `name`, `manifestName`,
 
 Read [`module-ui-declaration.md`](./module-ui-declaration.md).
 Declare `uiUrl` in `module.json` and hub renders one tile per
-service that declares it. Path form resolves against hub's origin
-(distinct from `managementUrl`'s relative form, which resolves
-against the module's own well-known origin). Absent = no tile.
+service that declares it. URL strings resolve by form (B4,
+2026-06-09): `http(s)://` verbatim · leading-`/` origin-absolute
+verbatim · no-leading-slash joined to the module's mount (per
+instance for multi-instance modules). Absent = no tile.
 
 ### Expose MCP tools from your module
 
 Read [`mcp-transport.md`](./mcp-transport.md). Streamable HTTP at
-`<base>/mcp` + `Authorization: Bearer <token>`. Both OAuth bearers
-and `pvt_*` PATs validate the same way. Discovery via RFC 8414
+`<base>/mcp` + `Authorization: Bearer <token>` (hub-issued JWTs —
+the historical `pvt_*` PAT alternate is retired; see
+[`token-auth.md`](./token-auth.md)'s banner). Discovery via RFC 8414
 metadata — links into the auth cluster
 ([`well-known-discovery-rfc.md`](./well-known-discovery-rfc.md),
 [`hub-as-issuer.md`](./hub-as-issuer.md)).
@@ -152,17 +154,21 @@ The canonical end-to-end (target shape):
       "claude.ai": { "appendPath": "/mcp" }
     }
   },
-  "managementUrl": "/admin/",
+  "uiUrl": "admin/",
+  "managementUrl": "admin/",
+  "configUiUrl": "/vault/admin/",
   "scopes": { "defines": ["vault:<name>:read", "vault:<name>:write", "vault:<name>:admin"] }
 }
 ```
 
 The field catalog is in
 [`module-json-extensibility.md`](./module-json-extensibility.md);
-`managementUrl` is the relative-resolves-against-module shape per
-the same doc (trailing slash deliberate per its fragment-token-SPA
-section); `init` carries a safety constraint that `command[0]` must
-equal a bin from the installed npm package.
+`uiUrl` / `managementUrl` use the B4 relative form (no leading slash —
+joined onto each instance's mount: `/vault/<name>/admin/`; trailing
+slash deliberate per the fragment-token-SPA section) while
+`configUiUrl` is origin-absolute (the daemon-level multi-vault home);
+`init` carries a safety constraint that `command[0]` must equal a bin
+from the installed npm package.
 
 **2. `parachute install @openparachute/vault`** populates
 `~/.parachute/services.json` with the entry, runs `init.command`,
@@ -170,12 +176,13 @@ and starts the service.
 [`module-protocol.md`](./module-protocol.md) §1-2.
 
 **3. Hub serves the well-known aggregate** at
-`/.well-known/parachute.json`. Each vault entry includes its
-`uiUrl` (intentionally omitted in vault's case — vault content is
-browsed via Notes, see
-[`module-ui-declaration.md`](./module-ui-declaration.md)'s adoption
-note) and `managementUrl` so hub's admin page renders a "Manage
-Vault `<name>`" link.
+`/.well-known/parachute.json`. Each vault entry carries its resolved
+per-instance `uiUrl` / `managementUrl` (`/vault/<name>/admin/` — one
+row per instance per the B4 join; the earlier "vault omits `uiUrl`"
+stance was reversed, see
+[`module-ui-declaration.md`](./module-ui-declaration.md) §Use vs
+admin), so hub's surfaces render a tile + "Manage Vault `<name>`"
+link per instance.
 [`module-protocol.md`](./module-protocol.md) §2.
 
 **4. An MCP client connects** to `<vault-url>/mcp` over Streamable

--- a/patterns/module-json-extensibility.md
+++ b/patterns/module-json-extensibility.md
@@ -51,7 +51,7 @@ one file the author controls.
       "claude.ai": { "appendPath": "/mcp" }
     }
   },
-  "managementUrl": "/admin",
+  "managementUrl": "admin",
   "scopes": { "defines": ["my-service:read", "my-service:write"] },
   "dependencies": {
     "vault": { "optional": true, "scopes": ["vault:read"] }
@@ -252,13 +252,12 @@ via the module's well-known doc) to shape its directory page. Optional;
 absent means "the hub renders nothing for this concern" — existing
 manifests stay valid unchanged.
 
-For the discovery-side peer field `uiUrl` — a path on **hub's** origin
-declaring where a module's user-facing UI lives, rendered as a tile on
-hub's discovery page — see
-[`module-ui-declaration.md`](./module-ui-declaration.md). Note the
-resolution-base difference: `managementUrl`'s relative form resolves
-against the module's own origin; `uiUrl`'s relative form resolves
-against hub's origin.
+For the discovery-side peer field `uiUrl` — declaring where a module's
+user-facing UI lives, rendered as a tile on hub's discovery page — see
+[`module-ui-declaration.md`](./module-ui-declaration.md). Since the
+2026-06-09 B4 unification, `uiUrl` / `managementUrl` / `configUiUrl`
+all share **one resolution rule set**, decided by the form of the
+string (see below) — there is no longer a per-field resolution base.
 
 ### `managementUrl: string`
 
@@ -271,15 +270,32 @@ well-known doc and renders a "Manage <displayName>" link on its
 directory page. Added 2026-05-02 alongside the hub vault-management SPA
 work (parachute-hub#158, parachute-vault#216).
 
-**Resolution.**
+**Resolution** — B4 canonical semantics (2026-06-09, the hub–module
+boundary shift; shared with `uiUrl` and `configUiUrl` — see
+[`module-ui-declaration.md`](./module-ui-declaration.md#shape)):
 
-- **Relative path** (e.g., `"/admin"`): hub resolves against the module's
-  well-known origin — `<module-url><managementUrl>`. For first-party
-  modules under the hub origin this means `<hub-origin>/<short><managementUrl>`
-  (e.g., `https://parachute.tailnet/vault/admin`).
 - **Full absolute URL** (e.g., `"https://admin.example.com"`): hub uses
   verbatim. Escape hatch for modules whose admin UI is hosted somewhere
-  other than the module's own origin.
+  other than the hub origin.
+- **Origin-absolute path** (leading `/`, e.g., `"/vault/admin/"`): hub
+  uses verbatim against the canonical origin — never mount-joined. This
+  is how a multi-instance module names a daemon-level surface that
+  exists once, not per instance.
+- **Relative path** (no leading `/`, e.g., `"admin/"`): hub joins it to
+  the module's mount — `<module-url>/admin/`. For multi-instance
+  modules (vault) the join happens **per instance**:
+  `/vault/<name>/admin/`, one resolved URL per instance. The hub's
+  `resolveManagementUrl` family treats its inputs as
+  per-instance-relative by contract.
+
+The pre-B4 doc said a leading-`/` path like `"/admin"` resolved against
+the module's well-known origin — that mount-joining of a leading-`/`
+string is retired. **Compat shim (one release):** the literal legacy
+`"/admin/"` on a *vault* entry still mount-joins, with a deprecation
+warning, until vault's new manifest (`managementUrl: "admin/"`) reaches
+`@latest`. See
+[`migrations/2026-06-09-hub-module-boundary.md`](../migrations/2026-06-09-hub-module-boundary.md)
+(B4).
 
 **Auth seam.** The module's UI handles its own auth — typically a
 hub-issued JWT scoped narrowly to that module (e.g., a vault-admin scope
@@ -358,8 +374,11 @@ form of the "modules own their config UIs" principle.
 | `managementUrl` | Hub admin pages (e.g. vault list) | An admin **deep-link** — "Manage `<name>`" per instance. |
 | `configUiUrl` | Hub config shell | The module's **own config surface** the hub frames / links. |
 
-Resolution follows the same rules as `managementUrl` (relative resolves
-against the module's own well-known origin; absolute is verbatim). See
+Resolution follows the shared B4 rules (see
+[`managementUrl`](#managementurl-string) above: `http(s)://` verbatim ·
+leading-`/` origin-absolute verbatim · no-leading-slash joined to the
+module's mount). Vault uses the origin-absolute form here —
+`configUiUrl: "/vault/admin/"`, the daemon-level multi-vault home. See
 [`module-ui-declaration.md`](./module-ui-declaration.md) for the full
 three-way comparison.
 

--- a/patterns/module-json-extensibility.md
+++ b/patterns/module-json-extensibility.md
@@ -314,7 +314,8 @@ emitting the canonical trailing-slash form directly from
 `managementUrl`, the redirect never fires and the token survives.
 Real-world example: vault#252 added a 301 from `/vault/<name>/admin`
 → `/vault/<name>/admin/`; vault#255 fixed token loss by changing
-`managementUrl: "/admin"` → `"/admin/"`. Modules with non-SPA
+`managementUrl: "/admin"` → `"/admin/"` (pre-B4 legacy forms — the
+current per-instance form is `"admin/"`). Modules with non-SPA
 admin UIs, or SPAs that don't use fragment-tokens, don't need this.
 
 **Backwards-compatible.** Absent field = no link rendered. Modules that

--- a/patterns/module-surfaces.md
+++ b/patterns/module-surfaces.md
@@ -13,7 +13,7 @@ A committed-core module SHOULD expose:
 | Surface | Path convention | Purpose |
 |---|---|---|
 | **HTTP API** | `/<short>/<rest>` (or `/<short>/<name>/<rest>` for multi-tenant modules like vault) | REST surface for direct programmatic access. |
-| **Admin UI** | `/<short>/admin` (relative `managementUrl` in `module.json`; or admin SPA route inside hub) | Operator-facing web UI for configuring + managing the module. |
+| **Admin UI** | `/<short>/admin` (relative `managementUrl: "admin"` in `module.json`) — **served by the module itself**. An admin SPA route inside the hub is *not* a valid shape (the hub#624 failure mode; see [`hub-module-boundary.md`](./hub-module-boundary.md)). | Operator-facing web UI for configuring + managing the module. |
 | **MCP server** | `/<short>/mcp` | LLM/agent integration via Model Context Protocol. |
 | **Health endpoint** | `/<short>/health` (or whatever `health` in `module.json` declares) | Hub-supervised liveness probe. |
 | **Self-registration** | writes own row to `~/.parachute/services.json` at boot | Per [`module-self-registration.md`](./module-self-registration.md). |
@@ -143,6 +143,10 @@ lighthouse — modules know which way they're heading.
 
 ## Related patterns
 
+- [`hub-module-boundary.md`](./hub-module-boundary.md) — the ownership
+  charter these surfaces live inside: the hub owns the substrate
+  (identity, issuance, transport, catalog, supervision); the module owns
+  its domain, including every one of these surfaces.
 - [`module-protocol.md`](./module-protocol.md) — the runtime contracts
   every module implements (`/.parachute/info`, `/.parachute/icon.svg`,
   `/.parachute/config*`). Module-surfaces is the broader framing

--- a/patterns/module-ui-declaration.md
+++ b/patterns/module-ui-declaration.md
@@ -1,9 +1,12 @@
 # Module UI declaration
 
 Services declare their UI URL in `module.json`; hub renders one
-discovery tile per declaring service. For multi-instance services
-(vault today), `uiUrl` is a per-instance path that hub prefixes with
-the mount path during well-known fan-out.
+discovery tile per declaring service. URL strings resolve by **form**,
+not by field: `http(s)://` = verbatim, leading-`/` = origin-absolute
+verbatim, no-leading-slash = relative to the module's mount (joined
+per instance for multi-instance services like vault). Semantics
+unified 2026-06-09 (the hub–module boundary shift, B4 — see
+[`migrations/2026-06-09-hub-module-boundary.md`](../migrations/2026-06-09-hub-module-boundary.md)).
 
 > **Status: adopted.** Data-driven discovery shipped in hub#288 and
 > the consumer-side `uiUrl` reader (`loadServiceUiMetadata`) landed
@@ -21,9 +24,13 @@ different audiences into one decision. They split cleanly:
 
 - **End users** browse vault data via Notes. Notes is the user-facing
   surface; vault is the storage backend Notes reads from.
-- **Operators** administer the vault — provision, configure, manage
-  per-vault tokens, inspect — via vault's own admin SPA at
-  `/vault/<name>/admin/`.
+- **Operators** administer the vault via vault's own surfaces:
+  per-instance config / tokens / mirror / inspection at
+  `/vault/<name>/admin/`, and instance *provisioning* (create / delete
+  vaults) at the daemon-level `/vault/admin/`. The provisioning UX is
+  module-owned; only the provisioning *transaction* (`POST /vaults` /
+  `DELETE /vaults/<name>`, host-admin-gated) is the hub's — per
+  [`hub-module-boundary.md`](./hub-module-boundary.md).
 
 `uiUrl` points operators at the admin SPA. It is not content
 browsing. The Notes tile (Notes' own `uiUrl`) covers the end-user
@@ -61,63 +68,86 @@ just don't render a clickable card on discovery.
 ### Multi-instance services (vault)
 
 Vault runs N instances behind one backend (`/vault/default`,
-`/vault/techne`, …). The declared `uiUrl` is the **per-instance path
-relative to the vault mount**, not relative to the hub origin. Hub
-prefixes it with the per-vault path when building well-known rows.
+`/vault/techne`, …). A **relative** (no leading slash) `uiUrl` /
+`managementUrl` is the per-instance form: hub joins it onto each
+instance's mount path when building well-known rows. A **leading-`/`**
+URL is origin-absolute and passes through verbatim — vault uses that
+form for its daemon-level multi-vault home.
 
 ```json
 {
   "name": "parachute-vault",
-  "uiUrl": "/admin/",
-  "managementUrl": "/admin/",
+  "uiUrl": "admin/",
+  "managementUrl": "admin/",
+  "configUiUrl": "/vault/admin/",
   "paths": ["/vault/default"]
 }
 ```
 
 For a vault mounted at `/vault/default`, hub emits one services row
-per instance with `uiUrl: "/vault/default/admin/"` (the configured
-hub origin joined onto the prefixed path). For a vault with paths
+per instance with `uiUrl: "/vault/default/admin/"` (the relative
+`"admin/"` joined onto the instance mount). For a vault with paths
 `["/vault/default", "/vault/techne"]`, hub emits two rows, each with
 its own `uiUrl`. Discovery renders one tile per instance; operators
-running multiple vaults see them all.
+running multiple vaults see them all. The origin-absolute
+`configUiUrl: "/vault/admin/"` emits **once** (not per instance) —
+it names the daemon-level surface where vaults are created / deleted
+(see [`hub-module-boundary.md`](./hub-module-boundary.md)).
 
-Single-instance services (scribe, notes, app) declare `uiUrl` as the
-hub-origin path directly; the prefix rule degenerates to a no-op
-(scribe's `paths: ["/scribe"]` + `uiUrl: "/scribe/admin"` resolves
-verbatim).
+Single-instance services (scribe, notes, app) typically declare the
+origin-absolute form (scribe's `uiUrl: "/scribe/admin"` resolves
+verbatim); a relative form would join their single mount and resolve
+to the same place.
 
 ## Shape
 
 ```ts
-uiUrl?: string;  // path under the hub origin, leading "/"
+uiUrl?: string;  // http(s) URL, origin-absolute path, or mount-relative path
 ```
 
-Resolution rules:
+Resolution rules — **B4 canonical semantics, 2026-06-09** (one rule
+set shared by `uiUrl`, `managementUrl`, and `configUiUrl`; resolution
+is decided by the *form of the string*, not by which field carries it):
 
-- **Path form (single-instance)** — `uiUrl: "/notes"`. `uiUrl` is a
-  path on **hub's origin** (not the module's). Hub renders the link
-  as `<hub-origin>${uiUrl}` regardless of where the module itself is
-  hosted. Leading `/` required; no trailing slash. Hub is the
-  renderer of the discovery page; clicks happen from hub, so the
-  relative path resolves there. This is **distinct from
-  `managementUrl`'s relative form**, which resolves against the
-  *module's own well-known origin* — see
-  [`module-json-extensibility.md`](./module-json-extensibility.md#managementurl-string).
-  The two collapse to the same URL for first-party modules colocated
-  on hub's origin, but a third-party module hosted elsewhere would
-  see the two diverge.
-- **Path form (multi-instance)** — `uiUrl: "/admin/"`. Hub prefixes
-  with the per-instance mount path during well-known fan-out: a
-  vault mounted at `/vault/default` resolves the declared `"/admin/"`
-  to `<hub-origin>/vault/default/admin/`. Trailing slash permitted on
-  multi-instance forms (vault's admin SPA expects one); leading `/`
-  required. Today vault is the only multi-instance service.
-- **Absolute URL** — `uiUrl: "https://notes.example.com"`. Hub uses
-  verbatim, no prefix. Escape hatch for modules whose UI is hosted
-  somewhere other than the hub origin.
+- **Absolute URL** — `"https://notes.example.com"`. Used verbatim, no
+  joining. The escape hatch for UIs hosted off the hub origin.
+- **Origin-absolute path (leading `/`)** — `"/notes"`, `"/scribe/admin"`,
+  `"/vault/admin/"`. Used **verbatim against the canonical origin**
+  (the hub origin, which proxied modules share). Never mount-prefixed.
+  This is how a multi-instance module names a daemon-level surface
+  that exists once, not per instance.
+- **Relative path (no leading `/`)** — `"admin/"`. Joined to the
+  module's mount path. For multi-instance modules (vault), joined
+  **per instance** during well-known fan-out:
+  `/vault/<name>/` + `"admin/"` → `/vault/<name>/admin/`, one row per
+  instance. For single-instance modules the join degenerates to
+  `<mount>/<path>`.
 - **Omitted** — no tile rendered. Use this for API-only services
   (no admin UI shipped yet) or services whose UI is only reachable
   via another module.
+
+**Resolver contract.** The hub's `resolveManagementUrl` family
+(`hub-server.ts`, `account-vault-admin-token.ts`,
+`web/ui/src/lib/api.ts`; `hub.ts` `loadServiceUiMetadata` is a fourth
+consumer) treats its inputs as **per-instance-relative by contract**:
+a relative string on a multi-instance module always resolves against
+the specific instance the link is rendered for. `buildWellKnown` and
+`resolveModuleUrl` apply the same three-form rules.
+
+**Compat shim (one release).** Before 2026-06-09, vault's manifest
+declared the *literal* `"/admin/"` and the hub mount-joined it despite
+the leading slash. For one release, a literal `"/admin/"` on a **vault**
+entry still mount-joins, with a deprecation warning; the shim is
+removed once vault's new manifest (`"admin/"` + `configUiUrl:
+"/vault/admin/"`) reaches `@latest`. Old-hub + new-vault skew is a
+known cosmetic 404 (links only, no auth impact). See
+[`migrations/2026-06-09-hub-module-boundary.md`](../migrations/2026-06-09-hub-module-boundary.md)
+(B4).
+
+Trailing slash: SPA surfaces that expect one (vault's admin) should
+declare it (`"admin/"`, `"/vault/admin/"`) — see the fragment-token
+rationale in
+[`module-json-extensibility.md`](./module-json-extensibility.md#managementurl-string).
 
 The hub picks `displayName` and `tagline` for the tile from the same
 `module.json` fields it already reads
@@ -151,7 +181,9 @@ The hub picks `displayName` and `tagline` for the tile from the same
 already exists as an admin-specific link for hub-owned admin pages —
 specifically, the hub's vault-management SPA renders a
 "Manage `<displayName>`" link per vault instance pointing at
-`<vault-url><managementUrl>`. That covers the case where hub admin
+the per-instance join of the relative `managementUrl` onto the
+instance mount (`/vault/<name>/` + `"admin/"` — the B4 relative
+form). That covers the case where hub admin
 pages need to link out to per-instance module admin UIs.
 
 `uiUrl` is its discovery-side peer:
@@ -178,11 +210,15 @@ retires).
 
 The three fields divide cleanly by audience and surface:
 
-| Field | Surface | Renders | Resolution base |
+| Field | Surface | Renders | Resolution |
 | --- | --- | --- | --- |
-| `uiUrl` | Hub **discovery** page | One **tile** per service (the user-facing UI) | hub origin |
-| `managementUrl` | Hub **admin** pages | "Manage `<name>`" **deep-link** per instance | module's own well-known origin |
-| `configUiUrl` | Hub **config shell** | The module's **own config surface** (hub frames / links it) | module's own well-known origin |
+| `uiUrl` | Hub **discovery** page | One **tile** per service (the user-facing UI) | shared B4 rules (§Resolution rules) |
+| `managementUrl` | Hub **admin** pages | "Manage `<name>`" **deep-link** per instance | shared B4 rules |
+| `configUiUrl` | Hub **config shell** | The module's **own config surface** (hub frames / links it) | shared B4 rules |
+
+The fields differ by the **surface they're rendered on**, not by how
+their strings resolve — resolution is one rule set, decided by the form
+of the string (§Resolution rules above).
 
 ```ts
 configUiUrl?: string;  // path or full URL — the module's own config surface
@@ -195,18 +231,17 @@ configUiUrl?: string;  // path or full URL — the module's own config surface
   consistent config shell and frames / links each module's `configUiUrl`;
   the module owns the config UI end-to-end. This is the machine-readable
   form of the "modules own their config UIs" principle. Resolution follows
-  `managementUrl`'s rules (relative → module's well-known origin; absolute →
-  verbatim).
+  the shared B4 rules (§Resolution rules: `http(s)://` verbatim ·
+  leading-`/` origin-absolute verbatim · no-leading-slash mount-joined).
 
 A module may declare any subset. Examples from the modular-UI arc:
 
 - **scribe** — `uiUrl: "/scribe/admin"` (discovery tile) and
   `configUiUrl: "/scribe/admin"` may point at the same self-served surface;
-  scribe's admin HTML *is* its config UI. Note the two strings resolve
-  against **different bases** — `uiUrl` against the hub origin, `configUiUrl`
-  against the module's own origin — and only collapse to the same URL because
-  scribe is co-located on the hub origin. A third-party module hosted
-  elsewhere would see them diverge.
+  scribe's admin HTML *is* its config UI. Both strings are leading-`/`
+  origin-absolute, so they resolve to the same URL by the same rule. A
+  module whose config UI is hosted off the hub origin uses the full
+  `http(s)://` form.
 - **channel** — builds + serves a config/admin UI (manage channels /
   transports) and declares `configUiUrl` for it (`focus: "experimental"`).
 - **runner** — builds + serves a job-listing / config UI and declares
@@ -229,23 +264,28 @@ The discovery-side `focus` tier (self-registration, no whitelist) is in
   server-rendered admin page (`src/admin-ui.ts`) is the operator
   surface — config form, provider status, credential clearing. No
   `managementUrl` (single-instance, no hub-side vault-list surface).
-- **`parachute-vault`** — declares `uiUrl: "/admin/"` (multi-instance
-  form). Hub prefixes with the per-vault mount path on emission,
-  producing one tile per vault instance pointing at
-  `/vault/<name>/admin/`. The earlier "vault content is browsed via
-  Notes — no tile" rule is retired: Notes covers the end-user surface,
-  vault's admin SPA covers the operator surface (per-vault tokens,
-  config, MCP). Both deserve discovery presence. Vault keeps its
-  per-instance `managementUrl: "/admin/"` for the hub admin SPA's
-  vault-list "Manage" link — a different surface, same target path.
+- **`parachute-vault`** — declares `uiUrl: "admin/"` and
+  `managementUrl: "admin/"` (relative form → joined per instance,
+  producing one tile / one "Manage" link per vault at
+  `/vault/<name>/admin/`), plus `configUiUrl: "/vault/admin/"`
+  (origin-absolute → the daemon-level multi-vault home where instances
+  are created / deleted; emitted once, not per instance). The earlier
+  "vault content is browsed via Notes — no tile" rule is retired: Notes
+  covers the end-user surface; vault's own surfaces cover the operator
+  surface (per-vault tokens, config, MCP at `/vault/<name>/admin/`;
+  provisioning at `/vault/admin/` per
+  [`hub-module-boundary.md`](./hub-module-boundary.md)).
 
 ## Rules
 
-- **Path-form `uiUrl` starts with `/`.** Single-instance forms omit
-  the trailing slash (`/notes`, `/scribe/admin`); multi-instance
-  forms may include it (`/admin/`) when the target SPA expects it.
-  Hub joins origin + (mount path if multi-instance) + `uiUrl`
-  verbatim — no extra normalization.
+- **The leading slash is load-bearing.** `"/scribe/admin"` is
+  origin-absolute (verbatim); `"admin/"` is mount-relative (joined per
+  instance for multi-instance modules). Don't write `"/admin/"` when
+  you mean "this module's admin, under its mount" — that is the
+  pre-2026-06-09 ambiguity the B4 unification retired (a one-release
+  compat shim mount-joins the legacy literal on vault entries, with a
+  deprecation warning). Include the trailing slash where the target
+  SPA expects it. No other normalization.
 - **`uiUrl` is for the hub discovery page.** Don't hand-jam admin-only
   paths in here when the user-facing UI is what belongs on discovery —
   that's what `managementUrl` is for. If a service has only an admin
@@ -270,7 +310,8 @@ Standard parallel-cross-repo shape (see
    `parachute-notes` declares `uiUrl: "/notes"`,
    `parachute-surface` declares `uiUrl: "/surface/admin/"`,
    `parachute-scribe` declares `uiUrl: "/scribe/admin"`,
-   `parachute-vault` declares `uiUrl: "/admin/"` (multi-instance form).
+   `parachute-vault` declares `uiUrl: "admin/"` (relative per-instance
+   form; B4 semantics).
    Each module ships its updated `module.json` inside its npm artifact.
 3. **Hub consumer-side update** — well-known doc carries `uiUrl`
    through; discovery page (`hub.ts`) reads `uiUrl` from
@@ -280,8 +321,9 @@ Standard parallel-cross-repo shape (see
    "Browse Vault" Get-started tile (added in hub#342 as a stopgap)
    retires under workstream C once vault declares `uiUrl` and hub
    reads it for vault entries (the current `loadServiceUiMetadata`
-   skips vault rows; lift that skip and have `buildWellKnown`
-   prefix the declared `uiUrl` with the per-instance mount path).
+   skips vault rows; lift that skip and have `buildWellKnown` join
+   the declared relative `uiUrl` onto each instance's mount path per
+   the B4 rules).
    Tile order: stable by service `displayName` alphabetical (or by
    an explicit `displayOrder` field if a need for explicit ordering
    surfaces — defer until two services actually conflict on natural
@@ -317,7 +359,8 @@ order.
   - `parachute-notes` — `uiUrl: "/notes"`.
   - `parachute-surface` — `uiUrl: "/surface/admin/"`.
   - `parachute-scribe` — `uiUrl: "/scribe/admin"` (workstream C).
-  - `parachute-vault` — `uiUrl: "/admin/"` (workstream C, multi-instance form).
+  - `parachute-vault` — `uiUrl: "admin/"` (relative per-instance form)
+    + `configUiUrl: "/vault/admin/"` (origin-absolute daemon-level home).
 - **Later:** any first- or third-party module that ships a UI under
   the hub origin. Same field, same shape.
 - **Not in scope:** services with truly no operator-facing UI simply

--- a/patterns/oauth-scopes.md
+++ b/patterns/oauth-scopes.md
@@ -15,8 +15,8 @@ Parachute OAuth tokens carry **whitespace-separated scope strings**
   verb like `transcribe`, `send`).
 - Middle segments (zero or more) — a resource hierarchy that narrows the
   scope. Today the only narrowing segment in use is `vault:<name>:<verb>`
-  (per-vault), which is **parsed but treated as a synonym** for
-  `vault:<verb>` in Phase 2.
+  (per-vault), which is **the enforced shape** for hub-issued JWTs —
+  see Parser rules below.
 
 ## Launch scopes (Phase 0+1)
 
@@ -27,27 +27,31 @@ Parachute OAuth tokens carry **whitespace-separated scope strings**
 | `vault:<name>:admin` | Write + read + `/.parachute/config*` |
 | `scribe:transcribe` | POST audio to scribe's transcription endpoint |
 | `scribe:admin` | Manage scribe config |
-| `agent:read` | Read agent groups + vault attachments via parachute-agent API/MCP |
-| `agent:write` | Mutate agent groups, secrets, channel wires, sessions |
-| `agent:admin` | Full parachute-agent admin (write + create/delete groups) |
 | `hub:admin` | Manage hub services catalog + OAuth config (Reserved; not yet enforced) |
-| `parachute:host:admin` | Provision new vaults via hub `POST /vaults` and other host-level admin (operator-only-mintable; not requestable from third-party clients) |
+| `parachute:host:admin` | Drive the hub's vault instance-lifecycle *transactions* (`POST /vaults` / `DELETE /vaults/<name>`) and other host-level admin (operator-only-mintable; not requestable from third-party clients). The provisioning *UX* lives in vault's own surface — see [`hub-module-boundary.md`](./hub-module-boundary.md). |
 | `channel:send` | Post messages via channel |
 
 Third-party modules declare their own namespace (`my-service:read`, etc.)
 and the hub renders consent for those scopes the same way.
 
+**Retired scopes.** `agent:read` / `agent:write` / `agent:admin` were the
+launch scopes for parachute-agent, retired with the module 2026-05-20 (see
+[`trust-gradient-isolation.md`](./trust-gradient-isolation.md)). No
+`agent:*` bearer was ever in the wild; the namespace is free to reclaim if
+a future module wants it.
+
 ## Inheritance
 
 ```
-admin ⊇ write ⊇ read       (for vault and agent)
+admin ⊇ write ⊇ read       (for vault; the retired agent namespace followed the same tree)
 ```
 
 - `vault:<name>:admin` satisfies any check for `vault:<name>:write` or
   `vault:<name>:read` on the same vault. Inheritance is per-resource —
   `vault:work:admin` does **not** satisfy a `vault:personal:read` check.
-- `agent:admin` satisfies `agent:write` and `agent:read` (single-namespace,
-  no per-resource binding — parachute-agent is one-installation-one-resource).
+- `agent:admin` satisfied `agent:write` and `agent:read` (single-namespace,
+  no per-resource binding) — historical; the `agent:*` namespace
+  retired with the agent module 2026-05-20.
 - **Non-inheritance scopes exact-match only.** `scribe:admin` does **not**
   currently imply `scribe:transcribe` — each non-inheritance-tree scope
   stands alone. This is deliberate: we add inheritance per-service
@@ -80,9 +84,13 @@ Canonical implementations:
   consent surface a friend sees connecting a single vault. A client that
   legitimately wants a `scribe:` token runs a separate flow naming the scribe
   resource. (hub#487; see `parachute-hub/src/resource-binding.ts`.)
-- **`pvt_*` tokens are unaffected.** They predate the resource-bound
-  shape; they're scoped at issue-time inside vault's own DB and the JWT
-  validation layer is bypassed for them.
+- **`pvt_*` tokens — retired (superseded).** This bullet used to say
+  `pvt_*` tokens were unaffected (issue-time-scoped in vault's own DB,
+  bypassing JWT validation). The module-minted `pvt_*` path was retired
+  entirely (vault#412; the vault 0.6.0 path) — **hub-minted JWTs are the
+  only token issuance**. See the supersession banner on
+  [`token-auth.md`](./token-auth.md) and
+  [`tag-scoped-tokens.md`](./tag-scoped-tokens.md) for the current model.
 - **Empty resource segments are preserved verbatim** (`vault::read` stays
   `vault::read`, so it can't satisfy any vault check — a one-line defence
   against a malformed DB row).
@@ -97,11 +105,18 @@ them to any third-party OAuth client. They can only be minted on the
 operator-token path (the locally-stored `~/.parachute/operator.token`
 that ships with hub install).
 
-- `parachute:host:admin` — provisioning new vaults via hub `POST /vaults`.
-  Cross-vault data sovereignty; high blast radius. The asymmetry vs
-  `hub:admin` (which IS requestable) is deliberate: `hub:admin` manages
-  service registration, `parachute:host:admin` creates new long-lived
-  data resources on the host filesystem.
+- `parachute:host:admin` — the vault instance-lifecycle *transactions* on
+  the hub: `POST /vaults` / `DELETE /vaults/<name>`. Cross-vault data
+  sovereignty; high blast radius. The asymmetry vs `hub:admin` (which IS
+  requestable) is deliberate: `hub:admin` manages service registration,
+  `parachute:host:admin` creates and destroys long-lived data resources
+  on the host filesystem. Ownership split per
+  [`hub-module-boundary.md`](./hub-module-boundary.md): the hub owns the
+  provisioning *transaction* (an identity transaction — token mints,
+  grants, lifecycle cascades); the module's own surface owns the
+  provisioning *UX* (vault's daemon-level `/vault/admin/`, which drives
+  these endpoints with a host-admin Bearer minted from the operator's
+  session).
 
 Implementation: hub maintains a `NON_REQUESTABLE_SCOPES` set checked at
 `/oauth/authorize` request time; `invalid_scope` per RFC 6749 if a third
@@ -171,12 +186,11 @@ for one release cycle so legacy clients don't hard-break on discovery.
 - **`vault:admin` (or any `:admin`) gates `/.parachute/config*`** on that
   module. This is the cross-cutting rule every module should honour.
 
-## Future: per-resource narrowing (Phase 2+)
+## Future: deeper per-resource narrowing
 
-`vault:<name>:<verb>` is parsed today but collapsed to `vault:<verb>`.
-The real shape, once enforced:
+`vault:<name>:<verb>` (per-vault) is **enforced today** — see Parser
+rules. The narrowing axis can go deeper; not yet designed:
 
-- `vault:work:read` — read the `work` vault only.
 - `vault:work:notes/inbox/:read` — read one path prefix inside one vault
   (notional; not yet designed).
 - `scribe:groq:transcribe` — use only the `groq` provider on scribe.

--- a/patterns/service-to-service-auth.md
+++ b/patterns/service-to-service-auth.md
@@ -87,9 +87,11 @@ tomorrow they come from JWT claims.
 
 They use the **same scope vocabulary** but **different validators**
 today. Phase B2 converges them — the same JWKS-backed verifier
-validates both. Until then, don't conflate them: a `pvt_*` user token
-should never be accepted by an inter-service callee, and a service
-secret should never appear on a user-facing surface.
+validates both. Until then, don't conflate them: a user-facing token
+(a hub-minted JWT; historically a `pvt_*` PAT — retired, see
+[`token-auth.md`](./token-auth.md)'s banner) should never be accepted
+by an inter-service callee, and a service secret should never appear
+on a user-facing surface.
 
 ## Rules
 
@@ -154,8 +156,11 @@ secret should never appear on a user-facing surface.
 - **User OAuth scopes and issuer** — see
   [`oauth-scopes.md`](./oauth-scopes.md) and
   [`hub-as-issuer.md`](./hub-as-issuer.md).
-- **`pvt_` user tokens** — see [`token-auth.md`](./token-auth.md).
-  Different trust axis; do not interchange with service secrets.
+- **User tokens** — hub-minted JWTs (scoping:
+  [`tag-scoped-tokens.md`](./tag-scoped-tokens.md)); the retired
+  `pvt_*` PAT path is [`token-auth.md`](./token-auth.md) (superseded —
+  see its banner). Different trust axis; do not interchange with
+  service secrets.
 - **Service-to-service over MCP** — MCP transport carries its own
-  bearer (typically a `pvt_*` user token, not a service secret).
-  Covered in [`mcp-transport.md`](./mcp-transport.md).
+  bearer (a hub-minted user JWT, not a service secret). Covered in
+  [`mcp-transport.md`](./mcp-transport.md).

--- a/patterns/token-auth.md
+++ b/patterns/token-auth.md
@@ -1,5 +1,17 @@
 # Token auth — `pvt_` tokens
 
+> **SUPERSEDED (2026-05-28; live as of vault 0.6.0 path).** The
+> module-minted `pvt_*` PAT model this doc describes was retired —
+> vault#412 dropped `pvt_*` issuance entirely. **Hub-minted JWTs via
+> `/api/auth/mint-token` are the only token issuance**; no module mints
+> its own credentials (the issuance boundary is the hub's — see
+> [`hub-module-boundary.md`](./hub-module-boundary.md)). For the current
+> model see [`tag-scoped-tokens.md`](./tag-scoped-tokens.md) and the
+> propagation checklist at
+> [`migrations/2026-05-28-operator-mintable-vault-admin.md`](../migrations/2026-05-28-operator-mintable-vault-admin.md).
+> This doc is retained for history; do not adopt the pattern below in
+> new modules.
+
 ## Convention
 
 Parachute-issued **personal access tokens** use a `pvt_` prefix

--- a/scripts/audit-canonical-refs.sh
+++ b/scripts/audit-canonical-refs.sh
@@ -200,6 +200,20 @@ echo "(vault no longer mints pvt_* opaque tokens — access tokens are hub-issue
 } || true
 echo ""
 
+echo "--- Legacy UI-URL semantics: mount-joined \"/admin/\" manifests + hub /admin/vaults route (B4 — hub-module-boundary 2026-06-09) ---"
+echo "(uiUrl/managementUrl/configUiUrl resolve by form: leading-/ is origin-absolute VERBATIM; vault's per-instance form is \"admin/\"; the provisioning UX lives at /vault/admin/. A manifest still declaring the legacy \"/admin/\" literal, or copy pointing at the hub's /admin/vaults page, is stale once Phase B lands. Lines narrating the shim/retirement + the migration-notes running log are excluded.)"
+{
+  grep -rn "${GREP_DIR_EXCLUDES[@]}" \
+    --include='*.md' --include='*.ts' --include='*.tsx' --include='*.json' --include='*.njk' \
+    -E "\"?(uiUrl|managementUrl|configUiUrl)\"?[[:space:]]*:[[:space:]]*\"/admin/?\"|/admin/vaults" \
+    "$WORKSPACE" 2>/dev/null \
+    | grep -v "$LINE_EXCLUDES" \
+    | grep -v "migration-notes" \
+    | grep -vi "legacy\|compat\|deprecat\|retire\|shim\|pre-B4\|hub-module-boundary" \
+    | head -30
+} || true
+echo ""
+
 # --- Missing-dependency UX: hand-synced install strings outside depcheck ----
 # patterns/missing-dependency-ux.md (task #188, migration 2026-05-29) makes
 # `@openparachute/depcheck` the single owner of dependency install strings +
@@ -239,4 +253,5 @@ echo "  - CHANGELOGs + DEPRECATED.md are excluded line-level (they're historical
 echo "  - parachute-notes/canonical-ports.md/service-spec.ts are excluded from the port-1942 check (they're the canonical source)."
 echo "  - parachute-agent retirement docs + launch-day artifacts are excluded from the agent check."
 echo "  - depcheck's own registry + vault git-preflight.ts + hub cloudflaredInstallHint are excluded from the install-string check (canonical sources)."
+echo "  - /admin/vaults hits in hub code are EXPECTED until the hub-module-boundary Phase B5 SPA slim lands — that sweep tracks the propagation."
 echo "  - Add new grep blocks above when you hit a new class of stale ref."


### PR DESCRIPTION
## What

The ownership charter for the deepest boundary in the system, the sequenced migration that builds it, and the Phase A doc-alignment sweep.

**New:**
- `patterns/hub-module-boundary.md` — **the hub owns the substrate; modules own their domain; module surfaces drive hub identity APIs.** Substrate table (identity · issuance · identity transactions · transport · catalog · supervision · bootstrap), the four seam mechanisms, and the rules the 2026-06-09 audit + adversarial review added: **lifecycle symmetry** (every provision has a deprovision cascading the identity artifacts; identity artifact defined; the registered-mint rule — TTL beyond ~10min MUST be in the token registry), the **per-module-view definition** (module-domain data via module APIs = forbidden; identity views naming instances = allowed), an honest **trust statement** (stored-XSS-in-module-surfaces named; per-module mint restriction impossible same-origin), the **bootstrap exception**, the **Known gap** (per-instance identity machinery is vault-only today), and the scoped third-party test.
- `migrations/2026-06-09-hub-module-boundary.md` — the build plan: Phase A (this PR) → hub wave 1 (B0 registered connection mints · B1 `DELETE /vaults` cascade · B2h reserved-name consolidation · B4 URL-semantics unification + compat shim · the `/vault/admin` daemon-level route — **open as hub#637**) → vault wave (B2v validators · B3 the `/vault/admin/` surface) → hub wave 2 (B5, feature-detected) → C seam hardening (CSRF first) → D residue → E tracked issues. Sequencing law for version skew on real boxes.

**Amended (the docs stopped contradicting each other):** oauth-scopes (provisioning transaction-vs-UX split, synonym-vs-enforced fix, pvt_*/agent:* retirement), module-ui-declaration (full B4 resolution-semantics rewrite), module-json-extensibility (same), module-surfaces (removed the "admin SPA route inside hub" license — the hub#624 failure mode), design-system (retired `/admin/vaults` create-form refs), token-auth (supersession banner), the 2026-06-09 modular-ui design doc + migration (superseded-in-part notes), auth-stack / service-to-service-auth / mcp-transport / module-discovery / hub-as-issuer (pvt_* live-path residue swept), adoption/migration-notes entry, and `scripts/audit-canonical-refs.sh` gains a uiUrl/managementUrl//admin/vaults sweep (repo clean; remaining hits are exactly the Phase B propagation targets in hub/vault).

## Grounding

7-repo multi-agent audit (127 concerns classified, file:line evidence) + 5-lens adversarial design review (10 blocking / 17 serious findings — all folded into the charter + migration before any code was written). Companion code PR: hub#637 (wave 1), reviewer-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)