### PR TITLE
pattern(backed-surface): four audience tiers — `surface` (backed surfaces own admission)

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,30 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-06-10 — Audience tiers: `surface` (backed surfaces own admission)
+
+**Change:** [`backed-surface.md`](../patterns/backed-surface.md) transport
+section — per-UI audience is now hub-proxy-enforced with FOUR tiers
+(`public | hub-users | operator | surface`). The new `surface` tier
+(hub#651) passes through at the proxy; the backed surface authenticates
+every request itself (kit deny-by-default). Replaces the stale "public flag
+today unenforced (parachute-surface#88)" note — enforcement shipped in
+hub#648 (H3).
+
+**Affected repos:**
+- `parachute-hub` — DONE (hub#648 gate, hub#651 `surface` tier; hub#650
+  tracks the future `granted-users` per-surface-ACL tier; hub#649 WS cap
+  flagged more-urgent post-#651)
+- `parachute-surface` — meta-schema accepts `audience: "surface"` (rides the
+  R6 docs-editor PR, with a hub-version-skew note); docs-editor flips from
+  `hub-users` → `surface` only after hub#651 deploys
+- `parachute.computer` — design doc §12 lacks an `audience` example for
+  backed surfaces (minor; sweep with the next design-doc pass)
+
+**Status:** in flight — hub#651 awaiting merge; surface side rides R6.
+
+---
+
 ## 2026-06-09 — Release versioning: patch (`y`) cadence by default
 
 **Change:** [`governance.md`](../patterns/governance.md) rule 2 clarified —

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -11,17 +11,19 @@ entries on top. Each entry: date, change, affected repos, status.
 section — per-UI audience is now hub-proxy-enforced with FOUR tiers
 (`public | hub-users | operator | surface`). The new `surface` tier
 (hub#651) passes through at the proxy; the backed surface authenticates
-every request itself (kit deny-by-default). Replaces the stale "public flag
-today unenforced (parachute-surface#88)" note — enforcement shipped in
-hub#648 (H3).
+every request itself (`@openparachute/surface-server`, deny-by-default).
+Replaces the stale "public flag today unenforced (parachute-surface#88)"
+note — enforcement shipped in hub#648 (the audience-gate work item from the
+surface-runtime design).
 
 **Affected repos:**
 - `parachute-hub` — DONE (hub#648 gate, hub#651 `surface` tier; hub#650
   tracks the future `granted-users` per-surface-ACL tier; hub#649 WS cap
   flagged more-urgent post-#651)
-- `parachute-surface` — meta-schema accepts `audience: "surface"` (rides the
-  R6 docs-editor PR, with a hub-version-skew note); docs-editor flips from
-  `hub-users` → `surface` only after hub#651 deploys
+- `parachute-surface` — meta-schema gains acceptance of
+  `audience: "surface"` (in flight on the R6 docs-editor branch, with a
+  hub-version-skew note); docs-editor flips from `hub-users` → `surface`
+  only after hub#651 deploys
 - `parachute.computer` — design doc §12 lacks an `audience` example for
   backed surfaces (minor; sweep with the next design-doc pass)
 

--- a/patterns/backed-surface.md
+++ b/patterns/backed-surface.md
@@ -154,10 +154,18 @@ cheap external-edit signal.
 
 - Public reachability rides the hub proxy + the surface module's exposure
   declarations — a surface never runs its own tunnel. Per-surface audience
-  exposure semantics (the `public` flag, today unenforced —
-  parachute-surface#88) land coherently with this shape.
+  is **hub-proxy-enforced** (H3, hub#648 fixed parachute-surface#88) with
+  four tiers: `public` (pass; chrome strip off), `hub-users` (hub session /
+  scoped Bearer; the default), `operator` (first-admin session only), and
+  `surface` (hub#651 — pass-through; the backed surface owns admission
+  end-to-end via the kit's deny-by-default auth; the tier for
+  capability-link audiences, who are by design not hub users). Exposure
+  layers are orthogonal: the proxy's row-level cloak still applies, so a
+  `surface` mount on a loopback-only row stays unreachable from funnel.
+  Version skew is fail-closed — a `surface`-audience row registered against
+  a pre-#651 hub is dropped by manifest validation (mount 404s).
 - The hub's identity **chrome strip is opted out** for audience-facing
-  routes — public readers are not hub users.
+  routes (`public` and `surface` tiers) — the audience are not hub users.
 - Never infer "local = trusted" from forwarded-header *absence* (one
   misconfigured deployment silently grants owner). Local-trust signals come
   from the substrate (the hub proxy's layer classification), not inference.

--- a/patterns/backed-surface.md
+++ b/patterns/backed-surface.md
@@ -154,12 +154,13 @@ cheap external-edit signal.
 
 - Public reachability rides the hub proxy + the surface module's exposure
   declarations — a surface never runs its own tunnel. Per-surface audience
-  is **hub-proxy-enforced** (H3, hub#648 fixed parachute-surface#88) with
-  four tiers: `public` (pass; chrome strip off), `hub-users` (hub session /
-  scoped Bearer; the default), `operator` (first-admin session only), and
-  `surface` (hub#651 — pass-through; the backed surface owns admission
-  end-to-end via the kit's deny-by-default auth; the tier for
-  capability-link audiences, who are by design not hub users). Exposure
+  is **hub-proxy-enforced** (hub#648, the audience gate — fixed
+  parachute-surface#88) with four tiers: `public`, `hub-users` (hub
+  session / scoped Bearer; the default), `operator` (first-admin session
+  only), and `surface` (hub#651 — pass-through; the backed surface owns
+  admission end-to-end via `@openparachute/surface-server`'s
+  deny-by-default auth; the tier for capability-link audiences, who are by
+  design not hub users). Exposure
   layers are orthogonal: the proxy's row-level cloak still applies, so a
   `surface` mount on a loopback-only row stays unreachable from funnel.
   Version skew is fail-closed — a `surface`-audience row registered against


### PR DESCRIPTION
Doc propagation from hub#651 (reviewer-flagged obligation, governance rule 3):

- `patterns/backed-surface.md` transport section: per-UI audience is hub-proxy-enforced (H3, hub#648 fixed surface#88 — the old "today unenforced" note was stale) with four tiers: `public | hub-users | operator | surface`. The new `surface` tier (hub#651): proxy passes through, the backed surface owns admission end-to-end via the kit's deny-by-default auth — the tier for capability-link audiences. Exposure-cloak orthogonality + fail-closed version skew documented.
- `adoption/migration-notes.md`: entry with affected repos + status (hub DONE pending merge; surface side rides the R6 docs-editor PR; parachute.computer §12 example is a minor follow-up).

Pattern remains [DRAFT] — drops when the second conforming surface (docs editor) merges.

Docs-only; no version bump per the doc-only exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)