### PR TITLE
docs(governance): surface ships stable (Rule 2 per-package carve-out)

### DIFF
--- a/adoption/migration-notes.md
+++ b/adoption/migration-notes.md
@@ -5,6 +5,28 @@ entries on top. Each entry: date, change, affected repos, status.
 
 ---
 
+## 2026-06-30 — `@openparachute/surface` ships stable, not rc (Rule 2 carve-out)
+
+**Change:** [`governance.md`](../patterns/governance.md) rule 2 gains a
+per-package exception — the **surface** host module publishes `@latest` STABLE
+directly on each code-touching PR (bump the patch, no `-rc.N` chain). Two
+package-specific reasons: (1) surface's `@rc` dist-tag is dead (behind `@latest`,
+no operator tracks it), so an rc soak there canaries nothing; (2) surface is a
+workspace whose sibling packages depend on it via `^` ranges, and publishing a
+prerelease makes those carets silently resolve the *stable* from npm (npm
+excludes prereleases from caret matches — the
+`feedback_workspace_caret_miss_npm_fallback` lesson), fragmenting the workspace.
+Every other module still follows per-PR rc.
+
+**Affected repos:** `parachute-surface` (already shipping stable — 0.3.4 / 0.3.5
+/ 0.3.6, and 0.3.7 with Surface Git Transport Phase 1). This entry records the
+convention so reviewers stop flagging surface PRs for a "missing rc bump."
+
+**Status:** documented; surface already conforms. Reassess if surface's `@rc`
+tag is revived or the workspace stops cross-depending via carets.
+
+---
+
 ## 2026-06-23 — resume per-PR rc bumps (reverse "tag when ready")
 
 **Change:** [`governance.md`](../patterns/governance.md) rule 2 bump-cadence

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -52,9 +52,10 @@ channel is a real canary — that's the point of the second ceremony. (See
 `Decisions/2026-06-13-rc-first-release-discipline` in the parachute-parachute
 team vault; Aaron chose re-affirm over amend-to-stable.)
 
-**Every code-touching PR bumps `rc.N` and publishes to `@rc`.**
-Re-adopted 2026-06-23 (Aaron), reversing the 2026-05-24 "tag when ready,
-not on every PR" rule. The earlier objection — rc bumps "living in commits
+**Every code-touching PR bumps `rc.N` and publishes to `@rc`** (the
+`@openparachute/surface` module is excepted — it ships stable; see the
+module-exception note below). Re-adopted 2026-06-23 (Aaron), reversing the
+2026-05-24 "tag when ready, not on every PR" rule. The earlier objection — rc bumps "living in commits
 but never reaching npm" (hub#349-#358's rc.30/31/32) — is now moot: CI
 publishes on tag push (Trusted Publishing, see [`release-ci.md`](release-ci.md)),
 so a bump that pushes its tag *does* reach npm. With that, per-PR rc earns

--- a/patterns/governance.md
+++ b/patterns/governance.md
@@ -114,6 +114,28 @@ token-free for `publish` only, and reintroducing an `NPM_TOKEN` just for
 **Doc-only PRs never bump version.** They merge straight to main and
 are captured by the next code-touching PR's rc bump.
 
+**Module exception — `@openparachute/surface` ships STABLE, not rc (Aaron,
+2026-06-30).** The surface host module bumps the patch (`0.X.Y` → `0.X.(Y+1)`)
+and publishes to `@latest` directly on each code-touching PR — it does NOT cut
+an `-rc.N` first. Two reasons, both specific to that package:
+
+- **A dead `@rc` tag.** surface's `@rc` dist-tag fell behind `@latest` and no
+  operator tracks it, so an rc soak there canaries nothing — the guarantee that
+  justifies Rule 2 (every box soaks every change on the rc channel) doesn't
+  apply.
+- **The workspace caret-miss.** surface is a workspace with sibling packages
+  that depend on it via `^` ranges. Publishing a prerelease (`-rc.N`) makes those
+  `^` ranges silently resolve the *stable* from npm instead of the prerelease
+  (npm excludes prereleases from caret matches), so an rc publish fragments the
+  workspace. (See [`adoption/migration-notes.md`](../adoption/migration-notes.md).)
+  Shipping stable keeps the caret ranges coherent.
+
+So for surface: bump the patch, add the CHANGELOG stable section, push the
+bare-version tag, publish `@latest` — no rc chain. **Reviewers should not flag a
+surface PR for "missing the rc bump."** This is a per-package carve-out; every
+other module still follows the per-PR-rc discipline above. Reassess if surface's
+`@rc` tag is ever revived or the workspace stops cross-depending via carets.
+
 **The increment is the PATCH (`y`) by default — minor (`x`) bumps are
 Aaron's explicit call, never inferred.** Settled 2026-06-09 after the
 boundary-arc stable train shipped as minor bumps (hub 0.6→0.7, vault


### PR DESCRIPTION
Documents the **surface-ships-stable** exception in [`governance.md`](../../patterns/governance.md) Rule 2, so reviewers stop flagging surface PRs for a "missing rc bump." Part of the Surface Git Transport Phase 1 sweep (pairs with the hub + surface-host PRs).

## What
Rule 2 (rc-first before `@latest`) gains a per-package carve-out: **`@openparachute/surface` publishes `@latest` STABLE directly** on each code-touching PR (bump the patch, no `-rc.N` chain). Two package-specific reasons:

1. **Dead `@rc` tag.** surface's `@rc` dist-tag fell behind `@latest` and no operator tracks it → an rc soak there canaries nothing (the guarantee that justifies Rule 2 doesn't apply).
2. **Workspace caret-miss.** surface is a workspace whose sibling packages depend on it via `^` ranges; publishing a prerelease makes those carets silently resolve the *stable* from npm (npm excludes prereleases from caret matches — the `feedback_workspace_caret_miss_npm_fallback` lesson), fragmenting the workspace.

Every other module still follows the per-PR rc discipline. Aaron-authorized.

Also adds the matching `adoption/migration-notes.md` entry (per the patterns-repo convention that a pattern change gets a dated migration note).

## Notes
- **Docs-only** — no version bump (patterns is a docs repo).
- surface already conforms (shipping 0.3.4 / 0.3.5 / 0.3.6, and 0.3.7 in the Phase 1 PR).

**Do NOT merge** — reviewer-gated (mandatory even for doc-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S