### PR TITLE
governance(rule-2): re-affirm rc-first + the upgrade channel-resolution guarantee

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,40 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-06-13 — rc-first release discipline re-affirmed + upgrade channel-resolution guarantee
+
+**Change:** [`governance.md`](../patterns/governance.md) rule 2 re-affirmed
+after a drift. Practice had slipped to **stable-direct** across three trains
+(hub 0.7.0, hub 0.7.1, vault 0.6.x — no rc was ever cut); the bun-linked
+local box + reviewer gating made it feel safe, but it stranded an rc-channel
+operator (`friends.parachute.computer` on `0.6.5-rc.8`) below `@latest`
+because `parachute upgrade` follows `@rc` and `@rc` never moved. The rule
+stands: every code-touching train publishes `-rc.1` (→ `@rc`) first, soaks,
+then promotes the SAME `0.X.Y` bits to `@latest`; the next code-touching
+train across any module starts at `rc.1`. Also documented: the local
+bun-linked box is **not** a substitute for an rc soak (it validates code,
+not the published-artifact + migration-at-real-install path), and the
+**upgrade channel-resolution guarantee** — `parachute upgrade` on the rc
+channel resolves to the highest version above installed across BOTH `@rc`
+and `@latest` (client-side, token-free; a server-side npm `dist-tag` advance
+was considered and deferred). Decision:
+`Decisions/2026-06-13-rc-first-release-discipline` in the parachute-parachute
+team vault (Aaron chose re-affirm over amend-to-stable).
+
+**Affected repos:**
+- `parachute-hub` — `upgrade.ts` best-of-channel resolution (closes
+  hub#659); IN FLIGHT. The friends box (old hub, no fix) needs a one-time
+  `parachute upgrade hub --channel latest` to reach a fixed hub; auto
+  thereafter.
+- all module repos (hub, vault, scribe, runner, surface) — process change,
+  no code: the **next code-touching train starts at `rc.1`** rather than
+  bumping straight to stable.
+
+**Status:** governance.md + this note DONE (this PR); hub#659 upgrade.ts fix
+in flight; rc-first in force for the next train on every module.
+
+---
+
 ## 2026-06-10 — Audience tiers: `surface` (backed surfaces own admission)
 
 **Change:** [`backed-surface.md`](../patterns/backed-surface.md) transport

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -15,7 +15,7 @@ operator (`friends.parachute.computer` on `0.6.5-rc.8`) below `@latest`
 because `parachute upgrade` follows `@rc` and `@rc` never moved. The rule
 stands: every code-touching train publishes `-rc.1` (→ `@rc`) first, soaks,
 then promotes the SAME `0.X.Y` bits to `@latest`; the next code-touching
-train across any module starts at `rc.1`. Also documented: the local
+train across any module starts at `-rc.1`. Also documented: the local
 bun-linked box is **not** a substitute for an rc soak (it validates code,
 not the published-artifact + migration-at-real-install path), and the
 **upgrade channel-resolution guarantee** — `parachute upgrade` on the rc
@@ -31,7 +31,7 @@ team vault (Aaron chose re-affirm over amend-to-stable).
   `parachute upgrade hub --channel latest` to reach a fixed hub; auto
   thereafter.
 - all module repos (hub, vault, scribe, runner, surface) — process change,
-  no code: the **next code-touching train starts at `rc.1`** rather than
+  no code: the **next code-touching train starts at `-rc.1`** rather than
   bumping straight to stable.
 
 **Status:** governance.md + this note DONE (this PR); hub#659 upgrade.ts fix

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -47,7 +47,7 @@ rc-channel operator (`friends.parachute.computer` on `0.6.5-rc.8`) below
 `@latest`, because `parachute upgrade` follows `@rc` and `@rc` never moved.
 The rule stands as written: **every code-touching train publishes `-rc.1`
 (→ `@rc`) first, soaks, then promotes the SAME `0.X.Y` bits to `@latest`.**
-The next code-touching train across any module starts at `rc.1`. The rc
+The next code-touching train across any module starts at `-rc.1`. The rc
 channel is a real canary — that's the point of the second ceremony. (See
 `Decisions/2026-06-13-rc-first-release-discipline` in the parachute-parachute
 team vault; Aaron chose re-affirm over amend-to-stable.)

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -39,6 +39,19 @@ summary; the repo owner (currently Aaron) clicks merge.
 While the ecosystem is pre-1.0, every published change goes to npm's `rc`
 dist-tag first; promotion to `@latest` is a deliberate, separate step.
 
+**Re-affirmed 2026-06-13 after a drift.** Practice had slipped to
+stable-direct across three trains (hub 0.7.0, hub 0.7.1, vault 0.6.x — no
+rc was ever cut); the bun-linked local box + reviewer gating carried the
+correctness weight, so it *felt* safe. It wasn't complete: it stranded an
+rc-channel operator (`friends.parachute.computer` on `0.6.5-rc.8`) below
+`@latest`, because `parachute upgrade` follows `@rc` and `@rc` never moved.
+The rule stands as written: **every code-touching train publishes `-rc.1`
+(→ `@rc`) first, soaks, then promotes the SAME `0.X.Y` bits to `@latest`.**
+The next code-touching train across any module starts at `rc.1`. The rc
+channel is a real canary — that's the point of the second ceremony. (See
+`Decisions/2026-06-13-rc-first-release-discipline` in the parachute-parachute
+team vault; Aaron chose re-affirm over amend-to-stable.)
+
 **Tag when it makes sense to ship, not on every PR.** Updated 2026-05-24
 from the earlier "every PR bumps rc.N" rule — that produced 30+ rc
 artifacts per stable cycle (hub#349-#358 was the worst offender, with
@@ -70,6 +83,23 @@ there's intent to release.
 - Push the bare-version tag (`v0.X.Y`). CI publishes with
   `dist-tag=latest` AND (where applicable) tags the container image as
   `:stable`.
+
+**The local bun-linked box is not a substitute for an rc soak.** It runs
+`main` (ahead of any rc) and validates *code* — not the published-artifact
++ migration-at-real-install path the `@rc` canary exercises. This is
+exactly why stable-direct felt safe but wasn't complete (2026-06-13 drift).
+
+**Upgrade channel resolution — the guarantee that prevents stranding.**
+`parachute upgrade` on the **rc channel** resolves to the highest version
+*above installed* across BOTH `@rc` and `@latest` (the downgrade guard is
+unchanged). So a canary mid-chain rides the newer rc; a canary with no
+newer rc but a newer stable converges to stable, and picks up the next rc
+when it ships. The operator stays on the rc *channel* without ever
+stranding below `@latest`. This is the client-side, token-free fix
+(parachute-hub `upgrade.ts`, closes hub#659). A server-side npm
+`dist-tag` advance was considered and deferred — trusted-publishing is
+token-free for `publish` only, and reintroducing an `NPM_TOKEN` just for
+`dist-tag` isn't worth it when the client-side fix is complete.
 
 **Doc-only PRs never bump version.** They merge straight to main and
 will be included in whatever the next ship-driven version bump captures.


### PR DESCRIPTION
## What

Re-affirm governance **rule 2** (rc-first release discipline) after a drift, and document the **upgrade channel-resolution guarantee** that prevents rc-channel operators from stranding below `@latest`. Docs-only.

## Why

Rule 2 has always said: pre-1.0, every code-touching train rides an `rc.N` chain to `@rc`, then promotes the same `0.X.Y` bits to `@latest`. Practice drifted to **stable-direct** across three trains (hub 0.7.0, hub 0.7.1, vault 0.6.x — no rc was ever cut). The bun-linked local box + reviewer gating carried correctness, so it felt safe — but it stranded an rc-channel operator (`friends.parachute.computer` on `0.6.5-rc.8`) below `@latest`, since `parachute upgrade` follows `@rc` and `@rc` never moved.

Aaron chose **A: re-affirm rc-first** (rejected B: amend the rule to bless stable-direct). Decision note: `Decisions/2026-06-13-rc-first-release-discipline` in the parachute-parachute team vault.

## Changes to `patterns/governance.md` rule 2

Core text unchanged — this is a re-affirmation, not a rewrite. Added:

1. **Re-affirmation note** — the rule is back in force after the drift; every code-touching train publishes `-rc.1` → `@rc` first, soaks, then promotes the SAME `0.X.Y` to `@latest`; the next train across any module starts at `rc.1`.
2. **Local box is not a substitute for an rc soak** — it runs `main` and validates code, not the published-artifact + migration-at-real-install path. This is why stable-direct felt safe but wasn't complete.
3. **Upgrade channel-resolution guarantee** — `parachute upgrade` on the rc channel resolves to the highest version above installed across BOTH `@rc` and `@latest` (canary mid-chain rides rc; canary with no newer rc but a newer stable converges to stable, then picks up the next rc). Client-side, token-free (parachute-hub `upgrade.ts`, closes hub#659); a server-side npm `dist-tag` advance was considered and deferred (would reintroduce an `NPM_TOKEN`).

## Migration note

`adoption/migration-notes.md` — 2026-06-13 entry (newest on top). Affected repos: `parachute-hub` (upgrade.ts fix in flight, hub#659) + all module repos (next train starts at `rc.1`).

## Patterns check

- Touches: `governance.md` rule 2 (RC versioning). Re-affirms an established pattern; no new pattern, no schema/protocol change.
- Conforms: yes — and follows the patterns-repo discipline (pattern file + migration note in the same PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)