### PR TITLE
pattern(governance): patch (y) cadence by default — minor bumps are Aaron's explicit call

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,19 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-06-09 — Release versioning: patch (`y`) cadence by default
+
+**Change:** [`governance.md`](../patterns/governance.md) rule 2 clarified —
+pre-1.0 stable releases increment the **patch** number by default
+(`0.X.Y` → `0.X.(Y+1)`); minor (`x`) bumps are Aaron's explicit call, never
+inferred from change magnitude. Settled after the 2026-06-09 stable train
+shipped as judged-by-magnitude minor bumps against Aaron's intent. The
+version is a release counter; significance lives in the release notes.
+**Affected repos:** all publishing repos (hub, vault, scribe, runner,
+surface) — process change, no code. **Status:** effective immediately;
+next stables are hub 0.7.1 / vault 0.6.1 / scribe 0.5.1 / runner 0.2.1 /
+surface 0.3.1 unless Aaron says otherwise.
+
 ## 2026-06-09 — The hub–module boundary: thin hub, module-owned instance lifecycle
 
 **Change:** new ownership charter

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -74,6 +74,17 @@ there's intent to release.
 **Doc-only PRs never bump version.** They merge straight to main and
 will be included in whatever the next ship-driven version bump captures.
 
+**The increment is the PATCH (`y`) by default — minor (`x`) bumps are
+Aaron's explicit call, never inferred.** Settled 2026-06-09 after the
+boundary-arc stable train shipped as minor bumps (hub 0.6→0.7, vault
+0.5→0.6, …) on a judged-by-magnitude basis that wasn't Aaron's intent:
+"let's make sure we move back to 0.x.y releases (on y dimension) going
+forward since we're about to be doing a lot more changes. We've got a
+long way to go yet until we're at 1.0." Pre-1.0, the version number is a
+release counter, not a significance signal — significance lives in the
+release notes. Don't read "big change" as "minor bump"; the next stable
+after `0.X.Y` is `0.X.(Y+1)` unless Aaron says otherwise.
+
 **v1.0 and after** — switch to standard SemVer with `alpha` / `beta` /
 `rc` prerelease tags as feature stability warrants. This pattern doc
 gets a v1.0 update at that time.

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -85,10 +85,6 @@ release counter, not a significance signal — significance lives in the
 release notes. Don't read "big change" as "minor bump"; the next stable
 after `0.X.Y` is `0.X.(Y+1)` unless Aaron says otherwise.
 
-**v1.0 and after** — switch to standard SemVer with `alpha` / `beta` /
-`rc` prerelease tags as feature stability warrants. This pattern doc
-gets a v1.0 update at that time.
-
 **At v1.0 and after**, switch to standard SemVer with `alpha` / `beta` / `rc`
 prerelease tags as feature stability warrants, and to a "release PR" pattern
 that promotes `0.X.Y-rc.N` → `0.X.Y` final via a small dedicated PR for a


### PR DESCRIPTION
Clarifies governance rule 2 after today's stable train shipped as judged-by-magnitude minor bumps (hub 0.6→0.7 etc.) against Aaron's intent: "let's make sure we move back to 0.x.y releases (on y dimension) going forward… We've got a long way to go yet until we're at 1.0." Pre-1.0 the version is a release counter, not a significance signal — the next stable after 0.X.Y is 0.X.(Y+1) unless Aaron says otherwise. + migration-notes entry. 🤖 Generated with [Claude Code](https://claude.com/claude-code)