### PR TITLE
governance(rule-2): resume per-PR rc bumps (reverse tag-when-ready)

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -29,6 +29,13 @@ notes-ui `0.1.7-rc.1` (#138).
 code-touching PR carries its rc bump + pushes the rc tag on merge. Decision:
 `Decisions/2026-06-23-resume-per-pr-rc` in the parachute-parachute team vault.
 
+*No per-repo follow issues filed:* this is a behavioral cadence change with
+no code change for any repo to make — agents apply it directly from this
+pattern doc on their next code-touching PR. The affected-repos list above is
+the propagation record; a per-repo "remember to bump rc" issue would be lower
+signal than this entry. (Contrast: a schema/protocol change, where each repo
+needs a code update, does warrant per-repo issues.)
+
 ---
 
 ## 2026-06-13 — rc-first release discipline re-affirmed + upgrade channel-resolution guarantee

--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,32 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-06-23 — resume per-PR rc bumps (reverse "tag when ready")
+
+**Change:** [`governance.md`](../patterns/governance.md) rule 2 bump-cadence
+flipped back to **every code-touching PR bumps `rc.N` and publishes to
+`@rc`** (Aaron's call). Reverses the 2026-05-24 "tag when ready, not on
+every PR" rule. The earlier objection (rc bumps living in commits but never
+reaching npm) is moot now that CI publishes on tag push — so per-PR rc keeps
+the `@rc` channel tracking `main`, letting every box soak every change via
+`parachute upgrade`. rc-first-before-`@latest` (2026-06-13), patch-by-default,
+and doc-only-never-bump are all unchanged. Re-baselining is lazy: each
+package's next code-touching PR starts at `0.X.(Y+1)-rc.1` above its current
+stable (no mass republish); hub#660's channel-resolution prevents stranding
+meanwhile. Note: the workspace `~/ParachuteComputer/CLAUDE.md` rule 2 already
+said "every code-touching PR bumps the rc.N suffix" — it never adopted the
+2026-05-24 wording, so this re-syncs the canonical doc to it.
+
+**Affected repos:** all code-publishing repos (hub, vault, scribe, runner,
+parachute-surface + its packages). First application: parachute-surface
+notes-ui `0.1.7-rc.1` (#138).
+
+**Status:** governance doc updated (this PR). Going forward every
+code-touching PR carries its rc bump + pushes the rc tag on merge. Decision:
+`Decisions/2026-06-23-resume-per-pr-rc` in the parachute-parachute team vault.
+
+---
+
 ## 2026-06-13 — rc-first release discipline re-affirmed + upgrade channel-resolution guarantee
 
 **Change:** [`governance.md`](../patterns/governance.md) rule 2 re-affirmed

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -112,7 +112,7 @@ token-free for `publish` only, and reintroducing an `NPM_TOKEN` just for
 `dist-tag` isn't worth it when the client-side fix is complete.
 
 **Doc-only PRs never bump version.** They merge straight to main and
-will be included in whatever the next ship-driven version bump captures.
+are captured by the next code-touching PR's rc bump.
 
 **The increment is the PATCH (`y`) by default — minor (`x`) bumps are
 Aaron's explicit call, never inferred.** Settled 2026-06-09 after the

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -52,29 +52,39 @@ channel is a real canary — that's the point of the second ceremony. (See
 `Decisions/2026-06-13-rc-first-release-discipline` in the parachute-parachute
 team vault; Aaron chose re-affirm over amend-to-stable.)
 
-**Tag when it makes sense to ship, not on every PR.** Updated 2026-05-24
-from the earlier "every PR bumps rc.N" rule — that produced 30+ rc
-artifacts per stable cycle (hub#349-#358 was the worst offender, with
-rc.30/31/32 living in commits but never reaching npm). The new policy:
-PRs land without version bumps; bump+tag happen together, only when
-there's intent to release.
+**Every code-touching PR bumps `rc.N` and publishes to `@rc`.**
+Re-adopted 2026-06-23 (Aaron), reversing the 2026-05-24 "tag when ready,
+not on every PR" rule. The earlier objection — rc bumps "living in commits
+but never reaching npm" (hub#349-#358's rc.30/31/32) — is now moot: CI
+publishes on tag push (Trusted Publishing, see [`release-ci.md`](release-ci.md)),
+so a bump that pushes its tag *does* reach npm. With that, per-PR rc earns
+its keep: the `@rc` channel tracks `main` continuously, so **every box can
+soak every change** (`parachute upgrade` on the rc channel) instead of waiting
+for an operator to decide to cut an rc. More frequent, lower-stakes testing
+across the fleet is the whole point; the version-history churn is the
+accepted cost. (Decision: `Decisions/2026-06-23-resume-per-pr-rc` in the
+parachute-parachute team vault.)
 
-**Per PR (typical case):**
+**Per code-touching PR (typical case):**
 
-- The PR does NOT bump `package.json` version. `package.json` stays at
-  whatever the last released version is.
-- Reviewer + merge as usual.
-- No tag, no publish. The PR's changes accumulate on `main`.
+- The PR bumps `package.json` to the next rc number (`0.X.Y-rc.(N+1)`).
+  The patch number `Y` stays fixed across the rc chain until promotion;
+  the rc counter increments each PR. Add the matching CHANGELOG rc section
+  (Rule 5).
+- Reviewer + human merge as usual.
+- On merge, push the matching git tag (`v0.X.Y-rc.N`, or the monorepo
+  per-package form like `notes-ui-v0.X.Y-rc.N`). CI publishes to `@rc`.
+  The tag is the canonical release marker; the publish is automated. The
+  tag points at the squashed merge commit on `main`, so it's pushed
+  *after* merge, not before.
 
-**When you want to ship (operator-driven):**
-
-- Bump `package.json` to the next rc number (`0.X.Y-rc.(N+1)`) or to a
-  stable (`0.X.Y` with no -rc suffix) in a small dedicated PR, OR
-  directly on `main` if your repo allows that. The patch number `Y`
-  stays fixed across the rc chain until promotion.
-- Push a matching git tag (`v0.X.Y-rc.N` or `v0.X.Y`). CI publishes —
-  see [`release-ci.md`](release-ci.md) for the workflow shape. The tag
-  is the canonical release marker; the publish is automated.
+**Re-baselining a stale `@rc` (stable ran ahead during the gap).** During
+the tag-when-ready interval the `@rc` dist-tag fell below `@latest` on
+several packages. No mass republish is needed: each package's **next**
+code-touching PR starts a fresh rc chain at `0.X.(Y+1)-rc.1` above its
+current stable, which re-points `@rc` above `@latest` organically as PRs
+land. hub#660's channel-resolution guarantee (below) prevents stranding in
+the meantime.
 
 **Promotion to stable:**
 


### PR DESCRIPTION
## What

Flips rule 2's bump cadence **back** to: every code-touching PR bumps `rc.N` and publishes to `@rc` on merge. Reverses the 2026-05-24 "tag when ready, not on every PR" rule, at Aaron's call (2026-06-23).

## Why

> "I'm ok with PRs bumping rc, I think I prefer it at this point. Because then we can do more regular testing on all of our various boxes way more easily." — Aaron

The 2026-05-24 objection was that rc bumps "lived in commits but never reached npm." That's **moot now** — CI publishes on tag push (Trusted Publishing), so a bump that pushes its tag *does* reach npm. With that, per-PR rc earns its keep: the `@rc` channel tracks `main` continuously, so every box soaks every change via `parachute upgrade` instead of waiting for an operator to cut an rc.

## What's unchanged

- **rc-first before `@latest`** (2026-06-13 re-affirm) — now automatically satisfied since every PR publishes an rc.
- **patch-by-default** for `Y`; minor `x` is Aaron's explicit call.
- **doc-only PRs never bump.**
- **promotion to stable** mechanics.

## Re-baselining the stale `@rc` tags

During the tag-when-ready interval, `@rc` fell below `@latest` on several packages. **No mass republish** — each package's next code-touching PR starts at `0.X.(Y+1)-rc.1` above its current stable, re-pointing `@rc` organically. hub#660's channel-resolution prevents stranding meanwhile.

First application: parachute-surface **notes-ui `0.1.7-rc.1`** (#138).

## Note

The workspace `~/ParachuteComputer/CLAUDE.md` rule 2 already said "every code-touching PR bumps the rc.N suffix" — it never adopted the 2026-05-24 wording. This **re-syncs the canonical doc to it**, so no CLAUDE.md change is needed.

Migration-notes entry added. Decision record `Decisions/2026-06-23-resume-per-pr-rc` to be written in the team vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)